### PR TITLE
Support for unary NOT operations

### DIFF
--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -74,6 +74,25 @@ namespace Couchbase.Linq.Tests
         }
 
         [Test]
+        public void Map2PocoTests_Simple_Projections_WhereNot()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from b in bucket.Queryable<Beer>()
+                                where b.Type == "beer" && !(b.Abv < 4)
+                                select new { name = b.Name, abv = b.Abv };
+
+                    foreach (var b in beers)
+                    {
+                        Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
+                    }
+                }
+            }
+        }
+
+        [Test]
         public void Map2PocoTests_Simple_Projections_Limit()
         {
             using (var cluster = new Cluster())

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -211,7 +211,18 @@ namespace Couchbase.Linq.QueryGeneration
 
         protected override Expression VisitUnaryExpression(UnaryExpression expression)
         {
-            VisitExpression(expression.Operand);
+            switch (expression.NodeType)
+            {
+                case ExpressionType.Not:
+                    _expression.Append("NOT ");
+                    VisitExpression(expression.Operand);
+                    break;
+
+                default:
+                    VisitExpression(expression.Operand);
+                    break;
+            }
+            
             return expression;
         }
     }


### PR DESCRIPTION
Modifications
-------------
Added handling for ExpressionType.Not to
N1QlExpressionTreeVisitor.VisitUnaryExpression.

Results
-------
Unary not operations are no longer ignored and therefore filter properly
in the WHERE clause.