### PR TITLE
Support for INNER JOIN, LEFT JOIN, INNER UNNEST, and OUTER UNNEST

### DIFF
--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="N1QLTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueryClientExtensionTests.cs" />
+    <Compile Include="QueryGeneration\NestTests.cs" />
     <Compile Include="QueryGeneration\JoinTests.cs" />
     <Compile Include="QueryGeneration\MetaTests.cs" />
     <Compile Include="QueryGeneration\ExplainTests.cs" />

--- a/Src/Couchbase.Linq.Tests/Documents/Geo.cs
+++ b/Src/Couchbase.Linq.Tests/Documents/Geo.cs
@@ -8,9 +8,9 @@ namespace Couchbase.Linq.Tests.Documents
         public string Accuracy { get; set; }
 
         [JsonProperty("lat")]
-        public string Latitude { get; set; }
+        public decimal Latitude { get; set; }
 
         [JsonProperty("lon")]
-        public string Longitude { get; set; }
+        public decimal Longitude { get; set; }
     }
 }

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/JoinTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/JoinTests.cs
@@ -16,24 +16,142 @@ namespace Couchbase.Linq.Tests.QueryGeneration
     public class JoinTests : N1QLTestBase
     {
         [Test]
-        public void Test_Join_Keyword()
+        public void Test_InnerJoin_Simple()
         {
             var mockBucket = new Mock<IBucket>();
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
-            var query = from p in QueryFactory.Queryable<Contact>(mockBucket.Object)
-                join c in QueryFactory.Queryable<Child>(mockBucket.Object)
-                        on p.FirstName equals c.FirstName
-                select new {p.LastName, c.Age};
+            var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                        join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                        on beer.BreweryId equals N1Ql.Key(brewery)
+                        select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
 
-            const string expected = "SELECT p.lastname, c.age " +
-                "FROM default as p "+
-                "JOIN default as c " +
-                "ON KEYS ARRAY s.contactId FOR s IN p END";
+            const string expected = "SELECT beer.name as Name, beer.abv as Abv, brewery.name as BreweryName " +
+                "FROM default as beer "+
+                "INNER JOIN default as brewery " +
+                "ON KEYS beer.`brewery_id`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
-            Assert.AreNotEqual(expected, n1QlQuery);//this should be true when joins properly work
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_InnerJoin_SortAndFilter()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                        join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                        on beer.BreweryId equals N1Ql.Key(brewery)
+                        where brewery.Geo.Longitude > -80
+                        orderby beer.Name
+                        select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
+
+            const string expected = "SELECT beer.name as Name, beer.abv as Abv, brewery.name as BreweryName " +
+                "FROM default as beer " +
+                "INNER JOIN default as brewery " +
+                "ON KEYS beer.`brewery_id` " +
+                "WHERE (brewery.geo.lon > -80) " + 
+                "ORDER BY beer.name ASC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_InnerJoin_Prefiltered()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object).Where(p => p.Type == "beer")
+                        join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object).Where(p => p.Type == "brewery")
+                        on beer.BreweryId equals N1Ql.Key(brewery)
+                        select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
+
+            const string expected = "SELECT p.name as Name, p.abv as Abv, brewery.name as BreweryName " +
+                "FROM default as p " +
+                "INNER JOIN default as brewery " +
+                "ON KEYS p.`brewery_id` " + 
+                "WHERE (p.type = 'beer') AND (brewery.type = 'brewery')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_LeftJoin_Simple()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                        join breweryGroup in QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                        on beer.BreweryId equals N1Ql.Key(breweryGroup) into bg
+                        from brewery in bg.DefaultIfEmpty()
+                        select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
+
+            const string expected = "SELECT beer.name as Name, beer.abv as Abv, brewery.name as BreweryName " +
+                "FROM default as beer " +
+                "LEFT JOIN default as brewery " +
+                "ON KEYS beer.`brewery_id`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_LeftJoin_SortAndFilter()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                        join breweryGroup in QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                        on beer.BreweryId equals N1Ql.Key(breweryGroup) into bg
+                        from brewery in bg.DefaultIfEmpty()
+                        where beer.Abv > 4
+                        orderby brewery.Name, beer.Name
+                        select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
+
+            const string expected = "SELECT beer.name as Name, beer.abv as Abv, brewery.name as BreweryName " +
+                "FROM default as beer " +
+                "LEFT JOIN default as brewery " +
+                "ON KEYS beer.`brewery_id` " +
+                "WHERE (beer.abv > 4) " +
+                "ORDER BY brewery.name ASC, beer.name ASC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_LeftJoin_Prefiltered()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object).Where(p => p.Type == "beer")
+                        join breweryGroup in QueryFactory.Queryable<Brewery>(mockBucket.Object).Where(p => p.Type == "brewery")
+                        on beer.BreweryId equals N1Ql.Key(breweryGroup) into bg
+                        from brewery in bg.DefaultIfEmpty()
+                        select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
+
+            const string expected = "SELECT p.name as Name, p.abv as Abv, brewery.name as BreweryName " +
+                "FROM default as p " +
+                "LEFT JOIN default as brewery " +
+                "ON KEYS p.`brewery_id` " +
+                "WHERE (p.type = 'beer') AND (brewery.type = 'brewery')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
         }
     }
 }

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/NestTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/NestTests.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Core;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Tests.Documents;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.Tests.QueryGeneration
+{
+    [TestFixture]
+    public class NestTests : N1QLTestBase
+    {
+        [Test]
+        public void Test_Unnest_Simple()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                        from address in brewery.Address
+                        select new {name = brewery.Name, address};
+
+            const string expected = "SELECT brewery.name as name, address as address " +
+                "FROM default as brewery "+
+                "INNER UNNEST brewery.address as address";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Unnest_Sort()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                        from address in brewery.Address
+                        orderby address
+                        select new { name = brewery.Name, address };
+
+            const string expected = "SELECT brewery.name as name, address as address " +
+                "FROM default as brewery " +
+                "INNER UNNEST brewery.address as address " +
+                "ORDER BY address ASC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Unnest_Prefiltered()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                        from address in brewery.Address.Where(p => p != "123 First Street")
+                        select new { name = brewery.Name, address };
+
+            const string expected = "SELECT brewery.name as name, address as address " +
+                "FROM default as brewery " +
+                "INNER UNNEST brewery.address as address " +
+                "WHERE (address != '123 First Street')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_LeftUnnest_Simple()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                        from address in brewery.Address.DefaultIfEmpty()
+                        select new { name = brewery.Name, address };
+
+            const string expected = "SELECT brewery.name as name, address as address " +
+                "FROM default as brewery " +
+                "OUTER UNNEST brewery.address as address";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Unnest_DoubleLevel()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from level1 in QueryFactory.Queryable<UnnestLevel1>(mockBucket.Object)
+                        from level2 in level1.Level2Items
+                        from level3 in level2.Level3Items
+                        select new { level3.Value };
+
+            const string expected = "SELECT level3.Value as Value " +
+                "FROM default as level1 " +
+                "INNER UNNEST level1.Level2Items as level2 " +
+                "INNER UNNEST level2.Level3Items as level3";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #region Helper Classes
+
+        public class UnnestLevel1
+        {
+            public List<UnnestLevel2> Level2Items { get; set; }
+        }
+
+        public class UnnestLevel2
+        {
+            public List<UnnestLevel3> Level3Items {get; set;}
+        }
+
+        public class UnnestLevel3
+        {
+            public string Value { get; set; }
+        }
+
+        #endregion
+
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -97,6 +97,7 @@
     <Compile Include="QueryGeneration\SelectMissingException.cs" />
     <Compile Include="Metadata\DocumentMetadata.cs" />
     <Compile Include="N1QL.cs" />
+    <Compile Include="QueryGeneration\UnclaimedGroupJoin.cs" />
     <Compile Include="QueryParserHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/Couchbase.Linq/N1QL.cs
+++ b/Src/Couchbase.Linq/N1QL.cs
@@ -31,5 +31,30 @@ namespace Couchbase.Linq
             }
         }
 
+        /// <summary>
+        /// Returns the key for a document object
+        /// </summary>
+        /// <param name="document">Document to get key from</param>
+        /// <returns>Key of the document</returns>
+        /// <remarks>Should only be called against a top-level document in Couchbase</remarks>
+        public static string Key(object document)
+        {
+            // Implementation will only be called when unit testing
+            // using LINQ-to-Objects and faking a Couchbase database
+            // Any faked document object should implement IDocumentMetadataProvider
+
+            var provider = document as IDocumentMetadataProvider;
+            if (provider != null)
+            {
+                var metadata = provider.GetMetadata();
+
+                return metadata != null ? metadata.Id : null;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
     }
 }

--- a/Src/Couchbase.Linq/QueryFactory.cs
+++ b/Src/Couchbase.Linq/QueryFactory.cs
@@ -1,10 +1,11 @@
-﻿using Couchbase.Core;
+﻿using System.Linq;
+using Couchbase.Core;
 
 namespace Couchbase.Linq
 {
     public class QueryFactory
     {
-        public static BucketQueryable<T> Queryable<T>(IBucket bucket)
+        public static IQueryable<T> Queryable<T>(IBucket bucket)
         {
             return new BucketQueryable<T>(bucket);
         }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -24,6 +24,7 @@ namespace Couchbase.Linq.QueryGeneration
             _parameterAggregator = parameterAggregator;
             _methodCallTranslators.Add(typeof (string).GetMethod("Contains"), ContainsMethodTranslator);
             _methodCallTranslators.Add(typeof (N1Ql).GetMethod("Meta"), MetaMethodTranslator);
+            _methodCallTranslators.Add(typeof (N1Ql).GetMethod("Key"), KeyMethodTranslator);
         }
 
         #region Method Translators
@@ -54,6 +55,15 @@ namespace Couchbase.Linq.QueryGeneration
             _expression.Append("META(");
             VisitExpression(methodCallExpression.Arguments[0]);
             _expression.Append(')');
+
+            return methodCallExpression;
+        }
+
+        private Expression KeyMethodTranslator(MethodCallExpression methodCallExpression)
+        {
+            _expression.Append("META(");
+            VisitExpression(methodCallExpression.Arguments[0]);
+            _expression.Append(").Id");
 
             return methodCallExpression;
         }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLFromQueryPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLFromQueryPart.cs
@@ -1,4 +1,6 @@
 ﻿
+using Remotion.Linq.Clauses;
+
 namespace Couchbase.Linq.QueryGeneration
 {
     /// <summary>
@@ -16,6 +18,16 @@ namespace Couchbase.Linq.QueryGeneration
         /// Name of the query data when being referenced in the query ("as" clause).  Should already be escaped.
         /// </summary>
         public string ItemName { get; set; }
+
+        /// <summary>
+        /// Type of join to perform
+        /// </summary>
+        public string JoinType { get; set; }
+
+        /// <summary>
+        /// For joins, the expression for the key value to join
+        /// </summary>
+        public string OnKeys { get; set; }
 
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -16,6 +16,7 @@ namespace Couchbase.Linq.QueryGeneration
     {
         private readonly ParameterAggregator _parameterAggregator = new ParameterAggregator();
         private readonly QueryPartsAggregator _queryPartsAggregator = new QueryPartsAggregator();
+        private readonly List<UnclaimedGroupJoin> _unclaimedGroupJoins = new List<UnclaimedGroupJoin>(); 
 
         private bool _isSubQuery = false;
 
@@ -37,6 +38,11 @@ namespace Couchbase.Linq.QueryGeneration
             queryModel.MainFromClause.Accept(this, queryModel);
             VisitBodyClauses(queryModel.BodyClauses, queryModel);
             VisitResultOperators(queryModel.ResultOperators, queryModel);
+
+            if (_unclaimedGroupJoins.Any())
+            {
+                throw new NotSupportedException("N1QL Requires All Group Joins Have A Matching From Clause Subquery");
+            }
         }
 
         public override void VisitMainFromClause(MainFromClause fromClause, QueryModel queryModel)
@@ -154,28 +160,247 @@ namespace Couchbase.Linq.QueryGeneration
             base.VisitOrderByClause(orderByClause, queryModel, index);
         }
 
-        //TODO: Implement Joins
+        #region Additional From Clauses
+
+        public override void VisitAdditionalFromClause(AdditionalFromClause fromClause, QueryModel queryModel, int index)
+        {
+            var handled = false;
+
+            switch (fromClause.FromExpression.NodeType)
+            {
+                case ExpressionType.MemberAccess:
+                    // Unnest operation
+
+                    var fromPart = VisitMemberFromExpression(fromClause, fromClause.FromExpression as MemberExpression);
+                    _queryPartsAggregator.AddFromPart(fromPart);
+                    handled = true;
+                    break;
+
+                case (ExpressionType)100002: // SubQueryExpression
+                    // Might be an unnest or a join to another bucket
+
+                    handled = VisitSubQueryFromExpression(fromClause, fromClause.FromExpression as SubQueryExpression);
+                    break;
+            }
+
+            if (!handled)
+            {
+                throw new NotSupportedException("N1QL Does Not Support This Type Of From Clause");
+            }
+
+            base.VisitAdditionalFromClause(fromClause, queryModel, index);
+        }
+
+        /// <summary>
+        /// Visits an AdditionalFromClause that is executing a subquery
+        /// </summary>
+        /// <param name="fromClause">AdditionalFromClause being visited</param>
+        /// <param name="subQuery">Subquery being executed by the AdditionalFromClause</param>
+        /// <returns>True if handled</returns>
+        private bool VisitSubQueryFromExpression(AdditionalFromClause fromClause, SubQueryExpression subQuery)
+        {
+            var mainFromExpression = subQuery.QueryModel.MainFromClause.FromExpression;
+
+            switch (mainFromExpression.NodeType)
+            {
+                case (ExpressionType)100001: // QuerySourceReferenceExpression
+                    // Joining to another bucket using a previous group join operation
+
+                    return VisitSubQuerySourceReferenceExpression(fromClause, subQuery, mainFromExpression as QuerySourceReferenceExpression);
+
+                case ExpressionType.MemberAccess:
+                    // Unnest operation
+
+                    var fromPart = VisitMemberFromExpression(fromClause, mainFromExpression as MemberExpression);
+
+                    if (subQuery.QueryModel.ResultOperators.OfType<DefaultIfEmptyResultOperator>().Any())
+                    {
+                        fromPart.JoinType = "OUTER UNNEST";
+                    }
+
+                    _queryPartsAggregator.AddFromPart(fromPart);
+
+                    // be sure the subquery clauses use the provided itemName
+                    subQuery.QueryModel.MainFromClause.ItemName = fromClause.ItemName;
+
+                    // Apply where filters in the subquery to the main query
+                    VisitBodyClauses(subQuery.QueryModel.BodyClauses, subQuery.QueryModel);
+
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Visit an AdditionalFromClause referencing a previous group join clause
+        /// </summary>
+        /// <param name="fromClause">AdditionalFromClause being visited</param>
+        /// <param name="subQuery">SubQueryExpression being visited</param>
+        /// <param name="querySourceReference">QuerySourceReferenceExpression that is the MainFromClause of the SubQuery</param>
+        /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator.  JoinType is defaulted to INNER UNNEST.</returns>
+        private bool VisitSubQuerySourceReferenceExpression(AdditionalFromClause fromClause, SubQueryExpression subQuery,
+            QuerySourceReferenceExpression querySourceReference)
+        {
+            var unclaimedJoin =
+                    _unclaimedGroupJoins.FirstOrDefault(
+                        p => p.GroupJoinClause == querySourceReference.ReferencedQuerySource);
+            if (unclaimedJoin != null)
+            {
+                // this additional from clause is for a previous group join
+                // if not, then it isn't supported and we'll let the method return false so an exception is thrown
+
+                var fromPart = ParseJoinClause(unclaimedJoin.JoinClause, fromClause.ItemName);
+
+                if (subQuery.QueryModel.ResultOperators.OfType<DefaultIfEmptyResultOperator>().Any())
+                {
+                    fromPart.JoinType = "LEFT JOIN";
+
+                    // TODO Handle where clauses applied to the inner sequence before the join
+                    // Currently they are filtered after the join is complete instead of before by N1QL
+                }
+
+                _unclaimedGroupJoins.Remove(unclaimedJoin);
+                _queryPartsAggregator.AddFromPart(fromPart);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Visit an AdditionalFromClause referencing a member
+        /// </summary>
+        /// <param name="fromClause">AdditionalFromClause being visited</param>
+        /// <param name="expression">MemberExpression being referenced</param>
+        /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator.  JoinType is defaulted to INNER UNNEST.</returns>
+        private N1QlFromQueryPart VisitMemberFromExpression(AdditionalFromClause fromClause, MemberExpression expression)
+        {
+            // This case represents an unnest operation
+
+            return new N1QlFromQueryPart()
+            {
+                Source = GetN1QlExpression(expression),
+                ItemName = EscapeIdentifier(fromClause.ItemName),
+                JoinType = "INNER UNNEST"
+            };
+        }
+        
+        #endregion
+
+        #region Join Clauses
+
         public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel,
             GroupJoinClause groupJoinClause)
         {
+            // Store the group join with the expectation it will be used later by an additional from clause
+
+            _unclaimedGroupJoins.Add(new UnclaimedGroupJoin()
+            {
+                JoinClause = joinClause,
+                GroupJoinClause = groupJoinClause
+            });
+
             base.VisitJoinClause(joinClause, queryModel, groupJoinClause);
         }
 
         public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel, int index)
         {
-            _queryPartsAggregator.AddFromPart(new N1QlFromQueryPart()
-            {
-                Source = joinClause.ItemType.Name.ToLower(),
-                ItemName = joinClause.ItemName
-            });
+            // basic join clause is an INNER JOIN against another bucket
 
-            _queryPartsAggregator.AddWherePart("ON KEYS ARRAY {0} FOR {1} IN {2} END",
-                joinClause.OuterKeySelector,
-                joinClause.InnerKeySelector,
-                joinClause.ItemName);
+            var fromQueryPart = ParseJoinClause(joinClause, joinClause.ItemName);
+
+            _queryPartsAggregator.AddFromPart(fromQueryPart);
 
             base.VisitJoinClause(joinClause, queryModel, index);
         }
+
+        /// <summary>
+        /// Visits a join against either a constant expression of IBucketQueryable, or a subquery based on an IBucketQueryable
+        /// </summary>
+        /// <param name="joinClause">Join clause being visited</param>
+        /// <param name="itemName">Name to be used when referencing the data being joined</param>
+        /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator.  JoinType is defaulted to INNER JOIN.</returns>
+        /// <remarks>The InnerKeySelector must be selecting the N1Ql.Key of the InnerSequence</remarks>
+        private N1QlFromQueryPart ParseJoinClause(JoinClause joinClause, string itemName)
+        {
+            switch (joinClause.InnerSequence.NodeType)
+            {
+                case ExpressionType.Constant:
+                    return VisitConstantExpressionJoinClause(joinClause, joinClause.InnerSequence as ConstantExpression, itemName);
+
+                case (ExpressionType)100002: // SubQueryExpression
+                    var subQuery = joinClause.InnerSequence as SubQueryExpression;
+                    if ((subQuery == null) || subQuery.QueryModel.ResultOperators.Any() || subQuery.QueryModel.MainFromClause.FromExpression.NodeType != ExpressionType.Constant)
+                    {
+                        throw new NotSupportedException("Unsupported Join Inner Sequence");
+                    }
+
+                    // be sure the subquery clauses use the provided itemName
+                    subQuery.QueryModel.MainFromClause.ItemName = itemName;
+
+                    var fromPart = VisitConstantExpressionJoinClause(joinClause,
+                        subQuery.QueryModel.MainFromClause.FromExpression as ConstantExpression, itemName);
+
+                    VisitBodyClauses(subQuery.QueryModel.BodyClauses, subQuery.QueryModel);
+                    
+                    return fromPart;
+
+                default:
+                    throw new NotSupportedException("Unsupported Join Inner Sequence");
+            }
+        }
+
+        /// <summary>
+        /// Visits a join against a constant expression, which must be an IBucketQueryable implementation
+        /// </summary>
+        /// <param name="joinClause">Join clause being visited</param>
+        /// <param name="constantExpression">Constant expression that is the InnerSequence of the JoinClause</param>
+        /// <param name="itemName">Name to be used when referencing the data being joined</param>
+        /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator.  JoinType is defaulted to INNER JOIN.</returns>
+        /// <remarks>The InnerKeySelector must be selecting the N1Ql.Key of the InnerSequence</remarks>
+        private N1QlFromQueryPart VisitConstantExpressionJoinClause(JoinClause joinClause, ConstantExpression constantExpression, string itemName)
+        {
+            string bucketName = null;
+
+            if (constantExpression != null)
+            {
+                var bucketQueryable = constantExpression.Value as IBucketQueryable;
+                if (bucketQueryable != null)
+                {
+                    bucketName = bucketQueryable.BucketName;
+                }
+            }
+
+            if (bucketName == null)
+            {
+                throw new NotSupportedException("N1QL Joins Must Be Against IBucketQueryable");
+            }
+
+            var keyExpression = joinClause.InnerKeySelector as MethodCallExpression;
+            if ((keyExpression == null) ||
+                (keyExpression.Method != typeof(N1Ql).GetMethod("Key")) ||
+                (keyExpression.Arguments.Count != 1))
+            {
+                throw new NotSupportedException("N1QL Join Selector Must Be A Call To N1Ql.Key");
+            }
+
+            if (!(keyExpression.Arguments[0] is QuerySourceReferenceExpression))
+            {
+                throw new NotSupportedException("N1QL Join Selector Call To N1Ql.Key Must Reference The Inner Sequence");
+            }
+
+            return new N1QlFromQueryPart()
+            {
+                Source = EscapeIdentifier(bucketName),
+                ItemName = EscapeIdentifier(itemName),
+                OnKeys = GetN1QlExpression(joinClause.OuterKeySelector),
+                JoinType = "INNER JOIN"
+            };
+        }
+
+        #endregion
 
         private string GetN1QlExpression(Expression expression)
         {

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -95,7 +95,20 @@ namespace Couchbase.Linq.QueryGeneration
                 var mainFrom = FromParts.First();
                 sb.AppendFormat(" FROM {0} as {1}",
                     mainFrom.Source,
-                    mainFrom.ItemName); //TODO support multiple from parts
+                    mainFrom.ItemName);
+
+                foreach (var joinPart in FromParts.Skip(1))
+                {
+                    sb.AppendFormat(" {0} {1} as {2}",
+                        joinPart.JoinType,
+                        joinPart.Source,
+                        joinPart.ItemName);
+
+                    if (!string.IsNullOrEmpty(joinPart.OnKeys))
+                    {
+                        sb.AppendFormat(" ON KEYS {0}", joinPart.OnKeys);
+                    }
+               }
             }
             if (WhereParts.Any())
             {
@@ -133,7 +146,20 @@ namespace Couchbase.Linq.QueryGeneration
                 var mainFrom = FromParts.First();
                 sb.AppendFormat(" FROM {0} as {1}",
                     mainFrom.Source,
-                    mainFrom.ItemName); //TODO support multiple from parts
+                    mainFrom.ItemName);
+
+                foreach (var joinPart in FromParts.Skip(1))
+                {
+                    sb.AppendFormat(" {0} {1} as {2}",
+                        joinPart.JoinType,
+                        joinPart.Source,
+                        joinPart.ItemName);
+
+                    if (!string.IsNullOrEmpty(joinPart.OnKeys))
+                    {
+                        sb.AppendFormat(" ON KEYS {0}", joinPart.OnKeys);
+                    }
+                }
             }
 
             bool hasWhereClause = false;

--- a/Src/Couchbase.Linq/QueryGeneration/UnclaimedGroupJoin.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/UnclaimedGroupJoin.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.Linq.QueryGeneration
+{
+    class UnclaimedGroupJoin
+    {
+
+        public JoinClause JoinClause { get; set; }
+        public GroupJoinClause GroupJoinClause { get; set; }
+
+    }
+}


### PR DESCRIPTION
Modifications
-------------
Handles join, group join, and additional from clauses in
N1QlQueryModelVisitor.  Throws exceptions for some known cases that are
unsupported.

Results
-------
Basic joins and unnests are now supported.  Cases where a Where clause is
applied to the inner sequence before the join operation are also handled
by moving the where clause to the main query.

Joins must always be made using the N1Ql.Key static method for the inner
key selector.  This is consistent with the N1QL requirement that joins
must use the ON KEYS statement.

Notes
-----
There are probably still edge cases that are not supported, some of which
are not throwing exceptions.

If you apply a Where clause to the inner sequence before a
DefaultIfEmpty() clause, the behavior between N1QL and LINQ is currently
inconsistent.  The generated N1QL query is filtering the Where clause
after the left join, while LINQ is filtering before the join.  Therefore,
it is possible that data on the left side that should be returned with a
null right side is dropped instead.