### PR TITLE
Added a global TestConfiguration

### DIFF
--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -27,14 +27,8 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Map2PocoTests()
         {
-            var clientConfiguration = new ClientConfiguration
-            {
-                Servers = new List<Uri>
-                {
-                    new Uri("http://localhost:8091")
-                }
-            };
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(
+                TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -52,7 +46,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Map2PocoTests_Simple_Projections()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -70,7 +64,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Map2PocoTests_Simple_Projections_Where()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -89,7 +83,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Map2PocoTests_Simple_Projections_WhereNot()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -108,7 +102,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Map2PocoTests_Simple_Projections_Limit()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -129,7 +123,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Map2PocoTests_Simple_Projections_Meta()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -149,7 +143,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Map2PocoTests_Explain()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -166,7 +160,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Map2PocoTests_NewObjectsInArray()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -185,7 +179,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void UseKeys_SelectDocuments()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -203,7 +197,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void AnyAllTests_AnyNestedArrayWithFilter()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -222,7 +216,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void AnyAllTests_AnyOnMainDocument_ReturnsTrue()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -239,7 +233,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void AnyAllTests_AnyOnMainDocument_ReturnsFalse()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -256,7 +250,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void AnyAllTests_AllNestedArray()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -274,7 +268,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void AnyAllTests_AllNestedArrayPrefiltered()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -298,7 +292,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void AnyAllTests_AllOnMainDocument_ReturnsFalse()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -312,7 +306,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void AnyAllTests_AllOnMainDocument_ReturnsTrue()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -329,7 +323,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Map2PocoTests_Simple_Projections_TypeFilterAttribute()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -347,7 +341,7 @@ namespace Couchbase.Linq.Tests
         {
             EntityFilterManager.SetFilter(new BreweryFilter());
 
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -362,7 +356,7 @@ namespace Couchbase.Linq.Tests
 
         public void Map2PocoTests_Simple_Projections_MetaWhere()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -381,7 +375,7 @@ namespace Couchbase.Linq.Tests
 
         public void Map2PocoTests_Simple_Projections_MetaId()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -400,7 +394,7 @@ namespace Couchbase.Linq.Tests
 
         public void AnyAllTests_AnyNestedArray()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -418,7 +412,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void JoinTests_InnerJoin_Simple()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -438,7 +432,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void JoinTests_InnerJoin_SortAndFilter()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -460,7 +454,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void JoinTests_InnerJoin_Prefiltered()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -482,7 +476,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void JoinTests_LeftJoin_Simple()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -503,7 +497,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void JoinTests_LeftJoin_SortAndFilter()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -526,7 +520,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void JoinTests_LeftJoin_Prefiltered()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -549,7 +543,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void NestTests_Unnest_Simple()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -568,7 +562,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void NestTests_Unnest_Sort()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {

--- a/Src/Couchbase.Linq.Tests/BucketExtensionTests.cs
+++ b/Src/Couchbase.Linq.Tests/BucketExtensionTests.cs
@@ -17,7 +17,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Test_AnonymousType_In_Projection()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket())
                 {
@@ -40,7 +40,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Test_POCO()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket())
                 {
@@ -56,7 +56,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Test_Select_Children()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket())
                 {
@@ -72,7 +72,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Test_POCO_Basic()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {

--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="QueryGeneration\SelectTests.cs" />
     <Compile Include="QueryGeneration\TakeAndSkipTests.cs" />
     <Compile Include="QueryGeneration\WhereClauseTests.cs" />
+    <Compile Include="TestConfigurations.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\couchbase-net-client\Src\Couchbase\Couchbase.csproj">

--- a/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
@@ -47,9 +47,9 @@ namespace Couchbase.Linq.Tests
             {
                 _contractResolver = contractResolver;
             }
-
-            var config = new ClientConfiguration();
-            config.Servers.Add(new Uri("http://127.0.0.1:8091"));
+            var config = TestConfigurations.DefaultConfig();
+            //var config = new ClientConfiguration();
+            //config.Servers.Add(new Uri("http://127.0.0.1:8091"));
             config.DeserializationSettings.ContractResolver = _contractResolver;
             config.SerializationSettings.ContractResolver = _contractResolver;
             ClusterHelper.Initialize(config);

--- a/Src/Couchbase.Linq.Tests/TestConfigurations.cs
+++ b/Src/Couchbase.Linq.Tests/TestConfigurations.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Configuration.Client;
+
+namespace Couchbase.Linq.Tests
+{
+    public class TestConfigurations
+    {
+        public static ClientConfiguration DefaultConfig()
+        {
+            return DefaultLocalhostConfig();
+        }
+
+        private static ClientConfiguration DefaultLocalhostConfig()
+        {
+            return new ClientConfiguration();
+        }
+    }
+}


### PR DESCRIPTION
Motivation
--------------
A global configuration class provides a single point for configuration; changing environments between localhost and distributed cluster for example are easy to do.

Modifications
----------------
Added a global TestConfiguration class to be used by all integration tests and updated all tests to use this class. Single point of configuration.

