### PR TITLE
Ensure unique extent names in N1QL queries

### DIFF
--- a/Src/Couchbase.Linq.Tests/BucketExtensionTests.cs
+++ b/Src/Couchbase.Linq.Tests/BucketExtensionTests.cs
@@ -28,7 +28,7 @@ namespace Couchbase.Linq.Tests
                             fname = c.FirstName
                         };
 
-                    const string expected = "SELECT `c`.`age` as `age`, `c`.`fname` as `fname` FROM `default` as `c`";
+                    const string expected = "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `fname` FROM `default` as `Extent1`";
 
                     var N1QLQuery = CreateN1QlQuery(bucket, query.Expression);
 
@@ -47,7 +47,7 @@ namespace Couchbase.Linq.Tests
                     var query = from c in bucket.Queryable<Contact>()
                         select c;
 
-                    const string expected = "SELECT `c`.* FROM `default` as `c`";
+                    const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1`";
                     Assert.AreEqual(expected, CreateN1QlQuery(bucket, query.Expression));
                 }
             }
@@ -63,7 +63,7 @@ namespace Couchbase.Linq.Tests
                     var query = from c in bucket.Queryable<Contact>()
                         select c.Children;
 
-                    const string expected = "SELECT `c`.`children` FROM `default` as `c`";
+                    const string expected = "SELECT `Extent1`.`children` FROM `default` as `Extent1`";
                     Assert.AreEqual(expected, CreateN1QlQuery(bucket, query.Expression));
                 }
             }

--- a/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
@@ -30,7 +30,13 @@ namespace Couchbase.Linq.Tests
         {
             var queryModel = QueryParserHelper.CreateQueryParser().GetParsedQuery(expression);
 
-            var visitor = new N1QlQueryModelVisitor(new DefaultMethodCallTranslatorProvider(), new JsonNetMemberNameResolver(_contractResolver));
+            var queryGenerationContext = new N1QlQueryGenerationContext()
+            {
+                MemberNameResolver = new JsonNetMemberNameResolver(_contractResolver),
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+            };
+
+            var visitor = new N1QlQueryModelVisitor(queryGenerationContext);
             visitor.VisitQueryModel(queryModel);
             return visitor.GetQuery();
         }

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/ArrayIndexTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/ArrayIndexTests.cs
@@ -25,7 +25,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 QueryFactory.Queryable<DocumentWithArray>(mockBucket.Object)
                     .Select(e => new { address = e.Array[0] });
 
-            const string expected = "SELECT `e`.`Array`[0] as `address` FROM `default` as `e`";
+            const string expected = "SELECT `Extent1`.`Array`[0] as `address` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -44,7 +44,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 QueryFactory.Queryable<Brewery>(mockBucket.Object)
                     .Select(e => new { address = e.Address[0] });
 
-            const string expected = "SELECT `e`.`address`[0] as `address` FROM `default` as `e`";
+            const string expected = "SELECT `Extent1`.`address`[0] as `address` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -63,7 +63,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 QueryFactory.Queryable<DocumentWithIList>(mockBucket.Object)
                     .Select(e => new { address = e.List[0] });
 
-            const string expected = "SELECT `e`.`List`[0] as `address` FROM `default` as `e`";
+            const string expected = "SELECT `Extent1`.`List`[0] as `address` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/BinaryExpressionTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/BinaryExpressionTests.cs
@@ -28,7 +28,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age });
 
             const string expected =
-                "SELECT `e`.`age` as `age` FROM `default` as `e` WHERE ((`e`.`age` = 10) AND (`e`.`fname` IS NOT NULL))";
+                "SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` = 10) AND (`Extent1`.`fname` IS NOT NULL))";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -47,7 +47,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age });
 
             const string expected =
-                "SELECT `e`.`age` as `age` FROM `default` as `e` WHERE ((`e`.`age` = 10) OR (`e`.`fname` IS NOT NULL))";
+                "SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` = 10) OR (`Extent1`.`fname` IS NOT NULL))";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -70,7 +70,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age });
 
             const string expected =
-                "SELECT `e`.`age` as `age` FROM `default` as `e` WHERE (`e`.`age` = 10)";
+                "SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1` WHERE (`Extent1`.`age` = 10)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -89,7 +89,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age });
 
             const string expected =
-                "SELECT `e`.`age` as `age` FROM `default` as `e` WHERE (`e`.`age` != 10)";
+                "SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1` WHERE (`Extent1`.`age` != 10)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -108,7 +108,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { firstName = e.FirstName });
 
             const string expected =
-                "SELECT `e`.`fname` as `firstName` FROM `default` as `e` WHERE (`e`.`fname` IS NULL)";
+                "SELECT `Extent1`.`fname` as `firstName` FROM `default` as `Extent1` WHERE (`Extent1`.`fname` IS NULL)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -127,7 +127,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { firstName = e.FirstName });
 
             const string expected =
-                "SELECT `e`.`fname` as `firstName` FROM `default` as `e` WHERE (`e`.`fname` IS NOT NULL)";
+                "SELECT `Extent1`.`fname` as `firstName` FROM `default` as `Extent1` WHERE (`Extent1`.`fname` IS NOT NULL)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -146,7 +146,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age });
 
             const string expected =
-                "SELECT `e`.`age` as `age` FROM `default` as `e` WHERE (`e`.`age` > 10)";
+                "SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1` WHERE (`Extent1`.`age` > 10)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -165,7 +165,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age });
 
             const string expected =
-                "SELECT `e`.`age` as `age` FROM `default` as `e` WHERE (`e`.`age` >= 10)";
+                "SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1` WHERE (`Extent1`.`age` >= 10)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -184,7 +184,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age });
 
             const string expected =
-                "SELECT `e`.`age` as `age` FROM `default` as `e` WHERE (`e`.`age` < 10)";
+                "SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1` WHERE (`Extent1`.`age` < 10)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -203,7 +203,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age });
 
             const string expected =
-                "SELECT `e`.`age` as `age` FROM `default` as `e` WHERE (`e`.`age` <= 10)";
+                "SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1` WHERE (`Extent1`.`age` <= 10)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -225,7 +225,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age + 2});
 
             const string expected =
-                "SELECT (`e`.`age` + 2) as `age` FROM `default` as `e`";
+                "SELECT (`Extent1`.`age` + 2) as `age` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -243,7 +243,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age - 2 });
 
             const string expected =
-                "SELECT (`e`.`age` - 2) as `age` FROM `default` as `e`";
+                "SELECT (`Extent1`.`age` - 2) as `age` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -261,7 +261,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age * 2 });
 
             const string expected =
-                "SELECT (`e`.`age` * 2) as `age` FROM `default` as `e`";
+                "SELECT (`Extent1`.`age` * 2) as `age` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -279,7 +279,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age / 2 });
 
             const string expected =
-                "SELECT (`e`.`age` / 2) as `age` FROM `default` as `e`";
+                "SELECT (`Extent1`.`age` / 2) as `age` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -297,7 +297,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age % 2 });
 
             const string expected =
-                "SELECT (`e`.`age` % 2) as `age` FROM `default` as `e`";
+                "SELECT (`Extent1`.`age` % 2) as `age` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -319,7 +319,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { name = e.FirstName + " " + e.LastName });
 
             const string expected =
-                "SELECT ((`e`.`fname` || ' ') || `e`.`lname`) as `name` FROM `default` as `e`";
+                "SELECT ((`Extent1`.`fname` || ' ') || `Extent1`.`lname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -337,7 +337,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { name = String.Concat(e.FirstName, " ", e.LastName) });
 
             const string expected =
-                "SELECT (`e`.`fname` || ' ' || `e`.`lname`) as `name` FROM `default` as `e`";
+                "SELECT (`Extent1`.`fname` || ' ' || `Extent1`.`lname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -355,7 +355,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { name = String.Concat(new[] {e.FirstName, " ", e.LastName}) });
 
             const string expected =
-                "SELECT (`e`.`fname` || ' ' || `e`.`lname`) as `name` FROM `default` as `e`";
+                "SELECT (`Extent1`.`fname` || ' ' || `Extent1`.`lname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -373,7 +373,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { name = String.Concat(e.FirstName, " ", e.LastName, " ", "suffix") });
 
             const string expected =
-                "SELECT (`e`.`fname` || ' ' || `e`.`lname` || ' ' || 'suffix') as `name` FROM `default` as `e`";
+                "SELECT (`Extent1`.`fname` || ' ' || `Extent1`.`lname` || ' ' || 'suffix') as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -395,7 +395,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { name = e.FirstName ?? e.LastName });
 
             const string expected =
-                "SELECT IFMISSINGORNULL(`e`.`fname`, `e`.`lname`) as `name` FROM `default` as `e`";
+                "SELECT IFMISSINGORNULL(`Extent1`.`fname`, `Extent1`.`lname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -413,7 +413,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { name = e.FirstName ?? e.LastName ?? e.Email });
 
             const string expected =
-                "SELECT IFMISSINGORNULL(`e`.`fname`, `e`.`lname`, `e`.`email`) as `name` FROM `default` as `e`";
+                "SELECT IFMISSINGORNULL(`Extent1`.`fname`, `Extent1`.`lname`, `Extent1`.`email`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/ConditionalExpressionTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/ConditionalExpressionTests.cs
@@ -25,7 +25,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 .Select(e => new { e.FirstName, Value = e.Age < 10 ? null : e.LastName });
 
             const string expected =
-                "SELECT `e`.`fname` as `FirstName`, CASE WHEN (`e`.`age` < 10) THEN NULL ELSE `e`.`lname` END as `Value` FROM `default` as `e`";
+                "SELECT `Extent1`.`fname` as `FirstName`, CASE WHEN (`Extent1`.`age` < 10) THEN NULL ELSE `Extent1`.`lname` END as `Value` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/ConstantExpressionTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/ConstantExpressionTests.cs
@@ -25,7 +25,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Where(e => e.FirstName != "Test");
 
             const string expected =
-                "SELECT `e`.* FROM `default` as `e` WHERE (`e`.`fname` != 'Test')";
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`fname` != 'Test')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -43,7 +43,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { e.FirstName, Value = true });
 
             const string expected =
-                "SELECT `e`.`fname` as `FirstName`, TRUE as `Value` FROM `default` as `e`";
+                "SELECT `Extent1`.`fname` as `FirstName`, TRUE as `Value` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -61,7 +61,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { e.FirstName, Value = false });
 
             const string expected =
-                "SELECT `e`.`fname` as `FirstName`, FALSE as `Value` FROM `default` as `e`";
+                "SELECT `Extent1`.`fname` as `FirstName`, FALSE as `Value` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -79,7 +79,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 .Select(e => new { e.FirstName, Value = (string)null });
 
             const string expected =
-                "SELECT `e`.`fname` as `FirstName`, NULL as `Value` FROM `default` as `e`";
+                "SELECT `Extent1`.`fname` as `FirstName`, NULL as `Value` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -97,7 +97,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 .Select(e => new { e.FirstName, Value = new[] {1, 2, 3, 4, 5} });
 
             const string expected =
-                "SELECT `e`.`fname` as `FirstName`, [1, 2, 3, 4, 5] as `Value` FROM `default` as `e`";
+                "SELECT `Extent1`.`fname` as `FirstName`, [1, 2, 3, 4, 5] as `Value` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -115,7 +115,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 .Select(e => new { Value = new[] { e.FirstName, e.LastName } });
 
             const string expected =
-                "SELECT [`e`.`fname`, `e`.`lname`] as `Value` FROM `default` as `e`";
+                "SELECT [`Extent1`.`fname`, `Extent1`.`lname`] as `Value` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -133,7 +133,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 .Select(e => new { Value = new { e.FirstName, e.LastName } });
 
             const string expected =
-                "SELECT {\"FirstName\": `e`.`fname`, \"LastName\": `e`.`lname`} as `Value` FROM `default` as `e`";
+                "SELECT {\"FirstName\": `Extent1`.`fname`, \"LastName\": `Extent1`.`lname`} as `Value` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -151,7 +151,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 .Select(e => new {Value = new[] { new {Name = e.FirstName}, new {Name = e.LastName} } });
 
             const string expected =
-                "SELECT [{\"Name\": `e`.`fname`}, {\"Name\": `e`.`lname`}] as `Value` FROM `default` as `e`";
+                "SELECT [{\"Name\": `Extent1`.`fname`}, {\"Name\": `Extent1`.`lname`}] as `Value` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/DistinctTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/DistinctTests.cs
@@ -23,7 +23,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 .Select(c => new {age = c.Age})
                 .Distinct();
 
-            const string expected = "SELECT DISTINCT `c`.`age` as `age` FROM `default` as `c`";
+            const string expected = "SELECT DISTINCT `Extent1`.`age` as `age` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/ExplainTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/ExplainTests.cs
@@ -26,7 +26,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
 
             var explainQuery = Expression.Call(null, typeof(QueryExtensions).GetMethod("Explain").MakeGenericMethod(query.ElementType), query.Expression);
 
-            const string expected = "EXPLAIN SELECT `c`.`age` as `age` FROM `default` as `c`";
+            const string expected = "EXPLAIN SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, explainQuery);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/IsMissingTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/IsMissingTests.cs
@@ -23,7 +23,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Where(p => N1Ql.IsMissing(p.Age));
 
-            const string expected = "SELECT `p`.* FROM `default` as `p` WHERE `p`.`age` IS MISSING";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`age` IS MISSING";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -39,7 +39,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Where(p => N1Ql.IsMissing(p, "test"));
 
-            const string expected = "SELECT `p`.* FROM `default` as `p` WHERE `p`.`test` IS MISSING";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`test` IS MISSING";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -55,7 +55,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Where(p => N1Ql.IsNotMissing(p.Age));
 
-            const string expected = "SELECT `p`.* FROM `default` as `p` WHERE `p`.`age` IS NOT MISSING";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`age` IS NOT MISSING";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -71,7 +71,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Where(p => N1Ql.IsNotMissing(p, "test"));
 
-            const string expected = "SELECT `p`.* FROM `default` as `p` WHERE `p`.`test` IS NOT MISSING";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`test` IS NOT MISSING";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -87,7 +87,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Select(p => new {age = N1Ql.IsMissing(p.Age) ? 10 : p.Age});
 
-            const string expected = "SELECT CASE WHEN `p`.`age` IS MISSING THEN 10 ELSE `p`.`age` END as `age` FROM `default` as `p`";
+            const string expected = "SELECT CASE WHEN `Extent1`.`age` IS MISSING THEN 10 ELSE `Extent1`.`age` END as `age` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -103,7 +103,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Where(p => N1Ql.IsValued(p.Age));
 
-            const string expected = "SELECT `p`.* FROM `default` as `p` WHERE `p`.`age` IS VALUED";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`age` IS VALUED";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -119,7 +119,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Where(p => N1Ql.IsValued(p, "test"));
 
-            const string expected = "SELECT `p`.* FROM `default` as `p` WHERE `p`.`test` IS VALUED";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`test` IS VALUED";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -135,7 +135,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Where(p => N1Ql.IsNotValued(p.Age));
 
-            const string expected = "SELECT `p`.* FROM `default` as `p` WHERE `p`.`age` IS NOT VALUED";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`age` IS NOT VALUED";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -151,7 +151,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Where(p => N1Ql.IsNotValued(p, "test"));
 
-            const string expected = "SELECT `p`.* FROM `default` as `p` WHERE `p`.`test` IS NOT VALUED";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`test` IS NOT VALUED";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -167,7 +167,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Select(p => new { age = N1Ql.IsNotValued(p.Age) ? 10 : p.Age });
 
-            const string expected = "SELECT CASE WHEN `p`.`age` IS NOT VALUED THEN 10 ELSE `p`.`age` END as `age` FROM `default` as `p`";
+            const string expected = "SELECT CASE WHEN `Extent1`.`age` IS NOT VALUED THEN 10 ELSE `Extent1`.`age` END as `age` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/JoinTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/JoinTests.cs
@@ -26,10 +26,10 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         on beer.BreweryId equals N1Ql.Key(brewery)
                         select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
 
-            const string expected = "SELECT `beer`.`name` as `Name`, `beer`.`abv` as `Abv`, `brewery`.`name` as `BreweryName` " +
-                "FROM `default` as `beer` "+
-                "INNER JOIN `default` as `brewery` " +
-                "ON KEYS `beer`.`brewery_id`";
+            const string expected = "SELECT `Extent1`.`name` as `Name`, `Extent1`.`abv` as `Abv`, `Extent2`.`name` as `BreweryName` " +
+                "FROM `default` as `Extent1` "+
+                "INNER JOIN `default` as `Extent2` " +
+                "ON KEYS `Extent1`.`brewery_id`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -49,12 +49,12 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         orderby beer.Name
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 
-            const string expected = "SELECT `beer`.`name` as `Name`, `beer`.`abv` as `Abv`, `brewery`.`name` as `BreweryName` " +
-                "FROM `default` as `beer` " +
-                "INNER JOIN `default` as `brewery` " +
-                "ON KEYS `beer`.`brewery_id` " +
-                "WHERE (`brewery`.`geo`.`lon` > -80) " + 
-                "ORDER BY `beer`.`name` ASC";
+            const string expected = "SELECT `Extent1`.`name` as `Name`, `Extent1`.`abv` as `Abv`, `Extent2`.`name` as `BreweryName` " +
+                "FROM `default` as `Extent1` " +
+                "INNER JOIN `default` as `Extent2` " +
+                "ON KEYS `Extent1`.`brewery_id` " +
+                "WHERE (`Extent2`.`geo`.`lon` > -80) " + 
+                "ORDER BY `Extent1`.`name` ASC";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -72,11 +72,11 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         on beer.BreweryId equals N1Ql.Key(brewery)
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 
-            const string expected = "SELECT `p`.`name` as `Name`, `p`.`abv` as `Abv`, `brewery`.`name` as `BreweryName` " +
-                "FROM `default` as `p` " +
-                "INNER JOIN `default` as `brewery` " +
-                "ON KEYS `p`.`brewery_id` " + 
-                "WHERE (`p`.`type` = 'beer') AND (`brewery`.`type` = 'brewery')";
+            const string expected = "SELECT `Extent1`.`name` as `Name`, `Extent1`.`abv` as `Abv`, `Extent2`.`name` as `BreweryName` " +
+                "FROM `default` as `Extent1` " +
+                "INNER JOIN `default` as `Extent2` " +
+                "ON KEYS `Extent1`.`brewery_id` " + 
+                "WHERE (`Extent1`.`type` = 'beer') AND (`Extent2`.`type` = 'brewery')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -95,10 +95,10 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         from brewery in bg.DefaultIfEmpty()
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 
-            const string expected = "SELECT `beer`.`name` as `Name`, `beer`.`abv` as `Abv`, `brewery`.`name` as `BreweryName` " +
-                "FROM `default` as `beer` " +
-                "LEFT JOIN `default` as `brewery` " +
-                "ON KEYS `beer`.`brewery_id`";
+            const string expected = "SELECT `Extent1`.`name` as `Name`, `Extent1`.`abv` as `Abv`, `Extent2`.`name` as `BreweryName` " +
+                "FROM `default` as `Extent1` " +
+                "LEFT JOIN `default` as `Extent2` " +
+                "ON KEYS `Extent1`.`brewery_id`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -119,12 +119,12 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         orderby brewery.Name, beer.Name
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 
-            const string expected = "SELECT `beer`.`name` as `Name`, `beer`.`abv` as `Abv`, `brewery`.`name` as `BreweryName` " +
-                "FROM `default` as `beer` " +
-                "LEFT JOIN `default` as `brewery` " +
-                "ON KEYS `beer`.`brewery_id` " +
-                "WHERE (`beer`.`abv` > 4) " +
-                "ORDER BY `brewery`.`name` ASC, `beer`.`name` ASC";
+            const string expected = "SELECT `Extent1`.`name` as `Name`, `Extent1`.`abv` as `Abv`, `Extent2`.`name` as `BreweryName` " +
+                "FROM `default` as `Extent1` " +
+                "LEFT JOIN `default` as `Extent2` " +
+                "ON KEYS `Extent1`.`brewery_id` " +
+                "WHERE (`Extent1`.`abv` > 4) " +
+                "ORDER BY `Extent2`.`name` ASC, `Extent1`.`name` ASC";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -143,11 +143,11 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         from brewery in bg.DefaultIfEmpty()
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 
-            const string expected = "SELECT `p`.`name` as `Name`, `p`.`abv` as `Abv`, `brewery`.`name` as `BreweryName` " +
-                "FROM `default` as `p` " +
-                "LEFT JOIN `default` as `brewery` " +
-                "ON KEYS `p`.`brewery_id` " +
-                "WHERE (`p`.`type` = 'beer') AND (`brewery`.`type` = 'brewery')";
+            const string expected = "SELECT `Extent1`.`name` as `Name`, `Extent1`.`abv` as `Abv`, `Extent2`.`name` as `BreweryName` " +
+                "FROM `default` as `Extent1` " +
+                "LEFT JOIN `default` as `Extent2` " +
+                "ON KEYS `Extent1`.`brewery_id` " +
+                "WHERE (`Extent1`.`type` = 'beer') AND (`Extent2`.`type` = 'brewery')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/MathTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/MathTests.cs
@@ -30,7 +30,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Abs(contact.Age) };
 
             const string expected =
-                "SELECT ABS(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT ABS(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -47,7 +47,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Ceiling((double)contact.Age) };
 
             const string expected =
-                "SELECT CEIL(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT CEIL(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -64,7 +64,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Floor((double)contact.Age) };
 
             const string expected =
-                "SELECT FLOOR(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT FLOOR(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -81,7 +81,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Pow(contact.Age, 2) };
 
             const string expected =
-                "SELECT POWER(`contact`.`age`, 2) as `i` FROM `default` as `contact`";
+                "SELECT POWER(`Extent1`.`age`, 2) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -98,7 +98,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Round((double)contact.Age) };
 
             const string expected =
-                "SELECT ROUND(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT ROUND(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -115,7 +115,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Round((double)contact.Age, 2) };
 
             const string expected =
-                "SELECT ROUND(`contact`.`age`, 2) as `i` FROM `default` as `contact`";
+                "SELECT ROUND(`Extent1`.`age`, 2) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -132,7 +132,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Sign(contact.Age) };
 
             const string expected =
-                "SELECT SIGN(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT SIGN(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -149,7 +149,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Sqrt(contact.Age) };
 
             const string expected =
-                "SELECT SQRT(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT SQRT(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -166,7 +166,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Truncate((double)contact.Age) };
 
             const string expected =
-                "SELECT TRUNC(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT TRUNC(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -187,7 +187,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Exp(contact.Age) };
 
             const string expected =
-                "SELECT EXP(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT EXP(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -204,7 +204,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Log(contact.Age) };
 
             const string expected =
-                "SELECT LN(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT LN(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -221,7 +221,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Log10(contact.Age) };
 
             const string expected =
-                "SELECT LOG(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT LOG(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -242,7 +242,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Acos(contact.Age) };
 
             const string expected =
-                "SELECT ACOS(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT ACOS(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -259,7 +259,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Asin(contact.Age) };
 
             const string expected =
-                "SELECT ASIN(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT ASIN(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -276,7 +276,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Atan(contact.Age) };
 
             const string expected =
-                "SELECT ATAN(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT ATAN(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -293,7 +293,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Atan2(contact.Age, 2) };
 
             const string expected =
-                "SELECT ATAN2(`contact`.`age`, 2) as `i` FROM `default` as `contact`";
+                "SELECT ATAN2(`Extent1`.`age`, 2) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -310,7 +310,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Cos(contact.Age) };
 
             const string expected =
-                "SELECT COS(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT COS(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -327,7 +327,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Sin(contact.Age) };
 
             const string expected =
-                "SELECT SIN(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT SIN(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -344,7 +344,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { i = Math.Tan(contact.Age) };
 
             const string expected =
-                "SELECT TAN(`contact`.`age`) as `i` FROM `default` as `contact`";
+                "SELECT TAN(`Extent1`.`age`) as `i` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/MemberNameResolutionTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/MemberNameResolutionTests.cs
@@ -25,7 +25,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         e => new {age = e.Age, firstName = e.FirstName, lastName = e.LastName, children = e.Children});
 
             const string expected =
-                "SELECT `e`.`age` as `age`, `e`.`fname` as `firstName`, `e`.`lname` as `lastName`, `e`.`children` as `children` FROM `default` as `e` WHERE ((`e`.`age` < 40) AND (`e`.`fname` LIKE '%a%'))";
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `firstName`, `Extent1`.`lname` as `lastName`, `Extent1`.`children` as `children` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` < 40) AND (`Extent1`.`fname` LIKE '%a%'))";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -46,7 +46,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {brewName = e.Name, brewCity = e.City});
 
             const string expected =
-                "SELECT `e`.`name` as `brewName`, `e`.`city` as `brewCity` FROM `default` as `e` WHERE (`e`.`country` LIKE '%a%')";
+                "SELECT `Extent1`.`name` as `brewName`, `Extent1`.`city` as `brewCity` FROM `default` as `Extent1` WHERE (`Extent1`.`country` LIKE '%a%')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -67,7 +67,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {brewName = e.Name, brewCity = e.City});
 
             const string expected =
-                "SELECT `e`.`name` as `brewName`, `e`.`city` as `brewCity` FROM `default` as `e` WHERE (`e`.`country` LIKE '%a%')";
+                "SELECT `Extent1`.`name` as `brewName`, `Extent1`.`city` as `brewCity` FROM `default` as `Extent1` WHERE (`Extent1`.`country` LIKE '%a%')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -87,7 +87,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Where(e => e.Age > 6)
                     .Select(e => new {name = e.FirstName, gender = e.Gender});
 
-            const string expected = "SELECT `e`.`fname` as `name` FROM `default` as `e` WHERE (`e`.`age` > 6)";
+            const string expected = "SELECT `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (`Extent1`.`age` > 6)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/MetaTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/MetaTests.cs
@@ -24,7 +24,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Select(p => N1Ql.Meta(p));
 
-            const string expected = "SELECT META(`p`) FROM `default` as `p`";
+            const string expected = "SELECT META(`Extent1`) FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -41,7 +41,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 .Select(c=> new {c.Age, Meta = N1Ql.Meta(c)});
 
 
-            const string expected = "SELECT `c`.`age` as `Age`, META(`c`) as `Meta` FROM `default` as `c`";
+            const string expected = "SELECT `Extent1`.`age` as `Age`, META(`Extent1`) as `Meta` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/NestTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/NestTests.cs
@@ -25,9 +25,9 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         from address in brewery.Address
                         select new {name = brewery.Name, address};
 
-            const string expected = "SELECT `brewery`.`name` as `name`, `address` as `address` " +
-                "FROM `default` as `brewery` "+
-                "INNER UNNEST `brewery`.`address` as `address`";
+            const string expected = "SELECT `Extent1`.`name` as `name`, `Extent2` as `address` " +
+                "FROM `default` as `Extent1` "+
+                "INNER UNNEST `Extent1`.`address` as `Extent2`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -45,10 +45,10 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         orderby address
                         select new { name = brewery.Name, address };
 
-            const string expected = "SELECT `brewery`.`name` as `name`, `address` as `address` " +
-                "FROM `default` as `brewery` " +
-                "INNER UNNEST `brewery`.`address` as `address` " +
-                "ORDER BY `address` ASC";
+            const string expected = "SELECT `Extent1`.`name` as `name`, `Extent2` as `address` " +
+                "FROM `default` as `Extent1` " +
+                "INNER UNNEST `Extent1`.`address` as `Extent2` " +
+                "ORDER BY `Extent2` ASC";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -65,10 +65,10 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         from address in brewery.Address.Where(p => p != "123 First Street")
                         select new { name = brewery.Name, address };
 
-            const string expected = "SELECT `brewery`.`name` as `name`, `address` as `address` " +
-                "FROM `default` as `brewery` " +
-                "INNER UNNEST `brewery`.`address` as `address` " +
-                "WHERE (`address` != '123 First Street')";
+            const string expected = "SELECT `Extent1`.`name` as `name`, `Extent2` as `address` " +
+                "FROM `default` as `Extent1` " +
+                "INNER UNNEST `Extent1`.`address` as `Extent2` " +
+                "WHERE (`Extent2` != '123 First Street')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -85,9 +85,9 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         from address in brewery.Address.DefaultIfEmpty()
                         select new { name = brewery.Name, address };
 
-            const string expected = "SELECT `brewery`.`name` as `name`, `address` as `address` " +
-                "FROM `default` as `brewery` " +
-                "OUTER UNNEST `brewery`.`address` as `address`";
+            const string expected = "SELECT `Extent1`.`name` as `name`, `Extent2` as `address` " +
+                "FROM `default` as `Extent1` " +
+                "OUTER UNNEST `Extent1`.`address` as `Extent2`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -105,10 +105,10 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         from level3 in level2.Level3Items
                         select new { level3.Value };
 
-            const string expected = "SELECT `level3`.`Value` as `Value` " +
-                "FROM `default` as `level1` " +
-                "INNER UNNEST `level1`.`Level2Items` as `level2` " +
-                "INNER UNNEST `level2`.`Level3Items` as `level3`";
+            const string expected = "SELECT `Extent3`.`Value` as `Value` " +
+                "FROM `default` as `Extent1` " +
+                "INNER UNNEST `Extent1`.`Level2Items` as `Extent2` " +
+                "INNER UNNEST `Extent2`.`Level3Items` as `Extent3`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -127,9 +127,9 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     level1 => level1.NestLevel2Keys,
                     (level1, level2) => new {level1.Value, level2});
                         
-            const string expected = "SELECT `level1`.`Value` as `Value`, `level2` as `level2` " +
-                "FROM `default` as `level1` " +
-                "INNER NEST `default` as `level2` ON KEYS `level1`.`NestLevel2Keys`";
+            const string expected = "SELECT `Extent1`.`Value` as `Value`, `Extent2` as `level2` " +
+                "FROM `default` as `Extent1` " +
+                "INNER NEST `default` as `Extent2` ON KEYS `Extent1`.`NestLevel2Keys`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -149,11 +149,11 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     level1 => level1.NestLevel2Keys,
                     (level1, level2) => new { level1.Value, level2 });
 
-            const string expected = "SELECT `level1`.`Value` as `Value`, `level2` as `level2` " +
-                "FROM `default` as `level1` " +
-                "INNER NEST `default` as `__genName0` ON KEYS `level1`.`NestLevel2Keys` " +
-                "LET `level2` = ARRAY `__genName1` FOR `__genName1` IN `__genName0` WHEN (`__genName1`.`Type` = 'level2') END " +
-                "WHERE (`level1`.`Type` = 'level1') AND (ARRAY_LENGTH(`level2`) > 0)";
+            const string expected = "SELECT `Extent1`.`Value` as `Value`, `Extent4` as `level2` " +
+                "FROM `default` as `Extent1` " +
+                "INNER NEST `default` as `Extent2` ON KEYS `Extent1`.`NestLevel2Keys` " +
+                "LET `Extent4` = ARRAY `Extent3` FOR `Extent3` IN `Extent2` WHEN (`Extent3`.`Type` = 'level2') END " +
+                "WHERE (`Extent1`.`Type` = 'level1') AND (ARRAY_LENGTH(`Extent4`) > 0)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -172,9 +172,9 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     level1 => level1.NestLevel2Keys,
                     (level1, level2) => new { level1.Value, level2 });
 
-            const string expected = "SELECT `level1`.`Value` as `Value`, `level2` as `level2` " +
-                "FROM `default` as `level1` " +
-                "LEFT OUTER NEST `default` as `level2` ON KEYS `level1`.`NestLevel2Keys`";
+            const string expected = "SELECT `Extent1`.`Value` as `Value`, `Extent2` as `level2` " +
+                "FROM `default` as `Extent1` " +
+                "LEFT OUTER NEST `default` as `Extent2` ON KEYS `Extent1`.`NestLevel2Keys`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -194,11 +194,11 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     level1 => level1.NestLevel2Keys,
                     (level1, level2) => new { level1.Value, level2 });
 
-            const string expected = "SELECT `level1`.`Value` as `Value`, `level2` as `level2` " +
-                "FROM `default` as `level1` " +
-                "LEFT OUTER NEST `default` as `__genName0` ON KEYS `level1`.`NestLevel2Keys` " +
-                "LET `level2` = ARRAY `__genName1` FOR `__genName1` IN `__genName0` WHEN (`__genName1`.`Type` = 'level2') END " +
-                "WHERE (`level1`.`Type` = 'level1')";
+            const string expected = "SELECT `Extent1`.`Value` as `Value`, `Extent4` as `level2` " +
+                "FROM `default` as `Extent1` " +
+                "LEFT OUTER NEST `default` as `Extent2` ON KEYS `Extent1`.`NestLevel2Keys` " +
+                "LET `Extent4` = ARRAY `Extent3` FOR `Extent3` IN `Extent2` WHEN (`Extent3`.`Type` = 'level2') END " +
+                "WHERE (`Extent1`.`Type` = 'level1')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/OrderByClauseTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/OrderByClauseTests.cs
@@ -23,7 +23,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
 
 
             const string expected =
-                "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` WHERE ((`e`.`age` > 10) AND (`e`.`fname` = 'Sam')) ORDER BY `e`.`age` ASC";
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam')) ORDER BY `Extent1`.`age` ASC";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -43,7 +43,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {age = e.Age});
 
 
-            const string expected = "SELECT `e`.`age` as `age` FROM `default` as `e` ORDER BY `e`.`age` ASC, `e`.`email` DESC";
+            const string expected = "SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1` ORDER BY `Extent1`.`age` ASC, `Extent1`.`email` DESC";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -63,7 +63,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {age = e.Age});
 
 
-            const string expected = "SELECT `e`.`age` as `age` FROM `default` as `e` ORDER BY `e`.`age` DESC, `e`.`email` ASC";
+            const string expected = "SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1` ORDER BY `Extent1`.`age` DESC, `Extent1`.`email` ASC";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/SelectTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/SelectTests.cs
@@ -20,7 +20,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
                     .Select(e => new {age = e.Age, name = e.FirstName});
 
-            const string expected = "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e`";
+            const string expected = "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -37,7 +37,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
                     .Select(e => e);
 
-            const string expected = "SELECT `e`.* FROM `default` as `e`";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -55,7 +55,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .UseKeys(new[] { "abc", "def" })
                     .Select(e => e);
 
-            const string expected = "SELECT `<generated>_1`.* FROM `default` as `<generated>_1` USE KEYS ['abc', 'def']";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` USE KEYS ['abc', 'def']";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/StringTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/StringTests.cs
@@ -33,8 +33,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` = 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` = 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -52,8 +52,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` = 'M''')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` = 'M''')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -70,7 +70,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName, ch = 'M' };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName`, 'M' as `ch` FROM `default` as `contact`";
+                "SELECT `Extent1`.`fname` as `FirstName`, 'M' as `ch` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -87,7 +87,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName, ch = '\'' };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName`, '''' as `ch` FROM `default` as `contact`";
+                "SELECT `Extent1`.`fname` as `FirstName`, '''' as `ch` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -109,8 +109,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (LENGTH(`contact`.`fname`) > 5)";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (LENGTH(`Extent1`.`fname`) > 5)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -128,8 +128,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.LastName };
 
             const string expected =
-                "SELECT `contact`.`lname` as `LastName` FROM `default` as `contact` " +
-                "WHERE (UPPER(`contact`.`fname`) = 'BOB')";
+                "SELECT `Extent1`.`lname` as `LastName` FROM `default` as `Extent1` " +
+                "WHERE (UPPER(`Extent1`.`fname`) = 'BOB')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -147,8 +147,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.LastName };
 
             const string expected =
-                "SELECT `contact`.`lname` as `LastName` FROM `default` as `contact` " +
-                "WHERE (LOWER(`contact`.`fname`) = 'bob')";
+                "SELECT `Extent1`.`lname` as `LastName` FROM `default` as `Extent1` " +
+                "WHERE (LOWER(`Extent1`.`fname`) = 'bob')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -165,7 +165,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.Substring(1) };
 
             const string expected =
-                "SELECT SUBSTR(`contact`.`fname`, 1) as `name` FROM `default` as `contact`";
+                "SELECT SUBSTR(`Extent1`.`fname`, 1) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -182,7 +182,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.Substring(1, 5) };
 
             const string expected =
-                "SELECT SUBSTR(`contact`.`fname`, 1, 5) as `name` FROM `default` as `contact`";
+                "SELECT SUBSTR(`Extent1`.`fname`, 1, 5) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -199,7 +199,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { firstLetter = contact.FirstName[0] };
 
             const string expected =
-                "SELECT SUBSTR(`contact`.`fname`, 0, 1) as `firstLetter` FROM `default` as `contact`";
+                "SELECT SUBSTR(`Extent1`.`fname`, 0, 1) as `firstLetter` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -216,7 +216,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.Split(null) };
 
             const string expected =
-                "SELECT SPLIT(`contact`.`fname`) as `name` FROM `default` as `contact`";
+                "SELECT SPLIT(`Extent1`.`fname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -233,7 +233,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.Split() };
 
             const string expected =
-                "SELECT SPLIT(`contact`.`fname`) as `name` FROM `default` as `contact`";
+                "SELECT SPLIT(`Extent1`.`fname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -250,7 +250,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.Split(' ') };
 
             const string expected =
-                "SELECT SPLIT(`contact`.`fname`, ' ') as `name` FROM `default` as `contact`";
+                "SELECT SPLIT(`Extent1`.`fname`, ' ') as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -279,7 +279,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { index = contact.FirstName.IndexOf(' ') };
 
             const string expected =
-                "SELECT POSITION(`contact`.`fname`, ' ') as `index` FROM `default` as `contact`";
+                "SELECT POSITION(`Extent1`.`fname`, ' ') as `index` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -296,7 +296,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { index = contact.FirstName.IndexOf(" ") };
 
             const string expected =
-                "SELECT POSITION(`contact`.`fname`, ' ') as `index` FROM `default` as `contact`";
+                "SELECT POSITION(`Extent1`.`fname`, ' ') as `index` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -313,7 +313,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.Replace(" ", "") };
 
             const string expected =
-                "SELECT REPLACE(`contact`.`fname`, ' ', '') as `name` FROM `default` as `contact`";
+                "SELECT REPLACE(`Extent1`.`fname`, ' ', '') as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -330,7 +330,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.Trim() };
 
             const string expected =
-                "SELECT TRIM(`contact`.`fname`) as `name` FROM `default` as `contact`";
+                "SELECT TRIM(`Extent1`.`fname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -347,7 +347,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.Trim(null) };
 
             const string expected =
-                "SELECT TRIM(`contact`.`fname`) as `name` FROM `default` as `contact`";
+                "SELECT TRIM(`Extent1`.`fname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -364,7 +364,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.Trim(' ', '\t', '\'') };
 
             const string expected =
-                "SELECT TRIM(`contact`.`fname`, ' \t''') as `name` FROM `default` as `contact`";
+                "SELECT TRIM(`Extent1`.`fname`, ' \t''') as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -381,7 +381,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.TrimEnd() };
 
             const string expected =
-                "SELECT RTRIM(`contact`.`fname`) as `name` FROM `default` as `contact`";
+                "SELECT RTRIM(`Extent1`.`fname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -398,7 +398,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.TrimEnd(null) };
 
             const string expected =
-                "SELECT RTRIM(`contact`.`fname`) as `name` FROM `default` as `contact`";
+                "SELECT RTRIM(`Extent1`.`fname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -415,7 +415,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.TrimEnd(' ', '\t', '\'') };
 
             const string expected =
-                "SELECT RTRIM(`contact`.`fname`, ' \t''') as `name` FROM `default` as `contact`";
+                "SELECT RTRIM(`Extent1`.`fname`, ' \t''') as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -432,7 +432,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.TrimStart() };
 
             const string expected =
-                "SELECT LTRIM(`contact`.`fname`) as `name` FROM `default` as `contact`";
+                "SELECT LTRIM(`Extent1`.`fname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -449,7 +449,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.TrimStart(null) };
 
             const string expected =
-                "SELECT LTRIM(`contact`.`fname`) as `name` FROM `default` as `contact`";
+                "SELECT LTRIM(`Extent1`.`fname`) as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -466,7 +466,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { name = contact.FirstName.TrimStart(' ', '\t', '\'') };
 
             const string expected =
-                "SELECT LTRIM(`contact`.`fname`, ' \t''') as `name` FROM `default` as `contact`";
+                "SELECT LTRIM(`Extent1`.`fname`, ' \t''') as `name` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -488,8 +488,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` = 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` = 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -507,8 +507,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` != 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` != 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -526,8 +526,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` < 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` < 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -545,8 +545,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` <= 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` <= 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -564,8 +564,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` > 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` > 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -583,8 +583,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` >= 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` >= 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -602,8 +602,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` = 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` = 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -621,8 +621,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` != 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` != 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -640,8 +640,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` < 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` < 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -659,8 +659,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` <= 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` <= 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -678,8 +678,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` > 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` > 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -697,8 +697,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                         select new { contact.FirstName };
 
             const string expected =
-                "SELECT `contact`.`fname` as `FirstName` FROM `default` as `contact` " +
-                "WHERE (`contact`.`fname` >= 'M')";
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` >= 'M')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -712,9 +712,14 @@ namespace Couchbase.Linq.Tests.QueryGeneration
         [Test]
         public void StringCompare_LessThan1_ReturnsLessThanOrEqual()
         {
-            var visitor = new Mock<N1QlExpressionTreeVisitor>(new ParameterAggregator(),
-                new DefaultMethodCallTranslatorProvider(),
-                new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()))
+            var queryGenerationContext = new N1QlQueryGenerationContext()
+            {
+                MemberNameResolver =
+                    new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()),
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+            };
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(queryGenerationContext)
             {
                 CallBase = true
             };
@@ -741,9 +746,14 @@ namespace Couchbase.Linq.Tests.QueryGeneration
         [Test]
         public void StringCompare_EqualTo1_ReturnsGreaterThan()
         {
-            var visitor = new Mock<N1QlExpressionTreeVisitor>(new ParameterAggregator(),
-                new DefaultMethodCallTranslatorProvider(),
-                new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()))
+            var queryGenerationContext = new N1QlQueryGenerationContext()
+            {
+                MemberNameResolver =
+                    new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()),
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+            };
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(queryGenerationContext)
             {
                 CallBase = true
             };
@@ -770,9 +780,14 @@ namespace Couchbase.Linq.Tests.QueryGeneration
         [Test]
         public void StringCompare_GreaterThanNeg1_ReturnsGreaterThanOrEqual()
         {
-            var visitor = new Mock<N1QlExpressionTreeVisitor>(new ParameterAggregator(),
-                new DefaultMethodCallTranslatorProvider(),
-                new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()))
+            var queryGenerationContext = new N1QlQueryGenerationContext()
+            {
+                MemberNameResolver =
+                    new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()),
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+            };
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(queryGenerationContext)
             {
                 CallBase = true
             };
@@ -799,9 +814,14 @@ namespace Couchbase.Linq.Tests.QueryGeneration
         [Test]
         public void StringCompare_EqualToNeg1_ReturnsLessThan()
         {
-            var visitor = new Mock<N1QlExpressionTreeVisitor>(new ParameterAggregator(),
-                new DefaultMethodCallTranslatorProvider(),
-                new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()))
+            var queryGenerationContext = new N1QlQueryGenerationContext()
+            {
+                MemberNameResolver =
+                    new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()),
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+            };
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(queryGenerationContext)
             {
                 CallBase = true
             };

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/TakeAndSkipTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/TakeAndSkipTests.cs
@@ -20,7 +20,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {age = e.Age, name = e.FirstName})
                     .Take(30);
 
-            const string expected = "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` LIMIT 30";
+            const string expected = "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` LIMIT 30";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -38,7 +38,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => e)
                     .Skip(10);
 
-            const string expected = "SELECT `e`.* FROM `default` as `e`";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -57,7 +57,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Skip(10)
                     .Take(10);
 
-            const string expected = "SELECT `e`.* FROM `default` as `e` LIMIT 10 OFFSET 10";
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 10 OFFSET 10";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/UnaryExpressionTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/UnaryExpressionTests.cs
@@ -29,7 +29,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new { age = e.Age });
 
             const string expected =
-                "SELECT `e`.`age` as `age` FROM `default` as `e` WHERE NOT (`e`.`age` = 10)";
+                "SELECT `Extent1`.`age` as `age` FROM `default` as `Extent1` WHERE NOT (`Extent1`.`age` = 10)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -51,7 +51,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {age = -e.Age});
 
             const string expected =
-                "SELECT -`e`.`age` as `age` FROM `default` as `e`";
+                "SELECT -`Extent1`.`age` as `age` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/WhereClauseTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/WhereClauseTests.cs
@@ -23,7 +23,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {age = e.Age, name = e.FirstName});
 
             const string expected =
-                "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` WHERE ((`e`.`age` > 10) AND (`e`.`fname` = 'Sam')) ORDER BY `e`.`age` ASC";
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam')) ORDER BY `Extent1`.`age` ASC";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -44,7 +44,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {age = e.Age, name = e.FirstName});
 
             const string expected =
-                "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` WHERE (`e`.`email` = 'something@gmail.com') AND `e`.`age` IS MISSING ORDER BY `e`.`age` ASC";
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (`Extent1`.`email` = 'something@gmail.com') AND `Extent1`.`age` IS MISSING ORDER BY `Extent1`.`age` ASC";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -63,7 +63,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {age = e.Age, name = e.FirstName});
 
             const string expected =
-                "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` WHERE (((`e`.`age` > 10) AND (`e`.`fname` = 'Sam')) AND (`e`.`lname` LIKE '%a%'))";
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam')) AND (`Extent1`.`lname` LIKE '%a%'))";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -83,7 +83,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
 
 
             const string expected =
-                "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` WHERE ((`e`.`age` > 10) AND (`e`.`fname` = 'Sam'))";
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam'))";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -106,7 +106,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
 
 
             const string expected =
-                "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` WHERE ((`e`.`age` > 10) AND (`e`.`fname` = 'Sam'))";
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam'))";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -126,7 +126,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {age = e.Age, name = e.FirstName});
 
             const string expected =
-                "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` WHERE ((`e`.`age` > 10) AND (`e`.`fname` = 'Sam')) AND (`e`.`email` = 'myemail@test.com')";
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam')) AND (`Extent1`.`email` = 'myemail@test.com')";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -145,7 +145,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => new {age = e.Age, name = e.FirstName});
 
             const string expected =
-                "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` WHERE ((`e`.`age` > 10) OR (`e`.`fname` = 'Sam'))";
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` > 10) OR (`Extent1`.`fname` = 'Sam'))";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -163,7 +163,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Where(e => e.Age < 10 + 30)
                     .Select(e => new {age = e.Age, name = e.FirstName});
 
-            const string expected = "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` WHERE (`e`.`age` < 40)";
+            const string expected = "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (`Extent1`.`age` < 40)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -183,7 +183,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
 
 
             const string expected =
-                "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` WHERE (`e`.`fname` IS NULL)";
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (`Extent1`.`fname` IS NULL)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
@@ -203,7 +203,7 @@ namespace Couchbase.Linq.Tests.QueryGeneration
 
 
             const string expected =
-                "SELECT `e`.`age` as `age`, `e`.`fname` as `name` FROM `default` as `e` WHERE (`e`.`fname` IS NOT NULL)";
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (`Extent1`.`fname` IS NOT NULL)";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -110,9 +110,11 @@
     <Compile Include="QueryGeneration\MethodCallTranslators\MathMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\SubstringMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\N1QLExpressionTreeVisitor.cs" />
+    <Compile Include="QueryGeneration\N1QlExtentNameProvider.cs" />
     <Compile Include="QueryGeneration\N1QLFromQueryPart.cs" />
     <Compile Include="QueryGeneration\N1QlHelpers.cs" />
     <Compile Include="QueryGeneration\N1QLLetQueryPart.cs" />
+    <Compile Include="QueryGeneration\N1QlQueryGenerationContext.cs" />
     <Compile Include="QueryGeneration\N1QLQueryModelVisitor.cs" />
     <Compile Include="QueryGeneration\N1QLQueryType.cs" />
     <Compile Include="QueryGeneration\NamedParameter.cs" />

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlExtentNameProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlExtentNameProvider.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.Linq.QueryGeneration
+{
+    /// <summary>
+    /// Provides unique names to use in N1QL queries for each IQuerySource extent
+    /// </summary>
+    public class N1QlExtentNameProvider
+    {
+        private const string ExtentNameFormat = "Extent{0}";
+
+        private int _extentIndex = 0;
+        private readonly Dictionary<IQuerySource, string> _extentDictionary = new Dictionary<IQuerySource, string>();
+
+        /// <summary>
+        /// Provides the extent name for a given query source
+        /// </summary>
+        /// <param name="querySource">IQuerySource for which to get the extent name</param>
+        /// <returns>The unescaped extent name for the N1QL query</returns>
+        public string GetExtentName(IQuerySource querySource)
+        {
+            if (querySource == null)
+            {
+                throw new ArgumentNullException("querySource");
+            }
+
+            string extentName;
+            if (!_extentDictionary.TryGetValue(querySource, out extentName))
+            {
+                extentName = GetNextExtentName();
+
+                _extentDictionary.Add(querySource, extentName);
+            }
+
+            return extentName;
+        }
+
+        /// <summary>
+        /// Links two extents together so they share the same name
+        /// </summary>
+        /// <param name="primaryExtent">Extent to link to, which may or may not already have a name</param>
+        /// <param name="secondaryExtent">New extent to share the name of the primaryExtent</param>
+        /// <returns>
+        /// Primarily used when handling join clauses that join to subqueries.  This allows the subquery from
+        /// clause to share the same name as the join clause itself, since they are being merged into a single
+        /// join clause in the N1QL query output.
+        /// </returns>
+        public void LinkExtents(IQuerySource primaryExtent, IQuerySource secondaryExtent)
+        {
+            if (primaryExtent == null)
+            {
+                throw new ArgumentNullException("primaryExtent");
+            }
+            if (secondaryExtent == null)
+            {
+                throw new ArgumentNullException("secondaryExtent");
+            }
+
+            if (_extentDictionary.ContainsKey(secondaryExtent))
+            {
+                throw new InvalidOperationException("The given secondaryExtent has already been generated a unique extent name");
+            }
+
+            _extentDictionary.Add(secondaryExtent, GetExtentName(primaryExtent));
+        }
+
+        /// <summary>
+        /// Generates a one-time use extent name, which isn't linked to an IQuerySource
+        /// </summary>
+        /// <returns>The unescaped extent name for the N1QL query</returns>
+        public string GetUnlinkedExtentName()
+        {
+            return GetNextExtentName();
+        }
+
+        private string GetNextExtentName()
+        {
+            return string.Format(ExtentNameFormat, ++_extentIndex);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Serialization;
+
+namespace Couchbase.Linq.QueryGeneration
+{
+    /// <summary>
+    /// Used to pass query generation context between various classes
+    /// </summary>
+    public class N1QlQueryGenerationContext
+    {
+
+        public N1QlExtentNameProvider ExtentNameProvider { get; set; }
+        public IMemberNameResolver MemberNameResolver { get; set; }
+        public IMethodCallTranslatorProvider MethodCallTranslatorProvider { get; set; }
+        public ParameterAggregator ParameterAggregator { get; set; }
+
+        public N1QlQueryGenerationContext()
+        {
+            ExtentNameProvider = new N1QlExtentNameProvider();
+            ParameterAggregator = new ParameterAggregator();
+        } 
+    }
+}


### PR DESCRIPTION
Motivation
----------
The current approach of using clause ItemNames as the extent name in
queries does not guarantee uniqueness.  For more information, see
https://github.com/re-motion/Relinq/blob/develop/Core/Clauses/FromClauseBase.cs#L59.
Ensuring unique extent names is especially important when working with
subqueries, where the possibility of extent name conflicts is much higher.

Modifications
-------------
Created `N1QlExtentNameProvider` to generate and cache extent names during
the query generation process.  Extents are numbered starting with
"Extent1".

Created `N1QlQueryGenerationContext` to wrap together a `N1QlExtentNameProvider`,
`IMemberNameResolver`, `MethodCallTranslatorProvider`, and `ParameterAggregator`.
This makes it simpler to pass these context items between the
`N1QlQueryModelVisitor` and the `N1QlExpressionTreeVisitor`.

Modified all points using ItemName properties to instead use
`N1QlExtentNameProvider.GetExtentName`.  Also replaced `GetNewGenName`
with calls to `GetExtentName` and `GetUnlinkedExtentName`.

Updated query generation tests to reflect the new extent names.

Results
-------
All extents have names which are guaranteed to be unique, rather than
using the ItemName property.  All tests are passing.