### PR TITLE
Automatic document filtering based on entity type

### DIFF
--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -11,6 +11,12 @@ namespace Couchbase.Linq.Tests
     [TestFixture]
     public class BeerSampleTests : N1QLTestBase
     {
+        [SetUp]
+        public void TestSetUp()
+        {
+            Filters.EntityFilterManager.Clear();   
+        }
+
         [Test]
         public void Map2PocoTests()
         {
@@ -90,6 +96,40 @@ namespace Couchbase.Linq.Tests
                     {
                         Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
                     }
+                }
+            }
+        }
+
+        [Test]
+        public void Map2PocoTests_Simple_Projections_TypeFilterAttribute()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = (from b in bucket.Queryable<BeerFiltered>()
+                                 select new { type = b.Type }).
+                                 AsEnumerable();
+
+                    Assert.True(beers.All(p => p.type == "beer"));
+                }
+            }
+        }
+
+        [Test]
+        public void Map2PocoTests_Simple_Projections_TypeFilterRuntime()
+        {
+            Filters.EntityFilterManager.SetFilter(new BreweryFilter());
+
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var breweries = (from b in bucket.Queryable<Brewery>()
+                                     select new { type = b.Type })
+                                     .AsEnumerable();
+
+                    Assert.True(breweries.All(p => p.type == "brewery"));
                 }
             }
         }

--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -84,8 +84,10 @@
   <ItemGroup>
     <Compile Include="BeerSampleTests.cs" />
     <Compile Include="BucketExtensionTests.cs" />
+    <Compile Include="Documents\BeerFiltered.cs" />
     <Compile Include="Documents\Beer.cs" />
     <Compile Include="Documents\Brewery.cs" />
+    <Compile Include="Documents\BreweryFilter.cs" />
     <Compile Include="Documents\ChildWithContract.cs" />
     <Compile Include="Documents\Child.cs" />
     <Compile Include="Documents\Contact.cs" />

--- a/Src/Couchbase.Linq.Tests/Documents/BeerFiltered.cs
+++ b/Src/Couchbase.Linq.Tests/Documents/BeerFiltered.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Couchbase.Linq.Tests.Documents
+{
+    [Filters.EntityTypeFilter("beer")]
+    public class BeerFiltered
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("abv")]
+        public decimal Abv { get; set; }
+
+        [JsonProperty("ibu")]
+        public decimal Ibu { get; set; }
+
+        [JsonProperty("srm")]
+        public decimal Srm { get; set; }
+
+        [JsonProperty("upc")]
+        public decimal Upc { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("brewery_id")]
+        public string BreweryId { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("style")]
+        public string Style { get; set; }
+
+        [JsonProperty("category")]
+        public string Category { get; set; }
+
+        [JsonProperty("updated")]
+        public DateTime Updated { get; set; }
+    }
+}

--- a/Src/Couchbase.Linq.Tests/Documents/Brewery.cs
+++ b/Src/Couchbase.Linq.Tests/Documents/Brewery.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Couchbase.Linq.Tests.Documents
 {
@@ -12,7 +13,10 @@ namespace Couchbase.Linq.Tests.Documents
         public string Country { get; set; }
         public string Phone { get; set; }
         public string Website { get; set; }
+
+        [JsonProperty("type")]
         public string Type { get; set; }
+
         public DateTime Updated { get; set; }
         public string Description { get; set; }
         public List<string> Address { get; set; }

--- a/Src/Couchbase.Linq.Tests/Documents/BreweryFilter.cs
+++ b/Src/Couchbase.Linq.Tests/Documents/BreweryFilter.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Linq;
+using Couchbase.Linq.Filters;
+
+namespace Couchbase.Linq.Tests.Documents
+{
+    class BreweryFilter : IEntityFilter<Brewery>
+    {
+        public int Priority { get; set; }
+
+        public IQueryable<Brewery> ApplyFilter(IQueryable<Brewery> source)
+        {
+            return source.Where(p => p.Type == "brewery");
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -64,9 +64,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Filters\AttributeEntityFilterSetGenerator.cs" />
+    <Compile Include="Filters\EntityFilterAttribute.cs" />
+    <Compile Include="Filters\EntityFilterManager.cs" />
+    <Compile Include="Filters\EntityFilterSet.cs" />
+    <Compile Include="Filters\IEntityFilter.cs" />
+    <Compile Include="Filters\EntityTypeFilterAttribute.cs" />
     <Compile Include="Clauses\WhereMissingClause.cs" />
     <Compile Include="Clauses\WhereMissingExpressionNode.cs" />
     <Compile Include="Extensions\QueryExtensions.cs" />
+    <Compile Include="Filters\IEntityFilterSetGenerator.cs" />
     <Compile Include="Operators\ExplainExpressionNode.cs" />
     <Compile Include="Operators\ExplainResultOperator.cs" />
     <Compile Include="Operators\MetaExpressionNode.cs" />

--- a/Src/Couchbase.Linq/Extensions/BucketExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/BucketExtensions.cs
@@ -1,12 +1,14 @@
-﻿using Couchbase.Core;
+﻿using System.Linq;
+using Couchbase.Core;
+using Couchbase.Linq.Filters;
 
 namespace Couchbase.Linq.Extensions
 {
     public static class BucketExtensions
     {
-        public static BucketQueryable<T> Queryable<T>(this IBucket bucket)
+        public static IQueryable<T> Queryable<T>(this IBucket bucket)
         {
-            return new BucketQueryable<T>(bucket);
+            return EntityFilterManager.ApplyFilters(new BucketQueryable<T>(bucket));
         }
     }
 }

--- a/Src/Couchbase.Linq/Extensions/QueryClientExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryClientExtensions.cs
@@ -1,13 +1,15 @@
 ﻿using System;
+using System.Linq;
+using Couchbase.Linq.Filters;
 using Couchbase.N1QL;
 
 namespace Couchbase.Linq.Extensions
 {
     public static class QueryClientExtensions
     {
-        internal static QueryClientQueryable<T> Queryable<T>(this IQueryClient queryClient, string bucketName, Uri uri)
+        internal static IQueryable<T> Queryable<T>(this IQueryClient queryClient, string bucketName, Uri uri)
         {
-            return new QueryClientQueryable<T>(queryClient, bucketName, uri);
+            return EntityFilterManager.ApplyFilters(new QueryClientQueryable<T>(queryClient, bucketName, uri));
         }
     }
 }

--- a/Src/Couchbase.Linq/Filters/AttributeEntityFilterSetGenerator.cs
+++ b/Src/Couchbase.Linq/Filters/AttributeEntityFilterSetGenerator.cs
@@ -4,23 +4,18 @@ using System.Linq;
 namespace Couchbase.Linq.Filters
 {
     /// <summary>
-    /// Generates an <see cref="EntityFilterSet">EntityFilterSet</see> for a particular type, using <see cref="EntityFilterAttribute">EntityFilterAttributes</see>
+    /// Generates an <see cref="EntityFilterSet&lt;T&gt;">EntityFilterSet</see> for a particular type, using <see cref="EntityFilterAttribute">EntityFilterAttributes</see>
     /// </summary>
-    class AttributeEntityFilterSetGenerator : IEntityFilterSetGenerator
+    public class AttributeEntityFilterSetGenerator : IEntityFilterSetGenerator
     {
 
         /// <summary>
-        /// Generates an <see cref="EntityFilterSet">EntityFilterSet</see> for a particular type, using <see cref="EntityFilterAttribute">EntityFilterAttribute</see>s
+        /// Generates an <see cref="EntityFilterSet&lt;T&gt;">EntityFilterSet</see> for a particular type, using <see cref="EntityFilterAttribute">EntityFilterAttribute</see>s
         /// </summary>
         /// <returns>Returns null if there are no filters.  This is to improve efficieny.</returns>
-        public EntityFilterSet GenerateEntityFilterSet(Type type)
+        public EntityFilterSet<T> GenerateEntityFilterSet<T>()
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException("type");
-            }
-
-            var filters = type.GetCustomAttributes(typeof (EntityFilterAttribute), true);
+            var filters = (EntityFilterAttribute[])typeof(T).GetCustomAttributes(typeof (EntityFilterAttribute), true);
 
             if (filters.Length == 0)
             {
@@ -28,7 +23,7 @@ namespace Couchbase.Linq.Filters
             }
             else 
             {
-                return new EntityFilterSet(filters.Cast<IEntityFilter>());
+                return new EntityFilterSet<T>(filters.Select(p => p.GetFilter<T>()));
             }
         }
 

--- a/Src/Couchbase.Linq/Filters/AttributeEntityFilterSetGenerator.cs
+++ b/Src/Couchbase.Linq/Filters/AttributeEntityFilterSetGenerator.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+
+namespace Couchbase.Linq.Filters
+{
+    /// <summary>
+    /// Generates an <see cref="EntityFilterSet">EntityFilterSet</see> for a particular type, using <see cref="EntityFilterAttribute">EntityFilterAttributes</see>
+    /// </summary>
+    class AttributeEntityFilterSetGenerator : IEntityFilterSetGenerator
+    {
+
+        /// <summary>
+        /// Generates an <see cref="EntityFilterSet">EntityFilterSet</see> for a particular type, using <see cref="EntityFilterAttribute">EntityFilterAttribute</see>s
+        /// </summary>
+        /// <returns>Returns null if there are no filters.  This is to improve efficieny.</returns>
+        public EntityFilterSet GenerateEntityFilterSet(Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException("type");
+            }
+
+            var filters = type.GetCustomAttributes(typeof (EntityFilterAttribute), true);
+
+            if (filters.Length == 0)
+            {
+                return null;
+            }
+            else 
+            {
+                return new EntityFilterSet(filters.Cast<IEntityFilter>());
+            }
+        }
+
+    }
+}

--- a/Src/Couchbase.Linq/Filters/EntityFilterAttribute.cs
+++ b/Src/Couchbase.Linq/Filters/EntityFilterAttribute.cs
@@ -1,23 +1,19 @@
 ﻿using System;
-using System.Linq;
 
 namespace Couchbase.Linq.Filters
 {
     /// <summary>
-    /// Abstract base class for attribute-based <see cref="IEntityFilter">IEntityFilter</see> implementations
+    /// Abstract base class for attribute-based <see cref="IEntityFilter&lt;T&gt;">IEntityFilter</see> implementations
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public abstract class EntityFilterAttribute : Attribute, IEntityFilter
+    public abstract class EntityFilterAttribute : Attribute
     {
         /// <summary>
         /// Priority of this filter compared to other filters against the same type.  Lower priorities execute first.
         /// </summary>
         public int Priority { get; set; }
 
-        /// <summary>
-        /// Apply the filter to a LINQ query
-        /// </summary>
-        public abstract IQueryable<T> ApplyFilter<T>(IQueryable<T> source);
+        public abstract IEntityFilter<T> GetFilter<T>(); 
 
     }
 }

--- a/Src/Couchbase.Linq/Filters/EntityFilterAttribute.cs
+++ b/Src/Couchbase.Linq/Filters/EntityFilterAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+
+namespace Couchbase.Linq.Filters
+{
+    /// <summary>
+    /// Abstract base class for attribute-based <see cref="IEntityFilter">IEntityFilter</see> implementations
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public abstract class EntityFilterAttribute : Attribute, IEntityFilter
+    {
+        /// <summary>
+        /// Priority of this filter compared to other filters against the same type.  Lower priorities execute first.
+        /// </summary>
+        public int Priority { get; set; }
+
+        /// <summary>
+        /// Apply the filter to a LINQ query
+        /// </summary>
+        public abstract IQueryable<T> ApplyFilter<T>(IQueryable<T> source);
+
+    }
+}

--- a/Src/Couchbase.Linq/Filters/EntityFilterManager.cs
+++ b/Src/Couchbase.Linq/Filters/EntityFilterManager.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Couchbase.Linq.Filters
+{
+    /// <summary>
+    /// Static class to cache and execute IEntityFilters based on the type being queried
+    /// </summary>
+    class EntityFilterManager
+    {
+
+        /// <summary>
+        /// Stores currently loaded filters.
+        /// </summary>
+        /// <remarks>
+        /// Any type which has no filters will be in the dictionary, with a value of null.  This will prevent another attempt
+        /// to generate the default <see cref="EntityFilterSet">EntityFilterSet</see> each time it is requested.
+        /// </remarks>
+        private static readonly Dictionary<Type, EntityFilterSet> Filters = new Dictionary<Type, EntityFilterSet>();
+
+        private static IEntityFilterSetGenerator _filterSetGenerator = new AttributeEntityFilterSetGenerator();
+        /// <summary>
+        /// Generates the <see cref="EntityFilterSet">EntityFilterSet</see> for a type if no filters have been previously loaded
+        /// </summary>
+        /// <remarks>By default, uses an <see cref="AttributeEntityFilterSetGenerator">AttributeEntityFeatureSetGenerator</see></remarks>
+        public static IEntityFilterSetGenerator FilterSetGenerator
+        {
+            get { return _filterSetGenerator; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
+                _filterSetGenerator = value;
+            }
+        }
+
+        /// <summary>
+        /// Returns the filter set for a type, creating a new filters set using the <see cref="FilterSetGenerator">FilterSetGenerator</see> if there is no key in the Filters dictionary.
+        /// </summary>
+        /// <returns>Returns null if there are no filters defined for this type</returns>
+        public static EntityFilterSet GetFilterSet(Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException("type");
+            }
+
+            EntityFilterSet filterSet;
+            lock (Filters)
+            {
+                if (!Filters.TryGetValue(type, out filterSet))
+                {
+                    filterSet = FilterSetGenerator.GenerateEntityFilterSet(type);
+                    Filters.Add(type, filterSet);
+                }
+            }
+
+            return filterSet;
+        }
+
+        /// <summary>
+        /// Add or change a filter set
+        /// </summary>
+        public static void SetFilterSet(Type type, EntityFilterSet filterSet)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException("type");
+            }
+            if (filterSet == null)
+            {
+                throw new ArgumentNullException("filterSet");
+            }
+
+            lock (Filters)
+            {
+                Filters[type] = filterSet;
+            }
+        }
+
+        /// <summary>
+        /// Remove a filter set.
+        /// </summary>
+        public static void RemoveFilterSet(Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException("type");
+            }
+
+            lock (Filters)
+            {
+                Filters[type] = null;
+            }
+        }
+
+        /// <summary>
+        /// Clear all filter sets.
+        /// </summary>
+        /// <remarks>Will cause future requests to be regenerated using the <see cref="FilterSetGenerator">FilterSetGenerator</see>.</remarks>
+        public static void Clear()
+        {
+            lock (Filters)
+            {
+                Filters.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Apply filters to a LINQ query
+        /// </summary>
+        public static IQueryable<T> ApplyFilters<T>(IQueryable<T> source)
+        {
+            var filterSet = GetFilterSet(typeof(T));
+
+            if (filterSet != null)
+            {
+                return filterSet.ApplyFilters(source);
+            }
+            else
+            {
+                return source;
+            }
+        }
+
+    }
+}

--- a/Src/Couchbase.Linq/Filters/EntityFilterSet.cs
+++ b/Src/Couchbase.Linq/Filters/EntityFilterSet.cs
@@ -5,12 +5,12 @@ using System.Linq;
 namespace Couchbase.Linq.Filters
 {
     /// <summary>
-    /// Stores a list of <see cref="IEntityFilter">IEntityFilter</see>s, sorted by Priority
+    /// Stores a list of <see cref="IEntityFilter&lt;T&gt;">IEntityFilter</see>s, sorted by Priority
     /// </summary>
     /// <remarks>
     /// Sort order of IEntityFilters with the same Priority is undefined
     /// </remarks>
-    class EntityFilterSet : SortedSet<IEntityFilter>
+    public class EntityFilterSet<T> : SortedSet<IEntityFilter<T>>
     {
 
         /// <summary>
@@ -23,14 +23,22 @@ namespace Couchbase.Linq.Filters
         /// <summary>
         /// Create an EntityFilterSet, filled with a set of filters
         /// </summary>
-        public EntityFilterSet(IEnumerable<IEntityFilter> filters) : base(filters, new PriorityComparer())
+        public EntityFilterSet(IEnumerable<IEntityFilter<T>> filters) : base(filters, new PriorityComparer())
         {   
+        }
+
+        /// <summary>
+        /// Create an EntityFilterSet, filled with a set of filters
+        /// </summary>
+        public EntityFilterSet(params IEntityFilter<T>[] filters)
+            : base(filters, new PriorityComparer())
+        {
         }
 
         /// <summary>
         /// Apply the filters to a LINQ query, in order
         /// </summary>
-        public IQueryable<T> ApplyFilters<T>(IQueryable<T> source)
+        public IQueryable<T> ApplyFilters(IQueryable<T> source)
         {
             if (source == null)
             {
@@ -45,10 +53,10 @@ namespace Couchbase.Linq.Filters
             return source;
         }
 
-        private class PriorityComparer : IComparer<IEntityFilter>
+        private class PriorityComparer : IComparer<IEntityFilter<T>>
         {
 
-            public int Compare(IEntityFilter x, IEntityFilter y)
+            public int Compare(IEntityFilter<T> x, IEntityFilter<T> y)
             {
                 return x.Priority.CompareTo(y.Priority);
             }

--- a/Src/Couchbase.Linq/Filters/EntityFilterSet.cs
+++ b/Src/Couchbase.Linq/Filters/EntityFilterSet.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Couchbase.Linq.Filters
+{
+    /// <summary>
+    /// Stores a list of <see cref="IEntityFilter">IEntityFilter</see>s, sorted by Priority
+    /// </summary>
+    /// <remarks>
+    /// Sort order of IEntityFilters with the same Priority is undefined
+    /// </remarks>
+    class EntityFilterSet : SortedSet<IEntityFilter>
+    {
+
+        /// <summary>
+        /// Create an empty EntityFilterSet
+        /// </summary>
+        public EntityFilterSet() : base(new PriorityComparer())
+        {
+        }
+
+        /// <summary>
+        /// Create an EntityFilterSet, filled with a set of filters
+        /// </summary>
+        public EntityFilterSet(IEnumerable<IEntityFilter> filters) : base(filters, new PriorityComparer())
+        {   
+        }
+
+        /// <summary>
+        /// Apply the filters to a LINQ query, in order
+        /// </summary>
+        public IQueryable<T> ApplyFilters<T>(IQueryable<T> source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+
+            foreach (var filter in this)
+            {
+                source = filter.ApplyFilter(source);
+            }
+
+            return source;
+        }
+
+        private class PriorityComparer : IComparer<IEntityFilter>
+        {
+
+            public int Compare(IEntityFilter x, IEntityFilter y)
+            {
+                return x.Priority.CompareTo(y.Priority);
+            }
+
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Filters/EntityTypeFilterAttribute.cs
+++ b/Src/Couchbase.Linq/Filters/EntityTypeFilterAttribute.cs
@@ -9,24 +9,10 @@ namespace Couchbase.Linq.Filters
     /// </summary>
     public class EntityTypeFilterAttribute : EntityFilterAttribute
     {
-        private Expression _expressionCache;
-
-        private string _type;
         /// <summary>
         /// Filter the results to include entities with this string as the "type" attribute
         /// </summary>
-        public string Type
-        {
-            get { return _type; }
-            set
-            {
-                if (value != _type)
-                {
-                    _type = value;
-                    _expressionCache = null;
-                }
-            }
-        }
+        public string Type { get; set; }
 
         /// <summary>
         /// Creates a new EntityTypeFilterAttribute
@@ -34,42 +20,37 @@ namespace Couchbase.Linq.Filters
         /// <param name="type">Filter the results to include entities with this string as the "type" attribute</param>
         public EntityTypeFilterAttribute(string type)
         {
-            _type = type;
+            Type = type;
         }
 
         /// <summary>
         /// Apply the filter to a LINQ query
         /// </summary>
-        public override IQueryable<T> ApplyFilter<T>(IQueryable<T> source)
+        public override IEntityFilter<T> GetFilter<T>()
         {
-            if (source == null)
+            return new WhereFilter<T>
             {
-                throw new ArgumentNullException("source");
-            }
-
-            if (!string.IsNullOrEmpty(Type))
-            {
-                return source.Where(GetExpression<T>());
-            }
-            else
-            {
-                return source;
-            }
+                Priority = Priority,
+                WhereExpression = GetExpression<T>()
+            };
         }
 
         private Expression<Func<T, bool>> GetExpression<T>()
         {
-            if (_expressionCache != null)
-            {
-                return (Expression<Func<T, bool>>) _expressionCache;
-            }
-
             var parameter = Expression.Parameter(typeof (T), "p");
             
-            var expression = Expression.Lambda<Func<T, bool>>(Expression.Equal(Expression.PropertyOrField(parameter, "type"), Expression.Constant(Type)), parameter);
+            return Expression.Lambda<Func<T, bool>>(Expression.Equal(Expression.PropertyOrField(parameter, "type"), Expression.Constant(Type)), parameter);
+        }
 
-            _expressionCache = expression;
-            return expression;
+        private class WhereFilter<T> : IEntityFilter<T>
+        {
+            public Expression<Func<T, bool>> WhereExpression { get; set; }
+            public int Priority { get; set; }
+
+            public IQueryable<T> ApplyFilter(IQueryable<T> source)
+            {
+                return source.Where(WhereExpression);
+            }
         }
 
     }

--- a/Src/Couchbase.Linq/Filters/EntityTypeFilterAttribute.cs
+++ b/Src/Couchbase.Linq/Filters/EntityTypeFilterAttribute.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Couchbase.Linq.Filters
+{
+    /// <summary>
+    /// When using Linq2Couchbase, automatically filter returned entities by the "type" attribute
+    /// </summary>
+    public class EntityTypeFilterAttribute : EntityFilterAttribute
+    {
+        private Expression _expressionCache;
+
+        private string _type;
+        /// <summary>
+        /// Filter the results to include entities with this string as the "type" attribute
+        /// </summary>
+        public string Type
+        {
+            get { return _type; }
+            set
+            {
+                if (value != _type)
+                {
+                    _type = value;
+                    _expressionCache = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a new EntityTypeFilterAttribute
+        /// </summary>
+        /// <param name="type">Filter the results to include entities with this string as the "type" attribute</param>
+        public EntityTypeFilterAttribute(string type)
+        {
+            _type = type;
+        }
+
+        /// <summary>
+        /// Apply the filter to a LINQ query
+        /// </summary>
+        public override IQueryable<T> ApplyFilter<T>(IQueryable<T> source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+
+            if (!string.IsNullOrEmpty(Type))
+            {
+                return source.Where(GetExpression<T>());
+            }
+            else
+            {
+                return source;
+            }
+        }
+
+        private Expression<Func<T, bool>> GetExpression<T>()
+        {
+            if (_expressionCache != null)
+            {
+                return (Expression<Func<T, bool>>) _expressionCache;
+            }
+
+            var parameter = Expression.Parameter(typeof (T), "p");
+            
+            var expression = Expression.Lambda<Func<T, bool>>(Expression.Equal(Expression.PropertyOrField(parameter, "type"), Expression.Constant(Type)), parameter);
+
+            _expressionCache = expression;
+            return expression;
+        }
+
+    }
+}

--- a/Src/Couchbase.Linq/Filters/IEntityFilter.cs
+++ b/Src/Couchbase.Linq/Filters/IEntityFilter.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq;
+
+namespace Couchbase.Linq.Filters
+{
+    /// <summary>
+    /// Filter designed to be applied to a LINQ query automatically
+    /// </summary>
+    interface IEntityFilter
+    {
+        /// <summary>
+        /// Priority of this filter compared to other filters against the same type.  Lower priorities execute first.
+        /// </summary>
+        int Priority { get; set; }
+
+        /// <summary>
+        /// Apply the filter to a LINQ query
+        /// </summary>
+        IQueryable<T> ApplyFilter<T>(IQueryable<T> source);
+    }
+}

--- a/Src/Couchbase.Linq/Filters/IEntityFilter.cs
+++ b/Src/Couchbase.Linq/Filters/IEntityFilter.cs
@@ -5,7 +5,7 @@ namespace Couchbase.Linq.Filters
     /// <summary>
     /// Filter designed to be applied to a LINQ query automatically
     /// </summary>
-    interface IEntityFilter
+    public interface IEntityFilter<T>
     {
         /// <summary>
         /// Priority of this filter compared to other filters against the same type.  Lower priorities execute first.
@@ -15,6 +15,6 @@ namespace Couchbase.Linq.Filters
         /// <summary>
         /// Apply the filter to a LINQ query
         /// </summary>
-        IQueryable<T> ApplyFilter<T>(IQueryable<T> source);
+        IQueryable<T> ApplyFilter(IQueryable<T> source);
     }
 }

--- a/Src/Couchbase.Linq/Filters/IEntityFilterSetGenerator.cs
+++ b/Src/Couchbase.Linq/Filters/IEntityFilterSetGenerator.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Couchbase.Linq.Filters
+{
+    /// <summary>
+    /// Generates an <see cref="EntityFilterSet">EntityFilterSet</see> for a particular type.
+    /// </summary>
+    interface IEntityFilterSetGenerator
+    {
+
+        /// <summary>
+        /// Generates an <see cref="EntityFilterSet">EntityFilterSet</see> for a particular type.
+        /// </summary>
+        /// <returns>Returns null if there are no filters.  This is to improve efficieny.</returns>
+        EntityFilterSet GenerateEntityFilterSet(Type type);
+
+    }
+}

--- a/Src/Couchbase.Linq/Filters/IEntityFilterSetGenerator.cs
+++ b/Src/Couchbase.Linq/Filters/IEntityFilterSetGenerator.cs
@@ -3,16 +3,16 @@
 namespace Couchbase.Linq.Filters
 {
     /// <summary>
-    /// Generates an <see cref="EntityFilterSet">EntityFilterSet</see> for a particular type.
+    /// Generates an <see cref="EntityFilterSet&lt;T&gt;">EntityFilterSet</see> for a particular type.
     /// </summary>
-    interface IEntityFilterSetGenerator
+    public interface IEntityFilterSetGenerator
     {
 
         /// <summary>
-        /// Generates an <see cref="EntityFilterSet">EntityFilterSet</see> for a particular type.
+        /// Generates an <see cref="EntityFilterSet&lt;T&gt;">EntityFilterSet</see> for a particular type.
         /// </summary>
         /// <returns>Returns null if there are no filters.  This is to improve efficieny.</returns>
-        EntityFilterSet GenerateEntityFilterSet(Type type);
+        EntityFilterSet<T> GenerateEntityFilterSet<T>();
 
     }
 }


### PR DESCRIPTION
Uses declarative attributes or runtime definitions to cause automatic filtering of documents based on the destination entity type. 

For example, easily filter all queries for Beer entities to automatically remove any documents where type <> 'beer' by applying `[EntityTypeFilter("beer")]` to the Beer class.