### PR TITLE
Support for NEST N1QL statements

### DIFF
--- a/Src/Couchbase.Linq.Tests/Clauses/NestClauseTests.cs
+++ b/Src/Couchbase.Linq.Tests/Clauses/NestClauseTests.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Metadata;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.Tests.Clauses
+{
+    /// <summary>
+    /// Tests related to the Nest clause
+    /// </summary>
+    [TestFixture]
+    public class NestClauseTests
+    {
+        [Test]
+        public void Nest_IEnumerableEmulation()
+        {
+            var outer = new[]
+            {
+                new Outer {Key = "outer1", Keys = new[] {"inner1", "inner2"}},
+                new Outer {Key = "outer2", Keys = new[] {"inner3", "inner4", "inner6"}},
+                new Outer {Key = "outer3", Keys = new string[] {}},
+                new Outer {Key = "outer4", Keys = null}
+            };
+
+            var inner = new[] { "inner1", "inner2", "inner3", "inner4", "inner5" }
+                .Select(key => new Inner { Key = key })
+                .ToArray();
+
+            var result = outer
+                .Nest(
+                    inner, 
+                    p => p.Keys,
+                    (outerDoc, innerDocs) => new Nested { OuterDoc = outerDoc, InnerDocs = innerDocs.OrderBy(p => p.GetMetadata().Id).ToArray()}
+                )
+                .OrderBy(p => p.OuterDoc.Key)
+                .ToArray();
+
+            Assert.AreEqual(2, result.Length);
+            Assert.AreEqual("outer1", result[0].OuterDoc.Key);
+            Assert.AreEqual(2, result[0].InnerDocs.Length);
+            Assert.AreEqual("inner1", result[0].InnerDocs[0].Key);
+            Assert.AreEqual("inner2", result[0].InnerDocs[1].Key);
+            Assert.AreEqual("outer2", result[1].OuterDoc.Key);
+            Assert.AreEqual(2, result[1].InnerDocs.Length);
+            Assert.AreEqual("inner3", result[1].InnerDocs[0].Key);
+            Assert.AreEqual("inner4", result[1].InnerDocs[1].Key);
+        }
+
+        [Test]
+        public void Nest_IEnumerableAsQueryable()
+        {
+            // This test is important for consumers who may use Nest clauses in their unit testing
+            // If they are using .AsQueryable() to convert a simple list or array to IQueryable
+            // Then we need to ensure that it is properly handled by the EnumerableQuery<T> LINQ implementation
+
+            var outer = new[]
+            {
+                new Outer {Key = "outer1", Keys = new[] {"inner1", "inner2"}},
+                new Outer {Key = "outer2", Keys = new[] {"inner3", "inner4", "inner6"}},
+                new Outer {Key = "outer3", Keys = new string[] {}},
+                new Outer {Key = "outer4", Keys = null}
+            };
+
+            var inner = new[] {"inner1", "inner2", "inner3", "inner4", "inner5"}
+                .Select(key => new Inner {Key = key})
+                .ToArray();
+
+            var result = outer
+                .AsQueryable()
+                .Nest(
+                    inner.AsQueryable(), 
+                    p => p.Keys,
+                    (outerDoc, innerDocs) => new Nested { OuterDoc = outerDoc, InnerDocs = innerDocs.OrderBy(p => p.GetMetadata().Id).ToArray() }
+                )
+                .OrderBy(p => p.OuterDoc.Key)
+                .ToArray();
+
+            Assert.AreEqual(2, result.Length);
+            Assert.AreEqual("outer1", result[0].OuterDoc.Key);
+            Assert.AreEqual(2, result[0].InnerDocs.Length);
+            Assert.AreEqual("inner1", result[0].InnerDocs[0].Key);
+            Assert.AreEqual("inner2", result[0].InnerDocs[1].Key);
+            Assert.AreEqual("outer2", result[1].OuterDoc.Key);
+            Assert.AreEqual(2, result[1].InnerDocs.Length);
+            Assert.AreEqual("inner3", result[1].InnerDocs[0].Key);
+            Assert.AreEqual("inner4", result[1].InnerDocs[1].Key);
+        }
+
+        [Test]
+        public void LeftOuterNest_IEnumerableEmulation()
+        {
+            var outer = new[]
+            {
+                new Outer {Key = "outer1", Keys = new[] {"inner1", "inner2"}},
+                new Outer {Key = "outer2", Keys = new[] {"inner3", "inner4", "inner6"}},
+                new Outer {Key = "outer3", Keys = new string[] {}},
+                new Outer {Key = "outer4", Keys = null}
+            };
+
+            var inner = new[] { "inner1", "inner2", "inner3", "inner4", "inner5" }
+                .Select(key => new Inner { Key = key })
+                .ToArray();
+
+            var result = outer
+                .LeftOuterNest(
+                    inner,
+                    p => p.Keys,
+                    (outerDoc, innerDocs) => new Nested { OuterDoc = outerDoc, InnerDocs = innerDocs != null ? innerDocs.OrderBy(p => p.GetMetadata().Id).ToArray() : null }
+                )
+                .OrderBy(p => p.OuterDoc.Key)
+                .ToArray();
+
+            Assert.AreEqual(4, result.Length);
+            Assert.AreEqual("outer1", result[0].OuterDoc.Key);
+            Assert.AreEqual(2, result[0].InnerDocs.Length);
+            Assert.AreEqual("inner1", result[0].InnerDocs[0].Key);
+            Assert.AreEqual("inner2", result[0].InnerDocs[1].Key);
+            Assert.AreEqual("outer2", result[1].OuterDoc.Key);
+            Assert.AreEqual(2, result[1].InnerDocs.Length);
+            Assert.AreEqual("inner3", result[1].InnerDocs[0].Key);
+            Assert.AreEqual("inner4", result[1].InnerDocs[1].Key);
+            Assert.AreEqual("outer3", result[2].OuterDoc.Key);
+            Assert.AreEqual(0, result[2].InnerDocs.Length);
+            Assert.AreEqual("outer4", result[3].OuterDoc.Key);
+            Assert.IsNull(result[3].InnerDocs);
+        }
+
+        [Test]
+        public void LeftOuterNest_IEnumerableAsQueryable()
+        {
+            // This test is important for consumers who may use Nest clauses in their unit testing
+            // If they are using .AsQueryable() to convert a simple list or array to IQueryable
+            // Then we need to ensure that it is properly handled by the EnumerableQuery<T> LINQ implementation
+
+            var outer = new[]
+            {
+                new Outer {Key = "outer1", Keys = new[] {"inner1", "inner2"}},
+                new Outer {Key = "outer2", Keys = new[] {"inner3", "inner4", "inner6"}},
+                new Outer {Key = "outer3", Keys = new string[] {}},
+                new Outer {Key = "outer4", Keys = null}
+            };
+
+            var inner = new[] { "inner1", "inner2", "inner3", "inner4", "inner5" }
+                .Select(key => new Inner { Key = key })
+                .ToArray();
+
+            var result = outer
+                .AsQueryable()
+                .LeftOuterNest(
+                    inner.AsQueryable(),
+                    p => p.Keys,
+                    (outerDoc, innerDocs) => new Nested { OuterDoc = outerDoc, InnerDocs = innerDocs != null ? innerDocs.OrderBy(p => p.GetMetadata().Id).ToArray() : null }
+                )
+                .OrderBy(p => p.OuterDoc.Key)
+                .ToArray();
+
+            Assert.AreEqual(4, result.Length);
+            Assert.AreEqual("outer1", result[0].OuterDoc.Key);
+            Assert.AreEqual(2, result[0].InnerDocs.Length);
+            Assert.AreEqual("inner1", result[0].InnerDocs[0].Key);
+            Assert.AreEqual("inner2", result[0].InnerDocs[1].Key);
+            Assert.AreEqual("outer2", result[1].OuterDoc.Key);
+            Assert.AreEqual(2, result[1].InnerDocs.Length);
+            Assert.AreEqual("inner3", result[1].InnerDocs[0].Key);
+            Assert.AreEqual("inner4", result[1].InnerDocs[1].Key);
+            Assert.AreEqual("outer3", result[2].OuterDoc.Key);
+            Assert.AreEqual(0, result[2].InnerDocs.Length);
+            Assert.AreEqual("outer4", result[3].OuterDoc.Key);
+            Assert.IsNull(result[3].InnerDocs);
+        }
+
+        #region Helper Classes
+
+        private class Outer
+        {
+            public string Key { get; set; }
+            public string[] Keys { get; set; }
+        }
+
+        private class Inner : IDocumentMetadataProvider
+        {
+            public string Key { get; set; }
+
+            public DocumentMetadata GetMetadata()
+            {
+                return new DocumentMetadata() {Id = Key};
+            }
+        }
+
+        private class Nested
+        {
+            public Outer OuterDoc { get; set; }
+            public Inner[] InnerDocs { get; set; }
+        }
+
+        #endregion
+
+    }
+}

--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -84,6 +84,7 @@
   <ItemGroup>
     <Compile Include="BeerSampleTests.cs" />
     <Compile Include="BucketExtensionTests.cs" />
+    <Compile Include="Clauses\NestClauseTests.cs" />
     <Compile Include="Documents\Airline.cs" />
     <Compile Include="Documents\BeerFiltered.cs" />
     <Compile Include="Documents\Beer.cs" />

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/JoinTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/JoinTests.cs
@@ -29,7 +29,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             const string expected = "SELECT beer.name as Name, beer.abv as Abv, brewery.name as BreweryName " +
                 "FROM default as beer "+
                 "INNER JOIN default as brewery " +
-                "ON KEYS beer.`brewery_id`";
+                "ON KEYS beer.brewery_id";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -52,7 +52,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             const string expected = "SELECT beer.name as Name, beer.abv as Abv, brewery.name as BreweryName " +
                 "FROM default as beer " +
                 "INNER JOIN default as brewery " +
-                "ON KEYS beer.`brewery_id` " +
+                "ON KEYS beer.brewery_id " +
                 "WHERE (brewery.geo.lon > -80) " + 
                 "ORDER BY beer.name ASC";
 
@@ -75,7 +75,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             const string expected = "SELECT p.name as Name, p.abv as Abv, brewery.name as BreweryName " +
                 "FROM default as p " +
                 "INNER JOIN default as brewery " +
-                "ON KEYS p.`brewery_id` " + 
+                "ON KEYS p.brewery_id " + 
                 "WHERE (p.type = 'beer') AND (brewery.type = 'brewery')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
@@ -98,7 +98,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             const string expected = "SELECT beer.name as Name, beer.abv as Abv, brewery.name as BreweryName " +
                 "FROM default as beer " +
                 "LEFT JOIN default as brewery " +
-                "ON KEYS beer.`brewery_id`";
+                "ON KEYS beer.brewery_id";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -122,7 +122,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             const string expected = "SELECT beer.name as Name, beer.abv as Abv, brewery.name as BreweryName " +
                 "FROM default as beer " +
                 "LEFT JOIN default as brewery " +
-                "ON KEYS beer.`brewery_id` " +
+                "ON KEYS beer.brewery_id " +
                 "WHERE (beer.abv > 4) " +
                 "ORDER BY brewery.name ASC, beer.name ASC";
 
@@ -146,7 +146,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             const string expected = "SELECT p.name as Name, p.abv as Abv, brewery.name as BreweryName " +
                 "FROM default as p " +
                 "LEFT JOIN default as brewery " +
-                "ON KEYS p.`brewery_id` " +
+                "ON KEYS p.brewery_id " +
                 "WHERE (p.type = 'beer') AND (brewery.type = 'brewery')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);

--- a/Src/Couchbase.Linq/Clauses/NestClause.cs
+++ b/Src/Couchbase.Linq/Clauses/NestClause.cs
@@ -3,25 +3,42 @@ using System.Linq.Expressions;
 using Couchbase.Linq.QueryGeneration;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
-using Remotion.Linq.Clauses.ExpressionTreeVisitors;
 
 namespace Couchbase.Linq.Clauses
 {
-    public class WhereMissingClause : IBodyClause
+    public class NestClause : IBodyClause, IQuerySource
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="WhereMissingClause" /> class.
+        ///     Initializes a new instance of the <see cref="NestClause" /> class.
         /// </summary>
-        /// <param name="predicate">The predicate used to filter data items.</param>
-        public WhereMissingClause(Expression predicate)
+        /// <param name="itemName">Name of the item returned by the nest clause</param>
+        /// <param name="itemType">Type of the item returned by the nest clause</param>
+        /// <param name="inner">The inner sequence being nested</param>
+        /// <param name="keySelector">Expression used to get the keys from each item in the outer sequence</param>
+        public NestClause(string itemName, Type itemType, Expression inner, Expression keySelector, bool isLeftOuterNest)
         {
-            Predicate = predicate;
+            ItemName = itemName;
+            ItemType = itemType;
+            InnerSequence = inner;
+            KeySelector = keySelector;
+            IsLeftOuterNest = isLeftOuterNest;
         }
 
+        public string ItemName { get; set; }
+
+        public Type ItemType { get; set; }
+
         /// <summary>
-        ///     Gets the predicate, the expression representing the where condition by which the data items are filtered
+        ///     Gets the inner sequence being nested
         /// </summary>
-        public Expression Predicate { get; set; }
+        public Expression InnerSequence { get; set; }
+
+        /// <summary>
+        ///     Gets the expression used to get the keys from each item in the outer sequence
+        /// </summary>
+        public Expression KeySelector { get; set; }
+
+        public bool IsLeftOuterNest { get; set; }
 
         /// <summary>
         ///     Accepts the specified visitor
@@ -35,7 +52,7 @@ namespace Couchbase.Linq.Clauses
         public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
         {
             var visotorx = visitor as IN1QlQueryModelVisitor;
-            if (visotorx != null) visotorx.VisitWhereMissingClause(this, queryModel, index);
+            if (visotorx != null) visotorx.VisitNestClause(this, queryModel, index);
         }
 
         /// <summary>
@@ -48,7 +65,8 @@ namespace Couchbase.Linq.Clauses
         /// </param>
         public void TransformExpressions(Func<Expression, Expression> transformation)
         {
-            Predicate = transformation(Predicate);
+            InnerSequence = transformation(InnerSequence);
+            KeySelector = transformation(KeySelector);
         }
 
         IBodyClause IBodyClause.Clone(CloneContext cloneContext)
@@ -61,15 +79,20 @@ namespace Couchbase.Linq.Clauses
         /// </summary>
         /// <param name="cloneContext">The clones of all query source clauses are registered with this <see cref="CloneContext" />.</param>
         /// <returns></returns>
-        public virtual WhereMissingClause Clone(CloneContext cloneContext)
+        public virtual NestClause Clone(CloneContext cloneContext)
         {
-            var clone = new WhereMissingClause(Predicate);
+            var clone = new NestClause(ItemName, ItemType, InnerSequence, KeySelector, IsLeftOuterNest);
             return clone;
         }
 
         public override string ToString()
         {
-            return "WHERE MISSING " + FormattingExpressionTreeVisitor.Format(Predicate);
+            return String.Format("{0} {1} {2} in {3} on keys {4}",
+                IsLeftOuterNest ? "left outer nest" : "nest",
+                ItemType.Name,
+                ItemName,
+                InnerSequence,
+                KeySelector);
         }
     }
 }

--- a/Src/Couchbase.Linq/Clauses/NestExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/NestExpressionNode.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    public class NestExpressionNode : MethodCallExpressionNodeBase, IQuerySourceExpressionNode
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+        {
+            GetSupportedMethod(() => QueryExtensions.Nest<object, object, object>(null, null, o => null, (o, p) => null)),
+            GetSupportedMethod(() => QueryExtensions.LeftOuterNest<object, object, object>(null, null, o => null, (o, p) => null))
+        };
+
+        private readonly ResolvedExpressionCache<Expression> _cachedKeySelector;
+        private readonly ResolvedExpressionCache<Expression> _cachedResultSelector;
+
+        public NestExpressionNode(MethodCallExpressionParseInfo parseInfo,
+            Expression innerSequence,
+            LambdaExpression keySelector,
+            LambdaExpression resultSelector)
+            : base(parseInfo)
+        {
+            if (innerSequence == null)
+            {
+                throw new ArgumentNullException("innerSequence");
+            }
+
+            if (keySelector == null)
+            {
+                throw new ArgumentNullException("keySelector");
+            }
+            if (keySelector.Parameters.Count != 1)
+            {
+                throw new ArgumentException("Key selector must have exactly one parameter.", "keySelector");
+            }
+
+            if (resultSelector == null)
+            {
+                throw new ArgumentNullException("resultSelector");
+            }
+            if (resultSelector.Parameters.Count != 2)
+            {
+                throw new ArgumentException("Result selector must have exactly two parameters.", "resultSelector");
+            }
+
+            InnerSequence = innerSequence;
+            KeySelector = keySelector;
+            ResultSelector = resultSelector;
+            IsLeftOuterNest = parseInfo.ParsedExpression.Method.Name == "LeftOuterNest";
+
+            _cachedKeySelector = new ResolvedExpressionCache<Expression>(this);
+            _cachedResultSelector = new ResolvedExpressionCache<Expression>(this);
+        }
+
+        public Expression InnerSequence { get; private set; }
+        public LambdaExpression KeySelector { get; private set; }
+        public LambdaExpression ResultSelector { get; private set; }
+        public bool IsLeftOuterNest { get; private set; }
+
+        public Expression GetResolvedKeySelector(ClauseGenerationContext clauseGenerationContext)
+        {
+            return
+                _cachedKeySelector.GetOrCreate(
+                    r => r.GetResolvedExpression(KeySelector.Body, KeySelector.Parameters[0], clauseGenerationContext));
+        }
+
+        public Expression GetResolvedResultSelector(ClauseGenerationContext clauseGenerationContext)
+        {
+            return
+                _cachedResultSelector.GetOrCreate(
+                    r => r.GetResolvedExpression(
+                        QuerySourceExpressionNodeUtility.ReplaceParameterWithReference(
+                            this,
+                            ResultSelector.Parameters[1],
+                            ResultSelector.Body,
+                            clauseGenerationContext),
+                        ResultSelector.Parameters[0],
+                        clauseGenerationContext));
+        }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override QueryModel ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            var nestClause = new NestClause(
+                ResultSelector.Parameters[1].Name, 
+                ResultSelector.Parameters[1].Type, 
+                InnerSequence, 
+                GetResolvedKeySelector(clauseGenerationContext),
+                IsLeftOuterNest);
+
+            clauseGenerationContext.AddContextInfo(this, nestClause);
+            queryModel.BodyClauses.Add(nestClause);
+
+            var selectClause = queryModel.SelectClause;
+            selectClause.Selector = GetResolvedResultSelector(clauseGenerationContext);
+
+            return queryModel;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -62,6 +62,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\EnumerableExtensions.cs" />
+    <Compile Include="QueryGeneration\IN1QlQueryModelVisitor.cs" />
+    <Compile Include="Clauses\NestClause.cs" />
+    <Compile Include="Clauses\NestExpressionNode.cs" />
     <Compile Include="Filters\AttributeEntityFilterSetGenerator.cs" />
     <Compile Include="Filters\EntityFilterAttribute.cs" />
     <Compile Include="Filters\EntityFilterManager.cs" />
@@ -98,6 +102,7 @@
     <Compile Include="QueryGeneration\DefaultMethodCallTranslatorProvider.cs" />
     <Compile Include="QueryGeneration\N1QLExpressionTreeVisitor.cs" />
     <Compile Include="QueryGeneration\N1QLFromQueryPart.cs" />
+    <Compile Include="QueryGeneration\N1QLLetQueryPart.cs" />
     <Compile Include="QueryGeneration\N1QLQueryModelVisitor.cs" />
     <Compile Include="QueryGeneration\N1QLQueryType.cs" />
     <Compile Include="QueryGeneration\NamedParameter.cs" />

--- a/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.Metadata;
+
+namespace Couchbase.Linq.Extensions
+{
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        ///     Emulates Nest for N1QL against an IEnumerable
+        /// </summary>
+        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
+        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
+        /// <typeparam name="TResult">Type of the result sequence</typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner">Sequence to be nested</param>
+        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
+        /// <param name="resultSelector">Expression that returns the result</param>
+        /// <returns></returns>
+        public static IEnumerable<TResult> Nest<TOuter, TInner, TResult>(
+            this IEnumerable<TOuter> outer, IEnumerable<TInner> inner,
+            Func<TOuter, IEnumerable<string>> keySelector,
+            Func<TOuter, IEnumerable<TInner>, TResult> resultSelector) where TInner : IDocumentMetadataProvider
+        {
+            return outer.Nest(inner, keySelector, resultSelector, true);
+        }
+
+        /// <summary>
+        ///     Emulates LeftNest for N1QL against an IEnumerable
+        /// </summary>
+        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
+        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
+        /// <typeparam name="TResult">Type of the result sequence</typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner">Sequence to be nested</param>
+        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
+        /// <param name="resultSelector">Expression that returns the result</param>
+        /// <returns></returns>
+        public static IEnumerable<TResult> LeftOuterNest<TOuter, TInner, TResult>(
+            this IEnumerable<TOuter> outer, IEnumerable<TInner> inner,
+            Func<TOuter, IEnumerable<string>> keySelector,
+            Func<TOuter, IEnumerable<TInner>, TResult> resultSelector) where TInner : IDocumentMetadataProvider
+        {
+            return outer.Nest(inner, keySelector, resultSelector, false);
+        }
+
+        /// <summary>
+        ///     Emulates Nest for N1QL against an IEnumerable
+        /// </summary>
+        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
+        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
+        /// <typeparam name="TResult">Type of the result sequence</typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner">Sequence to be nested</param>
+        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
+        /// <param name="resultSelector">Expression that returns the result</param>
+        /// <param name="innerNest">Excludes results where no matches are found in the inner sequence</param>
+        /// <returns></returns>
+        private static IEnumerable<TResult> Nest<TOuter, TInner, TResult>(
+            this IEnumerable<TOuter> outer, IEnumerable<TInner> inner,
+            Func<TOuter, IEnumerable<string>> keySelector,
+            Func<TOuter, IEnumerable<TInner>, TResult> resultSelector,
+            bool innerNest) where TInner : IDocumentMetadataProvider
+        {
+            if (inner == null)
+            {
+                throw new ArgumentNullException("inner");
+            }
+            if (outer == null)
+            {
+                throw new ArgumentNullException("outer");
+            }
+            if (keySelector == null)
+            {
+                throw new ArgumentNullException("keySelector");
+            }
+            if (resultSelector == null)
+            {
+                throw new ArgumentNullException("resultSelector");
+            }
+
+            // Create a dictionary on the inner sequence, based on document key
+            // This ensures that the inner sequence is only enumerated once
+            // And that lookups are fast
+            var innerDictionary = inner.ToDictionary(p => N1Ql.Key(p));
+
+            return outer
+                .Select(outerDocument =>
+                {
+                    var keys = keySelector.Invoke(outerDocument);
+
+                    List<TInner> innerDocuments = null;
+                    if (keys != null)
+                    {
+                        innerDocuments = keys.Select(key =>
+                        {
+                            TInner innerDocument;
+                            if (!innerDictionary.TryGetValue(key, out innerDocument))
+                            {
+                                innerDocument = default(TInner); // return null when not found
+                            }
+
+                            return innerDocument;
+                        })
+                            .Where(p => p != null) // skip any documents that weren't found in the dictionary
+                            .ToList();
+                    }
+
+                    if (innerNest && (innerDocuments == null || innerDocuments.Count == 0))
+                    {
+                        // For inner nest, return null if there are no inner documents
+                        return default(TResult);
+                    }
+
+                    return resultSelector.Invoke(outerDocument, innerDocuments);
+                })
+                .Where(p => p != null); // Filter out any null results returned due to inner nest or a null from the resultSelector
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.Clauses;
+using Remotion.Linq;
+
+namespace Couchbase.Linq.QueryGeneration
+{
+    public interface IN1QlQueryModelVisitor : IQueryModelVisitor
+    {
+        void VisitNestClause(NestClause clause, QueryModel queryModel, int index);
+        void VisitWhereMissingClause(WhereMissingClause clause, QueryModel queryModel, int index);
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLLetQueryPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLLetQueryPart.cs
@@ -1,0 +1,18 @@
+﻿namespace Couchbase.Linq.QueryGeneration
+{
+    /// <summary>
+    /// Represents an item in the LET part of a N1QL query
+    /// </summary>
+    public class N1QlLetQueryPart
+    {
+        /// <summary>
+        /// Name of the value being assigned
+        /// </summary>
+        public string ItemName { get; set; }
+
+        /// <summary>
+        /// Expression assigned to the item name
+        /// </summary>
+        public string Value { get; set; }
+    }
+}

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -18,6 +18,10 @@ namespace Couchbase.Linq
             customNodeTypeRegistry.Register(WhereMissingExpressionNode.SupportedMethods,
                 typeof (WhereMissingExpressionNode));
 
+            //register the "Nest" clause type
+            customNodeTypeRegistry.Register(NestExpressionNode.SupportedMethods,
+                typeof(NestExpressionNode));
+
             //register the "Explain" expression node parser
             customNodeTypeRegistry.Register(ExplainExpressionNode.SupportedMethods,
                 typeof(ExplainExpressionNode));


### PR DESCRIPTION
Modifications
-------------
Added IN1QlQueryModelVisitor interface to N1QlQueryModelVisitor to publish
methods used by custom clauses.  Implemented new NestClause and
NestExpressionNode classes to represent both INNER NEST and LEFT OUTER
NEST statements.  Implemented VisitNestClause in N1QlQueryModelVisitor to
handle the new clause.  Added LetParts to QueryPartsAggregator to handle
LET statements, which are used if the inner sequence of the Nest is
prefiltered.  Added Nest and LeftOuterNest static methods as an IQueryable
extension, as well as an IEnumerable extension for consistency.

Results
-------
Both INNER NEST and LEFT OUTER NEST are now fully supported via IQueryable
extension methods.  This includes support for prefiltering the inner
sequence being nested.

Note
----
Manipulating the list of keys is not yet supported.  This should tie in
with later work on subqueries, which should allow
N1QlExpressionTreeVisitor to handle filters and manipulations using the
ARRAY statement.