### PR TITLE
Support for USE KEYS statement

### DIFF
--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -178,6 +178,24 @@ namespace Couchbase.Linq.Tests
         }
 
         [Test]
+        public void UseKeys_SelectDocuments()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var query = from brewery in bucket.Queryable<Brewery>().UseKeys(new[] { "21st_amendment_brewery_cafe", "357" })
+                                select new { name = brewery.Name };
+
+                    foreach (var brewery in query)
+                    {
+                        Console.WriteLine("Brewery {0}", brewery.name);
+                    }
+                }
+            }
+        }
+
+        [Test]
         public void AnyAllTests_AnyNestedArrayWithFilter()
         {
             using (var cluster = new Cluster())

--- a/Src/Couchbase.Linq.Tests/Clauses/UseKeysClauseTests.cs
+++ b/Src/Couchbase.Linq.Tests/Clauses/UseKeysClauseTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Metadata;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.Tests.Clauses
+{
+    /// <summary>
+    /// Tests related to the UseKeys clause
+    /// </summary>
+    [TestFixture]
+    public class UseKeysClauseTests
+    {
+        [Test]
+        public void UseKeys_IEnumerableEmulation()
+        {
+            var items = new[]
+            {
+                new Item {Key = "item1"},
+                new Item {Key = "item2"},
+                new Item {Key = "item3"},
+                new Item {Key = "item4"}
+            };
+
+            var result = items
+                .UseKeys(new[] { "item1", "item3"})
+                .OrderBy(p => p.Key)
+                .ToArray();
+
+            Assert.AreEqual(2, result.Length);
+            Assert.AreEqual("item1", result[0].Key);
+            Assert.AreEqual("item3", result[1].Key);
+        }
+
+        [Test]
+        public void UseKeys_IEnumerableAsQueryable()
+        {
+            // This test is important for consumers who may use UseKeys clauses in their unit testing
+            // If they are using .AsQueryable() to convert a simple list or array to IQueryable
+            // Then we need to ensure that it is properly handled by the EnumerableQuery<T> LINQ implementation
+
+            var items = new[]
+            {
+                new Item {Key = "item1"},
+                new Item {Key = "item2"},
+                new Item {Key = "item3"},
+                new Item {Key = "item4"}
+            };
+
+            var result = items
+                .AsQueryable()
+                .UseKeys(new[] { "item1", "item3" })
+                .OrderBy(p => p.Key)
+                .ToArray();
+
+            Assert.AreEqual(2, result.Length);
+            Assert.AreEqual("item1", result[0].Key);
+            Assert.AreEqual("item3", result[1].Key);
+        }
+
+        #region Helper Classes
+
+        private class Item : IDocumentMetadataProvider
+        {
+            public string Key { get; set; }
+
+            public DocumentMetadata GetMetadata()
+            {
+                return new DocumentMetadata() { Id = Key };
+            }
+        }
+
+        #endregion
+
+    }
+}

--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="BeerSampleTests.cs" />
     <Compile Include="BucketExtensionTests.cs" />
     <Compile Include="Clauses\NestClauseTests.cs" />
+    <Compile Include="Clauses\UseKeysClauseTests.cs" />
     <Compile Include="Documents\Airline.cs" />
     <Compile Include="Documents\BeerFiltered.cs" />
     <Compile Include="Documents\Beer.cs" />

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/SelectTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/SelectTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Couchbase.Core;
+using Couchbase.Linq.Extensions;
 using Couchbase.Linq.Tests.Documents;
 using Moq;
 using NUnit.Framework;
@@ -37,6 +38,24 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => e);
 
             const string expected = "SELECT e.* FROM default as e";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Select_UseKeys()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                    .UseKeys(new[] { "abc", "def" })
+                    .Select(e => e);
+
+            const string expected = "SELECT `<generated>_1`.* FROM default as `<generated>_1` USE KEYS ['abc', 'def']";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq/Clauses/UseKeysClause.cs
+++ b/Src/Couchbase.Linq/Clauses/UseKeysClause.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Linq.Expressions;
+using Couchbase.Linq.QueryGeneration;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.Linq.Clauses
+{
+    public class UseKeysClause : IBodyClause
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="UseKeysClause" /> class.
+        /// </summary>
+        /// <param name="keys">Expression used to get the keys from each item in the outer sequence</param>
+        public UseKeysClause(Expression keys)
+        {
+            Keys = keys;
+        }
+
+        /// <summary>
+        ///     Gets the expression used to get the keys being selected
+        /// </summary>
+        public Expression Keys { get; set; }
+
+        /// <summary>
+        ///     Accepts the specified visitor
+        /// </summary>
+        /// <param name="visitor">The visitor to accept.</param>
+        /// <param name="queryModel">The query model in whose context this clause is visited.</param>
+        /// <param name="index">
+        ///     The index of this clause in the <paramref name="queryModel" />'s
+        ///     <see cref="QueryModel.BodyClauses" /> collection.
+        /// </param>
+        public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
+        {
+            var visotorx = visitor as IN1QlQueryModelVisitor;
+            if (visotorx != null) visotorx.VisitUseKeysClause(this, queryModel, index);
+        }
+
+        /// <summary>
+        ///     Transforms all the expressions in this clause and its child objects via the given
+        ///     <paramref name="transformation" /> delegate.
+        /// </summary>
+        /// <param name="transformation">
+        ///     The transformation object. This delegate is called for each <see cref="Expression" /> within this
+        ///     clause, and those expressions will be replaced with what the delegate returns.
+        /// </param>
+        public void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+            Keys = transformation(Keys);
+        }
+
+        IBodyClause IBodyClause.Clone(CloneContext cloneContext)
+        {
+            return Clone(cloneContext);
+        }
+
+        /// <summary>
+        ///     Clones this clause.
+        /// </summary>
+        /// <param name="cloneContext">The clones of all query source clauses are registered with this <see cref="CloneContext" />.</param>
+        /// <returns></returns>
+        public virtual UseKeysClause Clone(CloneContext cloneContext)
+        {
+            var clone = new UseKeysClause(Keys);
+            return clone;
+        }
+
+        public override string ToString()
+        {
+            return String.Format("use keys {0}", Keys);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/UseKeysExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/UseKeysExpressionNode.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    public class UseKeysExpressionNode : MethodCallExpressionNodeBase
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+        {
+            GetSupportedMethod(() => QueryExtensions.UseKeys<object>(null, null))
+        };
+
+        public UseKeysExpressionNode(MethodCallExpressionParseInfo parseInfo, Expression keys)
+            : base(parseInfo)
+        {
+            if (keys == null)
+            {
+                throw new ArgumentNullException("keys");
+            }
+
+            Keys = keys;
+        }
+
+        public Expression Keys { get; private set; }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override QueryModel ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            queryModel.BodyClauses.Add(new UseKeysClause(Keys));
+
+            return queryModel;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -62,6 +62,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Clauses\UseKeysExpressionNode.cs" />
+    <Compile Include="Clauses\UseKeysClause.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="QueryGeneration\Expressions\StringComparisonExpression.cs" />
     <Compile Include="QueryGeneration\IN1QlQueryModelVisitor.cs" />

--- a/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
@@ -11,6 +11,9 @@ namespace Couchbase.Linq.Extensions
 {
     public static class EnumerableExtensions
     {
+
+        #region Nest
+
         /// <summary>
         ///     Emulates Nest for N1QL against an IEnumerable
         /// </summary>
@@ -121,5 +124,34 @@ namespace Couchbase.Linq.Extensions
                 })
                 .Where(p => p != null); // Filter out any null results returned due to inner nest or a null from the resultSelector
         }
+
+        #endregion
+
+        #region UseKeys
+
+        /// <summary>
+        ///     Emulates UseKeys for N1QL against an IEnumerable
+        /// </summary>
+        /// <typeparam name="T">Type of the source sequence</typeparam>
+        /// <param name="items">Items being filtered</param>
+        /// <param name="keys">Keys to be selected</param>
+        /// <returns></returns>
+        public static IEnumerable<T> UseKeys<T>(
+            this IEnumerable<T> items, IEnumerable<string> keys) where T : IDocumentMetadataProvider
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException("items");
+            }
+            if (keys == null)
+            {
+                throw new ArgumentNullException("keys");
+            }
+
+            return items.Where(p => keys.Contains(N1Ql.Key(p)));
+        }
+
+        #endregion
+
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
@@ -12,6 +12,9 @@ namespace Couchbase.Linq.QueryGeneration
     public interface IN1QlQueryModelVisitor : IQueryModelVisitor
     {
         void VisitNestClause(NestClause clause, QueryModel queryModel, int index);
+
+        void VisitUseKeysClause(UseKeysClause clause, QueryModel queryModel, int index);
+
         void VisitWhereMissingClause(WhereMissingClause clause, QueryModel queryModel, int index);
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -88,6 +88,11 @@ namespace Couchbase.Linq.QueryGeneration
             base.VisitMainFromClause(fromClause, queryModel);
         }
 
+        public virtual void VisitUseKeysClause(UseKeysClause clause, QueryModel queryModel, int index)
+        {
+            _queryPartsAggregator.AddUseKeysPart(GetN1QlExpression(clause.Keys));
+        }
+
         public override void VisitSelectClause(SelectClause selectClause, QueryModel queryModel)
         {
             _queryPartsAggregator.SelectPart = GetSelectParameters(selectClause, queryModel);

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -21,6 +21,7 @@ namespace Couchbase.Linq.QueryGeneration
 
         public string SelectPart { get; set; }
         public List<N1QlFromQueryPart> FromParts { get; set; }
+        public string UseKeysPart { get; set; }
         public List<N1QlLetQueryPart> LetParts { get; set; } 
         public List<string> WhereParts { get; set; }
         public List<string> OrderByParts { get; set; }
@@ -52,6 +53,16 @@ namespace Couchbase.Linq.QueryGeneration
         public void AddFromPart(N1QlFromQueryPart fromPart)
         {
             FromParts.Add(fromPart);
+        }
+
+        public void AddUseKeysPart(string useKeysPart)
+        {
+            if (!string.IsNullOrEmpty(UseKeysPart))
+            {
+                throw new InvalidOperationException("AddUseKeysPart May Only Be Called Once");
+            }
+
+            UseKeysPart = useKeysPart;
         }
 
         public void AddLetPart(N1QlLetQueryPart letPart)
@@ -102,6 +113,11 @@ namespace Couchbase.Linq.QueryGeneration
                 sb.AppendFormat(" FROM {0} as {1}",
                     mainFrom.Source,
                     mainFrom.ItemName);
+
+                if (!string.IsNullOrEmpty(UseKeysPart))
+                {
+                    sb.AppendFormat(" USE KEYS {0}", UseKeysPart);
+                }
 
                 foreach (var joinPart in FromParts.Skip(1))
                 {
@@ -156,6 +172,11 @@ namespace Couchbase.Linq.QueryGeneration
                 sb.AppendFormat(" FROM {0} as {1}",
                     mainFrom.Source,
                     mainFrom.ItemName);
+
+                if (!string.IsNullOrEmpty(UseKeysPart))
+                {
+                    sb.AppendFormat(" USE KEYS {0}", UseKeysPart);
+                }
 
                 foreach (var joinPart in FromParts.Skip(1))
                 {

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -26,6 +26,10 @@ namespace Couchbase.Linq
             customNodeTypeRegistry.Register(ExplainExpressionNode.SupportedMethods,
                 typeof(ExplainExpressionNode));
 
+            //register the "UseKeys" expression node parser
+            customNodeTypeRegistry.Register(UseKeysExpressionNode.SupportedMethods,
+                typeof(UseKeysExpressionNode));
+
             //This creates all the default node types
             var nodeTypeProvider = ExpressionTreeParser.CreateDefaultNodeTypeProvider();
 


### PR DESCRIPTION
Motivation
----------
Add support for `SELECT * FROM bucket USE KEYS ['key1', 'key2']` syntax.
This is particularly important for future work implementing subqueries,
which require the USE KEYS statement if there is a FROM clause.

Modifications
-------------
Implemented UseKeysClause and UseKeysExpressionNode, with support in
N1QlQueryModelVisitor and QueryPartsAggregator.  Created IQueryable and
IEnumerable UseKeys extensions that accept a list of keys to select.
Added appropriate unit tests.

Results
-------
It is possible to query a document or set of documents by key using the
syntax `bucket.Queryable<T>().UseKeys(new[] {"key1", "key2"});`