### PR TITLE
Improve usability of the Explain() method

### DIFF
--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -128,7 +128,6 @@ namespace Couchbase.Linq.Tests
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
-
                     var beers = (from b in bucket.Queryable<Beer>()
                                  where b.Type == "beer"
                                  select new { name = b.Name, meta = N1Ql.Meta(b) }).
@@ -138,6 +137,23 @@ namespace Couchbase.Linq.Tests
                     {
                         Console.WriteLine("{0} has metadata {1}", b.name, b.meta);
                     }
+                }
+            }
+        }
+
+        [Test]
+        public void Map2PocoTests_Explain()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var explanation = (from b in bucket.Queryable<Beer>()
+                                       where b.Type == "beer"
+                                       select b).
+                        Explain();
+
+                    Console.WriteLine(explanation);
                 }
             }
         }

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/ExplainTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/ExplainTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Core;
@@ -21,12 +22,13 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Select(c => new {age = c.Age})
-                .Explain();
+                .Select(c => new {age = c.Age});
+
+            var explainQuery = Expression.Call(null, typeof(QueryExtensions).GetMethod("Explain").MakeGenericMethod(query.ElementType), query.Expression);
 
             const string expected = "EXPLAIN SELECT c.age as age FROM default as c";
 
-            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, explainQuery);
 
             Assert.AreEqual(expected, n1QlQuery);
         }

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
@@ -32,10 +32,19 @@ namespace Couchbase.Linq.Extensions
         /// </summary>
         /// <typeparam name="T">The target type.</typeparam>
         /// <param name="source">The source.</param>
-        /// <returns></returns>
-        public static IQueryable<T> Explain<T>(this IQueryable<T> source)
+        /// <returns>Explanation of the query</returns>
+        public static dynamic Explain<T>(this IQueryable<T> source)
         {
-            return CreateQuery(source, queryable => queryable.Explain());
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+
+            var newExpression = Expression.Call(null,
+                ((MethodInfo) MethodBase.GetCurrentMethod()).MakeGenericMethod(typeof (T)),
+                source.Expression);
+
+            return source.Provider.Execute<dynamic>(newExpression);
         }
 
         /// <summary>

--- a/Src/Couchbase.Linq/Operators/ExplainResultOperator.cs
+++ b/Src/Couchbase.Linq/Operators/ExplainResultOperator.cs
@@ -6,11 +6,11 @@ using Remotion.Linq.Clauses.StreamedData;
 
 namespace Couchbase.Linq.Operators
 {
-    public class ExplainResultOperator : SequenceTypePreservingResultOperatorBase
+    public class ExplainResultOperator : ValueFromSequenceResultOperatorBase
     {
-        public override StreamedSequence ExecuteInMemory<T>(StreamedSequence input)
+        public override StreamedValue ExecuteInMemory<T>(StreamedSequence input)
         {
-            return input; //no change to sequence
+            throw new NotImplementedException("Cannot explain N1QL queries in memory");
         }
 
         public override ResultOperatorBase Clone(CloneContext cloneContext)
@@ -18,10 +18,36 @@ namespace Couchbase.Linq.Operators
             return new ExplainResultOperator();
         }
 
+        public override IStreamedDataInfo GetOutputDataInfo(IStreamedDataInfo inputInfo)
+        {
+            if (inputInfo == null)
+            {
+                throw new ArgumentNullException("inputInfo");
+            }
+
+            var sequenceInfo = inputInfo as StreamedSequenceInfo;
+            if (sequenceInfo == null)
+            {
+                throw new ArgumentException(string.Format("Parameter 'inputInfo' has unexpected type '{0}'.", inputInfo.GetType()));
+            }
+
+            return GetOutputDataInfo(sequenceInfo);
+        }
+
+        private StreamedValueInfo GetOutputDataInfo(StreamedSequenceInfo sequenceInfo)
+        {
+            return new StreamedScalarValueInfo(typeof(object));
+        }
+
         public override void TransformExpressions(Func<Expression, Expression> transformation)
         {
             //no parameters so just ignore this
             //throw new NotImplementedException();
+        }
+
+        public override string ToString()
+        {
+            return "Explain()";
         }
     }
 }


### PR DESCRIPTION
Motivation
----------
There was a disconnect in the Explain() method related to its return type.
It was always returning an IQueryable<T> for the entity type at the time
it was called.  For example, bucket.Queryable<Beer>.Explain() would return an
IQueryable<Beer>, therefore indicating that it was returning a list of
Beers rather than an execution plan.

Modifications
-------------
ExplainResultOperator now inherits from
ValueFromSequenceResultOperatorBase, indicating that it is returning a
single value.  QueryExtensions.Explain now returns a dynamic type, and
calls source.Provider.Execute to run the query immediately when called.

Results
-------
Explain() now returns a dynamic object which will contain the execution
plan.  It also executes immediately using ExecuteScalar<dynamic> rather
than deferring execution, much like the Any() or All() methods.

Note that it might be possible to implement a well-known object structure
for the query plan, and return that instead of a dynamic object.  However,
it would require effort to create the object tree, a working knowledge of
the query execution plan structure, and probably some custom JSON
deserializers to choose the correct object types.