### PR TITLE
Support for [] array index accessors in expressions

### DIFF
--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="N1QLTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueryClientExtensionTests.cs" />
+    <Compile Include="QueryGeneration\ArrayIndexTests.cs" />
     <Compile Include="QueryGeneration\NestTests.cs" />
     <Compile Include="QueryGeneration\ConditionalExpressionTests.cs" />
     <Compile Include="QueryGeneration\ConstantExpressionTests.cs" />

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/ArrayIndexTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/ArrayIndexTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Couchbase.Core;
+using Couchbase.Linq.Tests.Documents;
+using Moq;
+using Newtonsoft.Json.Serialization;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.Tests.QueryGeneration
+{
+    [TestFixture]
+    public class ArrayIndexTests : N1QLTestBase
+    {
+
+        [Test]
+        public void Test_ArrayIndexAccessor()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<DocumentWithArray>(mockBucket.Object)
+                    .Select(e => new { address = e.Array[0] });
+
+            const string expected = "SELECT e.Array[0] as address FROM default as e";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_ListIndexAccessor()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                    .Select(e => new { address = e.Address[0] });
+
+            const string expected = "SELECT e.address[0] as address FROM default as e";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_IListIndexAccessor()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<DocumentWithIList>(mockBucket.Object)
+                    .Select(e => new { address = e.List[0] });
+
+            const string expected = "SELECT e.List[0] as address FROM default as e";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #region Helper Classes
+        
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class DocumentWithArray
+        {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public string[] Array { get; set; }
+        }
+
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class DocumentWithIList
+        {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public IList<string> List { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -94,6 +94,7 @@
     <Compile Include="QueryGeneration\IMethodCallTranslatorProvider.cs" />
     <Compile Include="QueryGeneration\JsonNetMemberNameResolver.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\ConcatMethodCallTranslator.cs" />
+    <Compile Include="QueryGeneration\MethodCallTranslators\ListIndexMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\ContainsMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\IsValuedMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\IsMissingMethodCallTranslator.cs" />

--- a/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
@@ -67,7 +67,139 @@ namespace Couchbase.Linq.QueryGeneration
                 }
             }
 
+            // Check if the generic form of the declaring type matches
+            translator = GetItemFromGenericType(key);
+            if (translator != null)
+            {
+                return translator;
+            }
+            
+            // Finally, check any interfaces that may have a matching 
+            return GetItemFromInterfaces(key);            
+        }
+
+        /// <summary>
+        /// Checks the generic version of the type that implements the key method to see if it has an IMethodCallTranslator defined
+        /// </summary>
+        /// <param name="key">MethodInfo to test</param>
+        /// <returns>Null if no IMethodCallTranslator is found</returns>
+        protected virtual IMethodCallTranslator GetItemFromGenericType(MethodInfo key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            if ((key.DeclaringType == null) ||
+                (!key.DeclaringType.IsGenericType || key.DeclaringType.IsGenericTypeDefinition))
+            {
+                return null;
+            }
+
+            var genericType = key.DeclaringType.GetGenericTypeDefinition();
+
+            var typeArgs = key.IsGenericMethod && !key.IsGenericMethodDefinition
+                ? key.GetGenericArguments()
+                : null;
+
+            var bindingFlags = (key.IsStatic ? BindingFlags.Static : BindingFlags.Instance) |
+                               (key.IsPublic ? BindingFlags.Public : BindingFlags.NonPublic);
+
+            var genericTypeKey = genericType.GetMethods(bindingFlags)
+                .FirstOrDefault(method => method.Name == key.Name && ArgsMatch(key.GetParameters(), method, typeArgs));
+
+            if (genericTypeKey != null)
+            {
+                IMethodCallTranslator translator;
+
+                if (Registry.TryGetValue(genericTypeKey, out translator))
+                {
+                    return translator;
+                }
+
+                if (genericTypeKey.IsGenericMethod && !genericTypeKey.IsGenericMethodDefinition)
+                {
+                    if (Registry.TryGetValue(genericTypeKey.GetGenericMethodDefinition(), out translator))
+                    {
+                        return translator;
+                    }
+                }
+            }
+
             return null;
+        }
+
+        /// <summary>
+        /// Checks all interfaces that implement the key method to see if one of them has an IMethodCallTranslator defined
+        /// </summary>
+        /// <param name="key">MethodInfo to test.  Must be an instance method on a class.</param>
+        /// <returns>Null if no IMethodCallTranslator is found</returns>
+        protected virtual IMethodCallTranslator GetItemFromInterfaces(MethodInfo key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+            
+            if (key.IsStatic || (key.DeclaringType == null) || (!key.DeclaringType.IsClass))
+            {
+                return null;
+            }
+
+            foreach (var interfaceType in key.DeclaringType.GetInterfaces())
+            {
+                var interfaceMap = key.DeclaringType.GetInterfaceMap(interfaceType);
+
+                var interfaceMethod = interfaceMap.TargetMethods
+                    .Where(p => p == key)
+                    .Select((p, i) => interfaceMap.InterfaceMethods[i])
+                    .FirstOrDefault();
+
+                if (interfaceMethod != null)
+                {
+                    var translator = GetItem(interfaceMethod);
+                    if (translator != null)
+                    {
+                        return translator;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private bool ArgsMatch(ParameterInfo[] args, MethodInfo method, Type[] typeArgs)
+        {
+            if (!method.IsGenericMethodDefinition && (typeArgs != null))
+            {
+                return false;
+            }
+
+            if (method.IsGenericMethodDefinition)
+            {
+                if ((typeArgs == null) || (typeArgs.Length != method.GetGenericArguments().Length))
+                {
+                    return false;
+                }
+
+                method = method.MakeGenericMethod(typeArgs);
+            }
+
+            var methodArgs = method.GetParameters();
+            if (methodArgs.Length != args.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                if (!methodArgs[i].ParameterType.IsAssignableFrom(args[i].ParameterType))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
     }

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ListIndexMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ListIndexMethodCallTranslator.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
+{
+    class ListIndexMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (IList).GetMethod("get_Item"),
+            typeof (IList<>).GetMethod("get_Item")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+            expression.Append('[');
+            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[0]);
+            expression.Append(']');
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -68,6 +68,9 @@ namespace Couchbase.Linq.QueryGeneration
             {
                 case ExpressionType.Coalesce:
                     return VisitCoalesceExpression((BinaryExpression) expression);
+
+                case ExpressionType.ArrayIndex:
+                    return VisitArrayIndexExpression((BinaryExpression) expression);
                     
                 default:
                     return base.VisitExpression(expression);
@@ -299,6 +302,19 @@ namespace Couchbase.Linq.QueryGeneration
             }
 
             _expression.Append(')');
+
+            return expression;
+        }
+
+        /// <summary>
+        ///     Special handling for ArrayIndex binary expressions
+        /// </summary>
+        protected virtual Expression VisitArrayIndexExpression(BinaryExpression expression)
+        {
+            VisitExpression(expression.Left);
+            _expression.Append('[');
+            VisitExpression(expression.Right);
+            _expression.Append(']');
 
             return expression;
         }


### PR DESCRIPTION
Modifications
-------------
Implemented handling for ExpressionType.ArrayIndex.  Added
ListIndexMethodCallTranslator to handle IList based collections.

Modified DefaultMethodCallTranslatorProvider to check for method call
translators on the generic type as well as on any interfaces.  This allows
ListIndexMethodCallTranslator to simply register against IList<>.get_Item
instead of every possible class which might implement IList<>.