### PR TITLE
Change dependency on Couchbase project to Couchbase NuGet package

### DIFF
--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -54,6 +54,10 @@
     <Reference Include="Common.Logging.Log4Net1213">
       <HintPath>..\packages\Common.Logging.Log4Net1213.3.1.0\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
     </Reference>
+    <Reference Include="Couchbase.NetClient, Version=2.1.4.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\CouchbaseNetClient.2.1.4\lib\net45\Couchbase.NetClient.dll</HintPath>
+    </Reference>
     <Reference Include="log4net">
       <HintPath>..\packages\log4net.2.0.0\lib\net40-full\log4net.dll</HintPath>
     </Reference>
@@ -125,10 +129,6 @@
     <Compile Include="TestConfigurations.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\couchbase-net-client\Src\Couchbase\Couchbase.csproj">
-      <Project>{244eb9c8-8bcb-421d-a6dc-d54dceb206e8}</Project>
-      <Name>Couchbase</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Couchbase.Linq\Couchbase.Linq.csproj">
       <Project>{c0254649-0162-47a4-b3d3-354e0b3ff7d0}</Project>
       <Name>Couchbase.Linq</Name>

--- a/Src/Couchbase.Linq.Tests/packages.config
+++ b/Src/Couchbase.Linq.Tests/packages.config
@@ -4,6 +4,7 @@
   <package id="Common.Logging" version="3.1.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.1.0" targetFramework="net45" />
   <package id="Common.Logging.Log4Net1213" version="3.1.0" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.1.4" targetFramework="net45" />
   <package id="log4net" version="2.0.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1409.1722" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -45,6 +45,10 @@
     <Reference Include="Common.Logging.Core">
       <HintPath>..\packages\Common.Logging.Core.3.1.0\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Couchbase.NetClient, Version=2.1.4.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\CouchbaseNetClient.2.1.4\lib\net45\Couchbase.NetClient.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -131,12 +135,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\couchbase-net-client\Src\Couchbase\Couchbase.csproj">
-      <Project>{244eb9c8-8bcb-421d-a6dc-d54dceb206e8}</Project>
-      <Name>Couchbase</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Src/Couchbase.Linq/packages.config
+++ b/Src/Couchbase.Linq/packages.config
@@ -3,6 +3,7 @@
 <packages>
   <package id="Common.Logging" version="3.1.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.1.0" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.1.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Remotion.Linq" version="1.15.15.0" targetFramework="net45" />
 </packages>

--- a/Src/couchbase-net-linq.sln
+++ b/Src/couchbase-net-linq.sln
@@ -9,17 +9,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Couchbase.Linq.Tests", "Cou
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Couchbase.Linq.Views", "Couchbase.Linq.Views\Couchbase.Linq.Views.csproj", "{6F80608B-2EB5-4EF1-9D77-A2033ADC84AB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Couchbase", "..\..\couchbase-net-client\Src\Couchbase\Couchbase.csproj", "{244EB9C8-8BCB-421D-A6DC-D54DCEB206E8}"
-<<<<<<< HEAD
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{A7E95B2F-7D09-4DBA-A877-EBDB026776CC}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
-=======
->>>>>>> 4c2d3092979e899c241c9339c06144b8fb2f5a5d
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,10 +34,6 @@ Global
 		{6F80608B-2EB5-4EF1-9D77-A2033ADC84AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F80608B-2EB5-4EF1-9D77-A2033ADC84AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F80608B-2EB5-4EF1-9D77-A2033ADC84AB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{244EB9C8-8BCB-421D-A6DC-D54DCEB206E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{244EB9C8-8BCB-421D-A6DC-D54DCEB206E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{244EB9C8-8BCB-421D-A6DC-D54DCEB206E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{244EB9C8-8BCB-421D-A6DC-D54DCEB206E8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Motivation
-------------
We want NuGet to resolve dependencies on the Couchbase .NET SDK, not via Visual Studio references to the project.

Modifications
-----------------
In preparation for Developer Preview, remove reference to Couchbase project and change to NuGet for Couchbase .NET SDK dependency.

