### PR TITLE
Improved query generation test speed and compatibility

### DIFF
--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -13,6 +13,11 @@ namespace Couchbase.Linq.Tests
     [TestFixture]
     public class BeerSampleTests : N1QLTestBase
     {
+        protected override bool IsClusterRequired
+        {
+            get { return true; }
+        }
+
         [SetUp]
         public void TestSetUp()
         {

--- a/Src/Couchbase.Linq.Tests/BucketExtensionTests.cs
+++ b/Src/Couchbase.Linq.Tests/BucketExtensionTests.cs
@@ -9,6 +9,11 @@ namespace Couchbase.Linq.Tests
     [TestFixture]
     public class BucketExtensionTests : N1QLTestBase
     {
+        protected override bool IsClusterRequired
+        {
+            get { return true; }
+        }
+
         [Test]
         public void Test_AnonymousType_In_Projection()
         {

--- a/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
@@ -10,36 +10,55 @@ namespace Couchbase.Linq.Tests
 // ReSharper disable once InconsistentNaming
     public class N1QLTestBase
     {
+        private IContractResolver _contractResolver = new DefaultContractResolver();
+
+        protected virtual bool IsClusterRequired
+        {
+            get { return false; }
+        }
+
         public N1QLTestBase()
         {
-            InitializeCluster();
+            // ReSharper disable once DoNotCallOverridableMethodsInConstructor
+            if (IsClusterRequired)
+            {
+                InitializeCluster();
+            }
         }
 
         protected string CreateN1QlQuery(IBucket bucket, Expression expression)
         {
             var queryModel = QueryParserHelper.CreateQueryParser().GetParsedQuery(expression);
-            return N1QlQueryModelVisitor.GenerateN1QlQuery(queryModel);
+
+            var visitor = new N1QlQueryModelVisitor(new DefaultMethodCallTranslatorProvider(), new JsonNetMemberNameResolver(_contractResolver));
+            visitor.VisitQueryModel(queryModel);
+            return visitor.GetQuery();
         }
 
         protected void InitializeCluster(IContractResolver contractResolver = null)
         {
-            if (contractResolver == null)
+            if (contractResolver != null)
             {
-                contractResolver = new DefaultContractResolver();
+                _contractResolver = contractResolver;
             }
 
             var config = new ClientConfiguration();
             config.Servers.Add(new Uri("http://127.0.0.1:8091"));
-            config.DeserializationSettings.ContractResolver = contractResolver;
-            config.SerializationSettings.ContractResolver = contractResolver;
+            config.DeserializationSettings.ContractResolver = _contractResolver;
+            config.SerializationSettings.ContractResolver = _contractResolver;
             ClusterHelper.Initialize(config);
         }
 
         protected void SetContractResolver(IContractResolver contractResolver)
         {
-            var cluster = ClusterHelper.Get();
-            cluster.Configuration.DeserializationSettings.ContractResolver = contractResolver;
-            cluster.Configuration.SerializationSettings.ContractResolver = contractResolver;
+            _contractResolver = contractResolver;
+
+            if (IsClusterRequired)
+            {
+                var cluster = ClusterHelper.Get();
+                cluster.Configuration.DeserializationSettings.ContractResolver = contractResolver;
+                cluster.Configuration.SerializationSettings.ContractResolver = contractResolver;
+            }
         }
     }
 }

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/StringTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/StringTests.cs
@@ -713,7 +713,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
         public void StringCompare_LessThan1_ReturnsLessThanOrEqual()
         {
             var visitor = new Mock<N1QlExpressionTreeVisitor>(new ParameterAggregator(),
-                new DefaultMethodCallTranslatorProvider())
+                new DefaultMethodCallTranslatorProvider(),
+                new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()))
             {
                 CallBase = true
             };
@@ -741,7 +742,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
         public void StringCompare_EqualTo1_ReturnsGreaterThan()
         {
             var visitor = new Mock<N1QlExpressionTreeVisitor>(new ParameterAggregator(),
-                new DefaultMethodCallTranslatorProvider())
+                new DefaultMethodCallTranslatorProvider(),
+                new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()))
             {
                 CallBase = true
             };
@@ -769,7 +771,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
         public void StringCompare_GreaterThanNeg1_ReturnsGreaterThanOrEqual()
         {
             var visitor = new Mock<N1QlExpressionTreeVisitor>(new ParameterAggregator(),
-                new DefaultMethodCallTranslatorProvider())
+                new DefaultMethodCallTranslatorProvider(),
+                new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()))
             {
                 CallBase = true
             };
@@ -797,7 +800,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
         public void StringCompare_EqualToNeg1_ReturnsLessThan()
         {
             var visitor = new Mock<N1QlExpressionTreeVisitor>(new ParameterAggregator(),
-                new DefaultMethodCallTranslatorProvider())
+                new DefaultMethodCallTranslatorProvider(),
+                new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()))
             {
                 CallBase = true
             };

--- a/Src/Couchbase.Linq/QueryGeneration/JsonNetMemberNameResolver.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/JsonNetMemberNameResolver.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json.Serialization;
 
@@ -6,6 +7,18 @@ namespace Couchbase.Linq.QueryGeneration
 {
     public class JsonNetMemberNameResolver : IMemberNameResolver
     {
+        private readonly IContractResolver _contractResolver;
+
+        public JsonNetMemberNameResolver(IContractResolver contractResolver)
+        {
+            if (contractResolver == null)
+            {
+                throw new ArgumentNullException("contractResolver");
+            }
+
+            _contractResolver = contractResolver;
+        }
+
         public bool TryResolveMemberName(MemberInfo member, out string memberName)
         {
             memberName = null;
@@ -13,8 +26,7 @@ namespace Couchbase.Linq.QueryGeneration
             if (member == null)
                 return false;
 
-            var contractResolver = ClusterHelper.Get().Configuration.SerializationSettings.ContractResolver;
-            var contract = contractResolver.ResolveContract(member.DeclaringType);
+            var contract = _contractResolver.ResolveContract(member.DeclaringType);
 
             if (contract.GetType() == typeof (JsonObjectContract) &&
                 ((JsonObjectContract) contract).Properties.Any(p => p.UnderlyingName == member.Name && !p.Ignored))

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -24,26 +24,27 @@ namespace Couchbase.Linq.QueryGeneration
             get { return _expression; }
         }
 
-        private readonly IMemberNameResolver _nameResolver = new JsonNetMemberNameResolver();
+        private readonly IMemberNameResolver _nameResolver;
         private readonly ParameterAggregator _parameterAggregator;
         private readonly IMethodCallTranslatorProvider _methodCallTranslatorProvider;
 
-        protected N1QlExpressionTreeVisitor(ParameterAggregator parameterAggregator, IMethodCallTranslatorProvider methodCallTranslatorProvider)
+        protected N1QlExpressionTreeVisitor(ParameterAggregator parameterAggregator, IMethodCallTranslatorProvider methodCallTranslatorProvider, IMemberNameResolver nameResolver)
         {
             _parameterAggregator = parameterAggregator;
             _methodCallTranslatorProvider = methodCallTranslatorProvider;
+            _nameResolver = nameResolver;
         }
 
-        public static string GetN1QlExpression(Expression expression, ParameterAggregator aggregator, IMethodCallTranslatorProvider methodCallTranslatorProvider)
+        public static string GetN1QlExpression(Expression expression, ParameterAggregator aggregator, IMethodCallTranslatorProvider methodCallTranslatorProvider, IMemberNameResolver nameResolver)
         {
-            var visitor = new N1QlExpressionTreeVisitor(aggregator, methodCallTranslatorProvider);
+            var visitor = new N1QlExpressionTreeVisitor(aggregator, methodCallTranslatorProvider, nameResolver);
             visitor.VisitExpression(expression);
             return visitor.GetN1QlExpression();
         }
 
-        public static string GetN1QlSelectNewExpression(NewExpression expression, ParameterAggregator aggregator, IMethodCallTranslatorProvider methodCallTranslatorProvider)
+        public static string GetN1QlSelectNewExpression(NewExpression expression, ParameterAggregator aggregator, IMethodCallTranslatorProvider methodCallTranslatorProvider, IMemberNameResolver nameResolver)
         {
-            var visitor = new N1QlExpressionTreeVisitor(aggregator, methodCallTranslatorProvider);
+            var visitor = new N1QlExpressionTreeVisitor(aggregator, methodCallTranslatorProvider, nameResolver);
             visitor.VisitSelectNewExpression(expression);
             return visitor.GetN1QlExpression();
         }
@@ -675,7 +676,7 @@ namespace Couchbase.Linq.QueryGeneration
 
         protected override Expression VisitSubQueryExpression(SubQueryExpression expression)
         {
-            var modelVisitor = new N1QlQueryModelVisitor(_methodCallTranslatorProvider);
+            var modelVisitor = new N1QlQueryModelVisitor(_methodCallTranslatorProvider, _nameResolver);
 
             modelVisitor.VisitQueryModel(expression.QueryModel);
             _expression.Append(modelVisitor.GetQuery());


### PR DESCRIPTION
Motivation
----------
Query generation tests shouldn't require a connection to a cluster on the
localhost in order to complete.  Instead, they should be able to function
using only fakes.

Modifications
-------------
Added IsClusterRequired property to N1QlTestBase.  The cluster will only
be connected during test setup if this property is overriden to return
true.  Removed the dependency on the cluster from
JsonNetMemberNameResolver, instead accepting an IContractResolver as a
constructor parameter.

Results
-------
All tests in the QueryGeneration folder no longer connect to the local
cluster when running.  This allows these tests to initialize and run more
quickly.  The tests can also be successfully run on a system without a
Couchbase cluster.