### PR TITLE
 LINQ-8: Add DbContext like type for abstracting the datastore

### DIFF
--- a/Src/Couchbase.Linq.Tests/App.config
+++ b/Src/Couchbase.Linq.Tests/App.config
@@ -6,8 +6,21 @@
       <section name="logging" type="Common.Logging.ConfigurationSectionHandler, Common.Logging" />
     </sectionGroup>
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+    <sectionGroup name="couchbaseClients">
+      <section name="couchbase" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+    </sectionGroup>
   </configSections>
-
+  <couchbaseClients>
+  <couchbase enableConfigHeartBeat="false">
+      <servers>
+        <!-- changes in appSettings section should also be reflected here -->
+        <add uri="http://192.168.76.101:8091"></add>
+      </servers>
+      <buckets>
+        <add></add>
+      </buckets>
+    </couchbase>
+  </couchbaseClients>
   <common>
     <logging>
       <!--<factoryAdapter type="Common.Logging.Log4Net.Log4NetLoggerFactoryAdapter, Common.Logging.Log4Net">

--- a/Src/Couchbase.Linq.Tests/BeerSample.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSample.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using Couchbase.Configuration.Client;
+using Couchbase.Core;
+using Couchbase.Linq.Filters;
+
+using Couchbase.Linq.Tests.Documents;
+
+namespace Couchbase.Linq.Tests
+{
+    /// <summary>
+    /// A concrete DbContext for the beer-sample example bucket.
+    /// </summary>
+    public class BeerSample : DbContext
+    {
+        /// <exception cref="InitializationException">Thrown if ClusterHelper.Initialize is not called before accessing this method.</exception>
+        public BeerSample() : this(ClusterHelper.Get())
+        {
+        }
+
+        public BeerSample(Cluster cluster) : base(cluster, "beer-sample")
+        {
+            //Two ways of applying a filter are included in this example.
+            //This is by implementing IEntityFilter and then adding explicitly.
+            //adding it to the EntityFilterManager
+            EntityFilterManager.SetFilter(new BreweryFilter());
+        }
+
+        public IQueryable<BeerFiltered> Beers
+        {
+            //This is an example of adding a filter declaratively by using an atribute
+            //to your entity. If you check out BeerFiltered clas you will see the EntityTypeFilter
+            //has been added to the class definition.
+            get { return Query<BeerFiltered>(); }
+        }
+
+        public IQueryable<Brewery> Breweries
+        {
+            get { return Query<Brewery>(); }
+        }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -178,6 +178,24 @@ namespace Couchbase.Linq.Tests
         }
 
         [Test]
+        public void UseKeys_SelectDocuments()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var query = from brewery in bucket.Queryable<Brewery>().UseKeys(new[] { "21st_amendment_brewery_cafe", "357" })
+                                select new { name = brewery.Name };
+
+                    foreach (var brewery in query)
+                    {
+                        Console.WriteLine("Brewery {0}", brewery.name);
+                    }
+                }
+            }
+        }
+
+        [Test]
         public void AnyAllTests_AnyNestedArrayWithFilter()
         {
             using (var cluster = new Cluster())

--- a/Src/Couchbase.Linq.Tests/Clauses/UseKeysClauseTests.cs
+++ b/Src/Couchbase.Linq.Tests/Clauses/UseKeysClauseTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Metadata;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.Tests.Clauses
+{
+    /// <summary>
+    /// Tests related to the UseKeys clause
+    /// </summary>
+    [TestFixture]
+    public class UseKeysClauseTests
+    {
+        [Test]
+        public void UseKeys_IEnumerableEmulation()
+        {
+            var items = new[]
+            {
+                new Item {Key = "item1"},
+                new Item {Key = "item2"},
+                new Item {Key = "item3"},
+                new Item {Key = "item4"}
+            };
+
+            var result = items
+                .UseKeys(new[] { "item1", "item3"})
+                .OrderBy(p => p.Key)
+                .ToArray();
+
+            Assert.AreEqual(2, result.Length);
+            Assert.AreEqual("item1", result[0].Key);
+            Assert.AreEqual("item3", result[1].Key);
+        }
+
+        [Test]
+        public void UseKeys_IEnumerableAsQueryable()
+        {
+            // This test is important for consumers who may use UseKeys clauses in their unit testing
+            // If they are using .AsQueryable() to convert a simple list or array to IQueryable
+            // Then we need to ensure that it is properly handled by the EnumerableQuery<T> LINQ implementation
+
+            var items = new[]
+            {
+                new Item {Key = "item1"},
+                new Item {Key = "item2"},
+                new Item {Key = "item3"},
+                new Item {Key = "item4"}
+            };
+
+            var result = items
+                .AsQueryable()
+                .UseKeys(new[] { "item1", "item3" })
+                .OrderBy(p => p.Key)
+                .ToArray();
+
+            Assert.AreEqual(2, result.Length);
+            Assert.AreEqual("item1", result[0].Key);
+            Assert.AreEqual("item3", result[1].Key);
+        }
+
+        #region Helper Classes
+
+        private class Item : IDocumentMetadataProvider
+        {
+            public string Key { get; set; }
+
+            public DocumentMetadata GetMetadata()
+            {
+                return new DocumentMetadata() { Id = Key };
+            }
+        }
+
+        #endregion
+
+    }
+}

--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -72,6 +72,7 @@
       <HintPath>..\packages\Remotion.Linq.1.15.15.0\lib\portable-net45+wp80+wpa81+win\Remotion.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
@@ -82,10 +83,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BeerSample.cs" />
     <Compile Include="BeerSampleTests.cs" />
     <Compile Include="BucketExtensionTests.cs" />
     <Compile Include="Clauses\NestClauseTests.cs" />
     <Compile Include="Clauses\UseKeysClauseTests.cs" />
+    <Compile Include="DbContextTests.cs" />
     <Compile Include="Documents\Airline.cs" />
     <Compile Include="Documents\BeerFiltered.cs" />
     <Compile Include="Documents\Beer.cs" />
@@ -118,6 +121,7 @@
     <Compile Include="QueryGeneration\SelectTests.cs" />
     <Compile Include="QueryGeneration\TakeAndSkipTests.cs" />
     <Compile Include="QueryGeneration\WhereClauseTests.cs" />
+    <Compile Include="TestConfigurations.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\couchbase-net-client\Src\Couchbase\Couchbase.csproj">

--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="BeerSampleTests.cs" />
     <Compile Include="BucketExtensionTests.cs" />
     <Compile Include="Clauses\NestClauseTests.cs" />
+    <Compile Include="Clauses\UseKeysClauseTests.cs" />
     <Compile Include="Documents\Airline.cs" />
     <Compile Include="Documents\BeerFiltered.cs" />
     <Compile Include="Documents\Beer.cs" />

--- a/Src/Couchbase.Linq.Tests/DbContextTests.cs
+++ b/Src/Couchbase.Linq.Tests/DbContextTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Linq;
+using Couchbase.Core;
+using Couchbase.Linq.Tests.Documents;
+using Couchbase.N1QL;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.Tests
+{
+    [TestFixture]
+    public class DbContextTests
+    {
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            ClusterHelper.Initialize(TestConfigurations.DefaultConfig());
+        }
+
+
+        [Test]
+        public void Test_Basic_Query()
+        {
+            var db = new DbContext(ClusterHelper.Get(), "beer-sample");
+            var query = from x in db.Query<Beer>()
+                where x.Type == "beer"
+                select x;
+
+            foreach (var beer in query)
+            {
+                Console.WriteLine(beer.Name);
+            }
+        }
+
+        /// <exception cref="InitializationException">Thrown if Initialize is not called before accessing this method.</exception>
+        [Test]
+        public void BeerSampleContext_Tests()
+        {
+            var db = new BeerSample();
+            var beers = from b in db.Beers
+                select b;
+
+            foreach (var beer in beers)
+            {
+                Console.WriteLine(beer.Name);
+            }
+        }
+
+        /// <exception cref="InitializationException">Thrown if Initialize is not called before accessing this method.</exception>
+        [Test]
+        public void BeerSample_Tests()
+        {
+            var db = new BeerSample();
+            var query = from beer in db.Beers
+                        join brewery in db.Breweries
+                        on beer.BreweryId equals N1Ql.Key(brewery)
+                        select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
+
+            foreach (var beer in query)
+            {
+                Console.WriteLine(beer.Name);
+            }
+        }
+    }
+
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/SelectTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/SelectTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Couchbase.Core;
+using Couchbase.Linq.Extensions;
 using Couchbase.Linq.Tests.Documents;
 using Moq;
 using NUnit.Framework;
@@ -37,6 +38,24 @@ namespace Couchbase.Linq.Tests.QueryGeneration
                     .Select(e => e);
 
             const string expected = "SELECT e.* FROM default as e";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Select_UseKeys()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                    .UseKeys(new[] { "abc", "def" })
+                    .Select(e => e);
+
+            const string expected = "SELECT `<generated>_1`.* FROM default as `<generated>_1` USE KEYS ['abc', 'def']";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.Tests/TestConfigurations.cs
+++ b/Src/Couchbase.Linq.Tests/TestConfigurations.cs
@@ -1,0 +1,20 @@
+using System.Configuration;
+using Couchbase.Configuration.Client;
+using Couchbase.Configuration.Client.Providers;
+
+namespace Couchbase.Linq.Tests
+{
+    public class TestConfigurations
+    {
+        public static ClientConfiguration DefaultConfig()
+        {
+            return DefaultLocalhostConfig();
+        }
+
+        private static ClientConfiguration DefaultLocalhostConfig()
+        {
+            var section = (CouchbaseClientSection)ConfigurationManager.GetSection("couchbaseClients/couchbase");
+            return new ClientConfiguration(section);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/UseKeysClause.cs
+++ b/Src/Couchbase.Linq/Clauses/UseKeysClause.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Linq.Expressions;
+using Couchbase.Linq.QueryGeneration;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.Linq.Clauses
+{
+    public class UseKeysClause : IBodyClause
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="UseKeysClause" /> class.
+        /// </summary>
+        /// <param name="keys">Expression used to get the keys from each item in the outer sequence</param>
+        public UseKeysClause(Expression keys)
+        {
+            Keys = keys;
+        }
+
+        /// <summary>
+        ///     Gets the expression used to get the keys being selected
+        /// </summary>
+        public Expression Keys { get; set; }
+
+        /// <summary>
+        ///     Accepts the specified visitor
+        /// </summary>
+        /// <param name="visitor">The visitor to accept.</param>
+        /// <param name="queryModel">The query model in whose context this clause is visited.</param>
+        /// <param name="index">
+        ///     The index of this clause in the <paramref name="queryModel" />'s
+        ///     <see cref="QueryModel.BodyClauses" /> collection.
+        /// </param>
+        public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
+        {
+            var visotorx = visitor as IN1QlQueryModelVisitor;
+            if (visotorx != null) visotorx.VisitUseKeysClause(this, queryModel, index);
+        }
+
+        /// <summary>
+        ///     Transforms all the expressions in this clause and its child objects via the given
+        ///     <paramref name="transformation" /> delegate.
+        /// </summary>
+        /// <param name="transformation">
+        ///     The transformation object. This delegate is called for each <see cref="Expression" /> within this
+        ///     clause, and those expressions will be replaced with what the delegate returns.
+        /// </param>
+        public void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+            Keys = transformation(Keys);
+        }
+
+        IBodyClause IBodyClause.Clone(CloneContext cloneContext)
+        {
+            return Clone(cloneContext);
+        }
+
+        /// <summary>
+        ///     Clones this clause.
+        /// </summary>
+        /// <param name="cloneContext">The clones of all query source clauses are registered with this <see cref="CloneContext" />.</param>
+        /// <returns></returns>
+        public virtual UseKeysClause Clone(CloneContext cloneContext)
+        {
+            var clone = new UseKeysClause(Keys);
+            return clone;
+        }
+
+        public override string ToString()
+        {
+            return String.Format("use keys {0}", Keys);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/UseKeysExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/UseKeysExpressionNode.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    public class UseKeysExpressionNode : MethodCallExpressionNodeBase
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+        {
+            GetSupportedMethod(() => QueryExtensions.UseKeys<object>(null, null))
+        };
+
+        public UseKeysExpressionNode(MethodCallExpressionParseInfo parseInfo, Expression keys)
+            : base(parseInfo)
+        {
+            if (keys == null)
+            {
+                throw new ArgumentNullException("keys");
+            }
+
+            Keys = keys;
+        }
+
+        public Expression Keys { get; private set; }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override QueryModel ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            queryModel.BodyClauses.Add(new UseKeysClause(Keys));
+
+            return queryModel;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -62,6 +62,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Clauses\UseKeysExpressionNode.cs" />
+    <Compile Include="Clauses\UseKeysClause.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="QueryGeneration\Expressions\StringComparisonExpression.cs" />
     <Compile Include="QueryGeneration\IN1QlQueryModelVisitor.cs" />

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -64,7 +64,9 @@
   <ItemGroup>
     <Compile Include="Clauses\UseKeysExpressionNode.cs" />
     <Compile Include="Clauses\UseKeysClause.cs" />
+    <Compile Include="DbContext.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
+    <Compile Include="IDbContext.cs" />
     <Compile Include="QueryGeneration\Expressions\StringComparisonExpression.cs" />
     <Compile Include="QueryGeneration\IN1QlQueryModelVisitor.cs" />
     <Compile Include="Clauses\NestClause.cs" />

--- a/Src/Couchbase.Linq/DbContext.cs
+++ b/Src/Couchbase.Linq/DbContext.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using Couchbase.Configuration.Client;
+using Couchbase.Core;
+using Couchbase.Linq.Filters;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Provides a single point of entry to a Couchbase bucket which makes it easier to compose
+    /// and execute queries and to group togather changes which will be submitted back into the bucket.
+    /// </summary>
+    public class DbContext : IDbContext
+    {
+        private readonly IBucket _bucket;
+        protected BucketConfiguration BucketConfig;
+
+        public DbContext(Cluster cluster, string bucketName)
+            : this(cluster, bucketName, string.Empty)
+        {
+        }
+
+        public DbContext(Cluster cluster, string bucketName, string password)
+        {
+            Cluster = cluster;
+            Configuration = Cluster.Configuration;
+            _bucket = Cluster.OpenBucket(bucketName, password);
+        }
+
+        /// <summary>
+        /// Gets a reference to the <see cref="Cluster" /> that the <see cref="IDbContext" /> is using.
+        /// </summary>
+        /// <value>
+        /// The cluster.
+        /// </value>
+        public ICluster Cluster { get; protected set; }
+
+        /// <summary>
+        /// Gets the configuration for the current <see cref="Cluster" />.
+        /// </summary>
+        /// <value>
+        /// The configuration.
+        /// </value>
+        public ClientConfiguration Configuration { get; protected set; }
+
+        /// <summary>
+        /// Queries the current <see cref="IBucket" /> for entities of type <see cref="T" />. This is the target of
+        /// the Linq query requires that the associated JSON document have a type property that is the same as <see cref="T" />.
+        /// </summary>
+        /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
+        /// <returns></returns>
+        public IQueryable<T> Query<T>()
+        {
+            return EntityFilterManager.ApplyFilters(new BucketQueryable<T>(_bucket));
+        }
+
+        /// <summary>
+        /// Gets the name of the <see cref="IBucket"/>.
+        /// </summary>
+        /// <value>
+        /// The name of the bucket.
+        /// </value>
+        public string BucketName
+        {
+            get { return _bucket.Name; }
+        }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
@@ -11,6 +11,9 @@ namespace Couchbase.Linq.Extensions
 {
     public static class EnumerableExtensions
     {
+
+        #region Nest
+
         /// <summary>
         ///     Emulates Nest for N1QL against an IEnumerable
         /// </summary>
@@ -121,5 +124,34 @@ namespace Couchbase.Linq.Extensions
                 })
                 .Where(p => p != null); // Filter out any null results returned due to inner nest or a null from the resultSelector
         }
+
+        #endregion
+
+        #region UseKeys
+
+        /// <summary>
+        ///     Emulates UseKeys for N1QL against an IEnumerable
+        /// </summary>
+        /// <typeparam name="T">Type of the source sequence</typeparam>
+        /// <param name="items">Items being filtered</param>
+        /// <param name="keys">Keys to be selected</param>
+        /// <returns></returns>
+        public static IEnumerable<T> UseKeys<T>(
+            this IEnumerable<T> items, IEnumerable<string> keys) where T : IDocumentMetadataProvider
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException("items");
+            }
+            if (keys == null)
+            {
+                throw new ArgumentNullException("keys");
+            }
+
+            return items.Where(p => keys.Contains(N1Ql.Key(p)));
+        }
+
+        #endregion
+
     }
 }

--- a/Src/Couchbase.Linq/Filters/EntityTypeFilterAttribute.cs
+++ b/Src/Couchbase.Linq/Filters/EntityTypeFilterAttribute.cs
@@ -38,7 +38,7 @@ namespace Couchbase.Linq.Filters
         private Expression<Func<T, bool>> GetExpression<T>()
         {
             var parameter = Expression.Parameter(typeof (T), "p");
-            
+
             return Expression.Lambda<Func<T, bool>>(Expression.Equal(Expression.PropertyOrField(parameter, "type"), Expression.Constant(Type)), parameter);
         }
 
@@ -52,6 +52,5 @@ namespace Couchbase.Linq.Filters
                 return source.Where(WhereExpression);
             }
         }
-
     }
 }

--- a/Src/Couchbase.Linq/Filters/IEntityFilterSetGenerator.cs
+++ b/Src/Couchbase.Linq/Filters/IEntityFilterSetGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿    using System;
 
 namespace Couchbase.Linq.Filters
 {

--- a/Src/Couchbase.Linq/IBucketQueryable.cs
+++ b/Src/Couchbase.Linq/IBucketQueryable.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Used to provide the bucket name to the query generator
     /// </summary>
-    interface IBucketQueryable
+    public interface IBucketQueryable
     {
         string BucketName { get; }
     }

--- a/Src/Couchbase.Linq/IDbContext.cs
+++ b/Src/Couchbase.Linq/IDbContext.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using Couchbase.Configuration.Client;
+using Couchbase.Core;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Provides a single point of entry to a Couchbase bucket which makes it easier to compose
+    /// and execute queries and to group togather changes which will be submitted back into the bucket.
+    /// </summary>
+    public interface IDbContext : IBucketQueryable
+    {
+        /// <summary>
+        /// Gets a reference to the <see cref="Cluster"/> that the <see cref="IDbContext"/> is using.
+        /// </summary>
+        /// <value>
+        /// The cluster.
+        /// </value>
+        ICluster Cluster { get; }
+
+        /// <summary>
+        /// Gets the configuration for the current <see cref="Cluster"/>.
+        /// </summary>
+        /// <value>
+        /// The configuration.
+        /// </value>
+        ClientConfiguration Configuration { get; }
+
+        /// <summary>
+        /// Queries the current <see cref="IBucket"/> for entities of type <see cref="T"/>. This is the target of
+        /// the Linq query requires that the associated JSON document have a type property that is the same as <see cref="T"/>.
+        /// </summary>
+        /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
+        /// <returns></returns>
+        IQueryable<T> Query<T>();
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
@@ -12,6 +12,9 @@ namespace Couchbase.Linq.QueryGeneration
     public interface IN1QlQueryModelVisitor : IQueryModelVisitor
     {
         void VisitNestClause(NestClause clause, QueryModel queryModel, int index);
+
+        void VisitUseKeysClause(UseKeysClause clause, QueryModel queryModel, int index);
+
         void VisitWhereMissingClause(WhereMissingClause clause, QueryModel queryModel, int index);
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -88,6 +88,11 @@ namespace Couchbase.Linq.QueryGeneration
             base.VisitMainFromClause(fromClause, queryModel);
         }
 
+        public virtual void VisitUseKeysClause(UseKeysClause clause, QueryModel queryModel, int index)
+        {
+            _queryPartsAggregator.AddUseKeysPart(GetN1QlExpression(clause.Keys));
+        }
+
         public override void VisitSelectClause(SelectClause selectClause, QueryModel queryModel)
         {
             _queryPartsAggregator.SelectPart = GetSelectParameters(selectClause, queryModel);

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -21,6 +21,7 @@ namespace Couchbase.Linq.QueryGeneration
 
         public string SelectPart { get; set; }
         public List<N1QlFromQueryPart> FromParts { get; set; }
+        public string UseKeysPart { get; set; }
         public List<N1QlLetQueryPart> LetParts { get; set; } 
         public List<string> WhereParts { get; set; }
         public List<string> OrderByParts { get; set; }
@@ -52,6 +53,16 @@ namespace Couchbase.Linq.QueryGeneration
         public void AddFromPart(N1QlFromQueryPart fromPart)
         {
             FromParts.Add(fromPart);
+        }
+
+        public void AddUseKeysPart(string useKeysPart)
+        {
+            if (!string.IsNullOrEmpty(UseKeysPart))
+            {
+                throw new InvalidOperationException("AddUseKeysPart May Only Be Called Once");
+            }
+
+            UseKeysPart = useKeysPart;
         }
 
         public void AddLetPart(N1QlLetQueryPart letPart)
@@ -102,6 +113,11 @@ namespace Couchbase.Linq.QueryGeneration
                 sb.AppendFormat(" FROM {0} as {1}",
                     mainFrom.Source,
                     mainFrom.ItemName);
+
+                if (!string.IsNullOrEmpty(UseKeysPart))
+                {
+                    sb.AppendFormat(" USE KEYS {0}", UseKeysPart);
+                }
 
                 foreach (var joinPart in FromParts.Skip(1))
                 {
@@ -156,6 +172,11 @@ namespace Couchbase.Linq.QueryGeneration
                 sb.AppendFormat(" FROM {0} as {1}",
                     mainFrom.Source,
                     mainFrom.ItemName);
+
+                if (!string.IsNullOrEmpty(UseKeysPart))
+                {
+                    sb.AppendFormat(" USE KEYS {0}", UseKeysPart);
+                }
 
                 foreach (var joinPart in FromParts.Skip(1))
                 {

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -26,6 +26,10 @@ namespace Couchbase.Linq
             customNodeTypeRegistry.Register(ExplainExpressionNode.SupportedMethods,
                 typeof(ExplainExpressionNode));
 
+            //register the "UseKeys" expression node parser
+            customNodeTypeRegistry.Register(UseKeysExpressionNode.SupportedMethods,
+                typeof(UseKeysExpressionNode));
+
             //This creates all the default node types
             var nodeTypeProvider = ExpressionTreeParser.CreateDefaultNodeTypeProvider();
 


### PR DESCRIPTION
Motivation
----------
Linq2SQL and EntityFramework have the concept of a "db context" object
which aggregates changes, makes it easier to compose queries and provides
an abstraction of the persistence store.

Modifications
-------------
Added a DbContext class and a concrete example that abstracts the
beer-sample bucket and provides strongly typed properties for the document
types in that bucket.

Results
-------
There is a now a higher level object for interacting with a bucket. It's
possible to inherit from this context object with a concrete
representations. Expect things like change tracking and tooling in future
commits. Also, expect the interface and DbContext to change quite a bit in future
releases especially around construction/destruction.