### PR TITLE
Support for .Any() and .All() operators

### DIFF
--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Couchbase.Configuration.Client;
 using Couchbase.Linq.Extensions;
 using Couchbase.Linq.Tests.Documents;
+using Couchbase.N1QL;
 using NUnit.Framework;
 
 namespace Couchbase.Linq.Tests
@@ -131,6 +132,40 @@ namespace Couchbase.Linq.Tests
         }
 
         [Test]
+        public void AnyAllTests_AnyOnMainDocument_ReturnsTrue()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var hasBreweries = (from b in bucket.Queryable<Brewery>()
+                                        where b.Type == "brewery"
+                                        select new { name = b.Name, address = b.Address }).
+                        Any();
+
+                    Assert.True(hasBreweries);
+                }
+            }
+        }
+
+        [Test]
+        public void AnyAllTests_AnyOnMainDocument_ReturnsFalse()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var hasFaketype = (from b in bucket.Queryable<Brewery>()
+                                       where b.Type == "faketype"
+                                       select new { name = b.Name, address = b.Address }).
+                        Any();
+
+                    Assert.False(hasFaketype);
+                }
+            }
+        }
+
+        [Test]
         public void AnyAllTests_AllNestedArray()
         {
             using (var cluster = new Cluster())
@@ -168,6 +203,37 @@ namespace Couchbase.Linq.Tests
 
                     Assert.IsNotEmpty(breweries);
                     Assert.False(breweries.SelectMany(p => p.address).Any(p => p == "563 Second Street"));
+                }
+            }
+        }
+
+        [Test]
+        public void AnyAllTests_AllOnMainDocument_ReturnsFalse()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var isAllBreweries = bucket.Queryable<Brewery>().All(p => p.Type == "brewery");
+
+                    Assert.False(isAllBreweries);
+                }
+            }
+        }
+
+        [Test]
+        public void AnyAllTests_AllOnMainDocument_ReturnsTrue()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var allBreweriesHaveAddress = (from b in bucket.Queryable<Brewery>()
+                                                   where b.Type == "brewery"
+                                                   select new { b.Name })
+                        .All(p => p.Name != "");
+
+                    Assert.True(allBreweriesHaveAddress);
                 }
             }
         }

--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -93,5 +93,42 @@ namespace Couchbase.Linq.Tests
                 }
             }
         }
+
+        [Test]
+        public void AnyAllTests_AnyNestedArray()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var breweries = (from b in bucket.Queryable<Brewery>()
+                        where b.Type == "brewery" && b.Address.Any()
+                        select new {name = b.Name, address = b.Address}).
+                        ToList();
+
+                    Assert.IsNotEmpty(breweries);
+                    Assert.True(breweries.All(p => p.address.Any()));
+                }
+            }
+        }
+
+        [Test]
+        public void AnyAllTests_AnyNestedArrayWithFilter()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var breweries = (from b in bucket.Queryable<Brewery>()
+                                     where b.Type == "brewery" && b.Address.Any(p => p == "563 Second Street")
+                                     select new { name = b.Name, address = b.Address }).
+                        ToList();
+
+                    Assert.IsNotEmpty(breweries);
+                    Assert.True(breweries.All(p => p.address.Contains("563 Second Street")));
+                }
+            }
+        }
+
     }
 }

--- a/Src/Couchbase.Linq.Tests/Documents/Brewery.cs
+++ b/Src/Couchbase.Linq.Tests/Documents/Brewery.cs
@@ -1,21 +1,45 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Couchbase.Linq.Tests.Documents
 {
     public class Brewery
     {
+        [JsonProperty("name")]
         public string Name { get; set; }
+
+        [JsonProperty("city")]
         public string City { get; set; }
+
+        [JsonProperty("state")]
         public string State { get; set; }
+
+        [JsonProperty("code")]
         public string Code { get; set; }
+
+        [JsonProperty("country")]
         public string Country { get; set; }
+
+        [JsonProperty("phone")]
         public string Phone { get; set; }
+
+        [JsonProperty("website")]
         public string Website { get; set; }
+
+        [JsonProperty("type")]
         public string Type { get; set; }
+
+        [JsonProperty("updated")]
         public DateTime Updated { get; set; }
+
+        [JsonProperty("description")]
         public string Description { get; set; }
+
+        [JsonProperty("address")]
         public List<string> Address { get; set; }
+
+        [JsonProperty("geo")]
         public Geo Geo { get; set; }
     }
 }

--- a/Src/Couchbase.Linq.Tests/Documents/Geo.cs
+++ b/Src/Couchbase.Linq.Tests/Documents/Geo.cs
@@ -4,6 +4,7 @@ namespace Couchbase.Linq.Tests.Documents
 {
     public class Geo
     {
+        [JsonProperty("accuracy")]
         public string Accuracy { get; set; }
 
         [JsonProperty("lat")]

--- a/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
@@ -18,7 +18,7 @@ namespace Couchbase.Linq.Tests
         protected string CreateN1QlQuery(IBucket bucket, Expression expression)
         {
             var queryModel = QueryParserHelper.CreateQueryParser().GetParsedQuery(expression);
-            return N1QlQueryModelVisitor.GenerateN1QlQuery(queryModel, bucket.Name);
+            return N1QlQueryModelVisitor.GenerateN1QlQuery(queryModel);
         }
 
         protected void InitializeCluster(IContractResolver contractResolver = null)

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/MemberNameResolutionTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/MemberNameResolutionTests.cs
@@ -46,7 +46,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {brewName = e.Name, brewCity = e.City});
 
             const string expected =
-                "SELECT e.Name as brewName, e.City as brewCity FROM default as e WHERE (e.Country LIKE '%a%')";
+                "SELECT e.name as brewName, e.city as brewCity FROM default as e WHERE (e.country LIKE '%a%')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/MetaTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/MetaTests.cs
@@ -23,7 +23,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Meta();
 
-            const string expected = "SELECT META(default) FROM default";
+            const string expected = "SELECT `<generated>_1`.*, META(`<generated>_1`) FROM default as `<generated>_1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -40,7 +40,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 .Select(c=>c.Age)
                 .Meta();
 
-            const string expected = "SELECT c.age, META(default) FROM default as c";
+            const string expected = "SELECT c.age, META(c) FROM default as c";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq/BucketQueryExecuter.cs
+++ b/Src/Couchbase.Linq/BucketQueryExecuter.cs
@@ -14,6 +14,11 @@ namespace Couchbase.Linq
     {
         private readonly IBucket _bucket;
 
+        public string BucketName
+        {
+            get { return _bucket.Name; }
+        }
+
         public BucketQueryExecuter(IBucket bucket)
         {
             _bucket = bucket;
@@ -57,7 +62,7 @@ namespace Couchbase.Linq
 
         public string ExecuteCollection(QueryModel queryModel)
         {
-            return N1QlQueryModelVisitor.GenerateN1QlQuery(queryModel, _bucket.Name);
+            return N1QlQueryModelVisitor.GenerateN1QlQuery(queryModel);
         }
     }
 }

--- a/Src/Couchbase.Linq/BucketQueryable.cs
+++ b/Src/Couchbase.Linq/BucketQueryable.cs
@@ -6,26 +6,38 @@ using Remotion.Linq.Parsing.Structure;
 
 namespace Couchbase.Linq
 {
-    public class BucketQueryable<T> : QueryableBase<T>
+    public class BucketQueryable<T> : QueryableBase<T>, IBucketQueryable
     {
+
+        private readonly IBucket _bucket;
+
+        public string BucketName
+        {
+            get { return _bucket.Name; }
+        }
+
         public BucketQueryable(IQueryParser queryParser, IQueryExecutor executor)
             : base(queryParser, executor)
         {
+            // Is this constructor necessary?
         }
 
         public BucketQueryable(IQueryProvider provider)
             : base(provider)
         {
+            // Is this constructor necessary?
         }
 
         public BucketQueryable(IQueryProvider provider, Expression expression)
             : base(provider, expression)
         {
+            // Is this constructor necessary?
         }
 
         public BucketQueryable(IBucket bucket)
             : base(QueryParserHelper.CreateQueryParser(), new BucketQueryExecuter(bucket))
         {
+            _bucket = bucket;
         }
     }
 }

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Clauses\WhereMissingClause.cs" />
     <Compile Include="Clauses\WhereMissingExpressionNode.cs" />
     <Compile Include="Extensions\QueryExtensions.cs" />
+    <Compile Include="IBucketQueryable.cs" />
     <Compile Include="Operators\ExplainExpressionNode.cs" />
     <Compile Include="Operators\ExplainResultOperator.cs" />
     <Compile Include="Operators\MetaExpressionNode.cs" />

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -84,7 +84,9 @@
     <Compile Include="QueryGeneration\IMemberNameResolver.cs" />
     <Compile Include="QueryGeneration\JsonNetMemberNameResolver.cs" />
     <Compile Include="QueryGeneration\N1QLExpressionTreeVisitor.cs" />
+    <Compile Include="QueryGeneration\N1QLFromQueryPart.cs" />
     <Compile Include="QueryGeneration\N1QLQueryModelVisitor.cs" />
+    <Compile Include="QueryGeneration\N1QLQueryType.cs" />
     <Compile Include="QueryGeneration\NamedParameter.cs" />
     <Compile Include="QueryGeneration\ParameterAggregator.cs" />
     <Compile Include="QueryGeneration\QueryPartsAggregator.cs" />

--- a/Src/Couchbase.Linq/IBucketQueryable.cs
+++ b/Src/Couchbase.Linq/IBucketQueryable.cs
@@ -1,0 +1,10 @@
+﻿namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Used to provide the bucket name to the query generator
+    /// </summary>
+    interface IBucketQueryable
+    {
+        string BucketName { get; }
+    }
+}

--- a/Src/Couchbase.Linq/QueryClientQueryExecuter.cs
+++ b/Src/Couchbase.Linq/QueryClientQueryExecuter.cs
@@ -7,11 +7,16 @@ using Remotion.Linq;
 
 namespace Couchbase.Linq
 {
-    public sealed class QueryClientQueryExecuter : IQueryExecutor
+    public sealed class QueryClientQueryExecuter : IQueryExecutor, IBucketQueryable
     {
         private readonly string _bucketName;
         private readonly IQueryClient _queryClient;
         private readonly Uri _uri;
+
+        public string BucketName
+        {
+            get { return _bucketName; }
+        }
 
         internal QueryClientQueryExecuter(IQueryClient queryClient, string bucketName, Uri uri)
         {
@@ -41,7 +46,7 @@ namespace Couchbase.Linq
 
         public string ExecuteCollection(QueryModel queryModel)
         {
-            return N1QlQueryModelVisitor.GenerateN1QlQuery(queryModel, _bucketName);
+            return N1QlQueryModelVisitor.GenerateN1QlQuery(queryModel);
         }
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -215,5 +215,14 @@ namespace Couchbase.Linq.QueryGeneration
             return expression;
         }
 
+        protected override Expression VisitSubQueryExpression(SubQueryExpression expression)
+        {
+            var modelVisitor = new N1QlQueryModelVisitor();
+
+            modelVisitor.VisitQueryModel(expression.QueryModel);
+            _expression.Append(modelVisitor.GetQuery());
+
+            return expression;
+        }
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -92,7 +92,7 @@ namespace Couchbase.Linq.QueryGeneration
                 //only add 'as' part if the  previous visitexpression has generated something.
                 if (_expression.Length > expressionLength)
                 {
-                    _expression.AppendFormat(" as {0}", members[i].Name);
+                    _expression.AppendFormat(" as {0}", N1QlQueryModelVisitor.EscapeIdentifier(members[i].Name));
                 }
             }
 
@@ -192,7 +192,7 @@ namespace Couchbase.Linq.QueryGeneration
 
         protected override Expression VisitQuerySourceReferenceExpression(QuerySourceReferenceExpression expression)
         {
-            _expression.Append(expression.ReferencedQuerySource.ItemName);
+            _expression.Append(N1QlQueryModelVisitor.EscapeIdentifier(expression.ReferencedQuerySource.ItemName));
             return expression;
         }
 
@@ -203,7 +203,7 @@ namespace Couchbase.Linq.QueryGeneration
             if (_nameResolver.TryResolveMemberName(expression.Member, out memberName))
             {
                 VisitExpression(expression.Expression);
-                _expression.AppendFormat(".{0}", memberName);
+                _expression.AppendFormat(".{0}", N1QlQueryModelVisitor.EscapeIdentifier(memberName));
             }
 
             return expression;
@@ -214,5 +214,6 @@ namespace Couchbase.Linq.QueryGeneration
             VisitExpression(expression.Operand);
             return expression;
         }
+
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLFromQueryPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLFromQueryPart.cs
@@ -1,0 +1,21 @@
+﻿
+namespace Couchbase.Linq.QueryGeneration
+{
+    /// <summary>
+    /// Represents the FROM part of a query
+    /// </summary>
+    public class N1QlFromQueryPart
+    {
+
+        /// <summary>
+        /// Source of the query data, such as a bucket name.  Should already be escaped.
+        /// </summary>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Name of the query data when being referenced in the query ("as" clause).  Should already be escaped.
+        /// </summary>
+        public string ItemName { get; set; }
+
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -129,6 +129,13 @@ namespace Couchbase.Linq.QueryGeneration
             {
                 _queryPartsAggregator.QueryType = N1QlQueryType.Any;
             }
+            else if (resultOperator is AllResultOperator)
+            {
+                var allResultOperator = (AllResultOperator) resultOperator;
+                _queryPartsAggregator.WhereAllPart = GetN1QlExpression(allResultOperator.Predicate);
+
+                _queryPartsAggregator.QueryType = N1QlQueryType.All;
+            }
 
             base.VisitResultOperator(resultOperator, queryModel, index);
         }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
@@ -5,8 +5,29 @@
     /// </summary>
     public enum N1QlQueryType
     {
+        /// <summary>
+        /// Main SELECT statement
+        /// </summary>
         Select = 0,
+
+        /// <summary>
+        /// Any operation performed on a nested array as a subquery
+        /// </summary>
         Any,
-        All
+
+        /// <summary>
+        /// Any operation performed on the main query
+        /// </summary>
+        AnyMainQuery,
+
+        /// <summary>
+        /// All operation performed on a nested array as a subquery
+        /// </summary>
+        All,
+
+        /// <summary>
+        /// All operation performed on the main query
+        /// </summary>
+        AllMainQuery
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
@@ -1,0 +1,11 @@
+﻿namespace Couchbase.Linq.QueryGeneration
+{
+    /// <summary>
+    /// Represents the type of query or subquery being generated
+    /// </summary>
+    public enum N1QlQueryType
+    {
+        Select = 0,
+        Any
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
@@ -6,6 +6,7 @@
     public enum N1QlQueryType
     {
         Select = 0,
-        Any
+        Any,
+        All
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -89,7 +89,7 @@ namespace Couchbase.Linq.QueryGeneration
             if (FromParts.Any())
             {
                 var mainFrom = FromParts.First();
-                sb.AppendFormat(" FROM {0}", mainFrom.Replace(" as <generated>_1", "")); //TODO support multiple from parts
+                sb.AppendFormat(" FROM {0}", mainFrom); //TODO support multiple from parts
             }
             if (WhereParts.Any())
             {


### PR DESCRIPTION
Completes support for .Any() and .All() operators against both the main document collection and nested arrays inside document objects.  Includes tests which demonstrate their usage.

Note that the changes required to the handling of FromParts may affect ongoing work on Join operations.  Also, this work won't handle Any and All operations which involve joining to other buckets or documents.  That should probably be implemented after Joins rather than before.