### PR TITLE
Support for GROUP BY, HAVING, and aggregates

### DIFF
--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -656,7 +656,7 @@ namespace Couchbase.Linq.Tests
         [Test()]
         public void AggregateTests_SimpleAverage()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -670,7 +670,7 @@ namespace Couchbase.Linq.Tests
         [Test()]
         public void AggregateTests_SimpleCount()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -684,7 +684,7 @@ namespace Couchbase.Linq.Tests
         [Test()]
         public void AggregateTests_GroupBy()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -707,7 +707,7 @@ namespace Couchbase.Linq.Tests
         [Test()]
         public void AggregateTests_Having()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -731,7 +731,7 @@ namespace Couchbase.Linq.Tests
         [Test()]
         public void AggregateTests_OrderByAggregate()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {
@@ -754,7 +754,7 @@ namespace Couchbase.Linq.Tests
         [Test()]
         public void AggregateTests_JoinBeforeGroupByAndMultipartKey()
         {
-            using (var cluster = new Cluster())
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
             {
                 using (var bucket = cluster.OpenBucket("beer-sample"))
                 {

--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -652,5 +652,126 @@ namespace Couchbase.Linq.Tests
                 }
             }
         }
+
+        [Test()]
+        public void AggregateTests_SimpleAverage()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var avg = bucket.Queryable<Beer>().Where(p => p.Type == "beer" && N1Ql.IsValued(p.Abv)).Average(p => p.Abv);
+
+                    Console.WriteLine("Average ABV of all beers is {0}", avg);
+                }
+            }
+        }
+
+        [Test()]
+        public void AggregateTests_SimpleCount()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var count = bucket.Queryable<Beer>().Count(p => p.Type == "beer");
+
+                    Console.WriteLine("Number of beers is {0}", count);
+                }
+            }
+        }
+
+        [Test()]
+        public void AggregateTests_GroupBy()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var breweries =
+                        from beer in bucket.Queryable<Beer>()
+                        where beer.Type == "beer"
+                        group beer by beer.BreweryId
+                        into g
+                        orderby g.Key
+                        select new { breweryid = g.Key, count = g.Count(), avgAbv = g.Average(p => p.Abv)};
+
+                    foreach (var brewery in breweries)
+                    {
+                        Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryid, brewery.count, brewery.avgAbv);
+                    }
+                }
+            }
+        }
+
+        [Test()]
+        public void AggregateTests_Having()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var breweries =
+                        from beer in bucket.Queryable<Beer>()
+                        where beer.Type == "beer"
+                        group beer by beer.BreweryId
+                        into g
+                        where g.Count() >= 5
+                        orderby g.Key
+                        select new { breweryid = g.Key, count = g.Count(), avgAbv = g.Average(p => p.Abv) };
+
+                    foreach (var brewery in breweries)
+                    {
+                        Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryid, brewery.count, brewery.avgAbv);
+                    }
+                }
+            }
+        }
+
+        [Test()]
+        public void AggregateTests_OrderByAggregate()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var breweries =
+                        from beer in bucket.Queryable<Beer>()
+                        where beer.Type == "beer"
+                        group beer by beer.BreweryId
+                        into g
+                        orderby g.Count() descending 
+                        select new { breweryid = g.Key, count = g.Count(), avgAbv = g.Average(p => p.Abv) };
+
+                    foreach (var brewery in breweries)
+                    {
+                        Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryid, brewery.count, brewery.avgAbv);
+                    }
+                }
+            }
+        }
+
+        [Test()]
+        public void AggregateTests_JoinBeforeGroupByAndMultipartKey()
+        {
+            using (var cluster = new Cluster())
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var breweries =
+                        from beer in bucket.Queryable<Beer>()
+                        join brewery in bucket.Queryable<Brewery>() on beer.BreweryId equals N1Ql.Key(brewery)
+                        where beer.Type == "beer"
+                        group beer by new { breweryid = beer.BreweryId, breweryName = brewery.Name }
+                        into g
+                        select new { g.Key.breweryName, count = g.Count(), avgAbv = g.Average(p => p.Abv) };
+
+                    foreach (var brewery in breweries)
+                    {
+                        Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryName, brewery.count, brewery.avgAbv);
+                    }
+                }
+            }
+        }
     }
 }

--- a/Src/Couchbase.Linq.Tests/BucketQueryExecutorEmulator.cs
+++ b/Src/Couchbase.Linq.Tests/BucketQueryExecutorEmulator.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Couchbase.Core;
+using Couchbase.Linq.QueryGeneration;
+using Remotion.Linq;
+
+namespace Couchbase.Linq.Tests
+{
+    /// <summary>
+    /// Used to test query generation for result operators that always execute the query immediately.
+    /// This class fakes the result (always returns null or an empty list), but stores the query that was 
+    /// generated in the Query property.
+    /// </summary>
+    public class BucketQueryExecutorEmulator : IQueryExecutor
+    {
+        private readonly N1QLTestBase _test;
+        public N1QLTestBase Test
+        {
+            get { return _test; }
+        }
+
+        private string _query;
+        public string Query
+        {
+            get { return _query; }
+        }
+
+        public BucketQueryExecutorEmulator(N1QLTestBase test)
+        {
+            if (test == null)
+            {
+                throw new ArgumentNullException("test");
+            }
+
+            _test = test;
+        }
+
+        public IEnumerable<T> ExecuteCollection<T>(QueryModel queryModel)
+        {
+            _query = ExecuteCollection(queryModel);
+
+            return new T[] {};
+        }
+
+        public T ExecuteScalar<T>(QueryModel queryModel)
+        {
+            ExecuteCollection<T>(queryModel);
+            return default(T);
+        }
+
+        public T ExecuteSingle<T>(QueryModel queryModel, bool returnDefaultWhenEmpty)
+        {
+            ExecuteCollection<T>(queryModel);
+            return default(T);
+        }
+
+        public string ExecuteCollection(QueryModel queryModel)
+        {
+            var queryGenerationContext = new N1QlQueryGenerationContext()
+            {
+                MemberNameResolver = new JsonNetMemberNameResolver(Test.ContractResolver),
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+            };
+
+            var visitor = new N1QlQueryModelVisitor(queryGenerationContext);
+            visitor.VisitQueryModel(queryModel);
+            return visitor.GetQuery();
+        }
+    }
+}

--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -107,6 +107,8 @@
     <Compile Include="N1QLTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueryGeneration\ArrayIndexTests.cs" />
+    <Compile Include="QueryGeneration\AggregateTests.cs" />
+    <Compile Include="BucketQueryExecutorEmulator.cs" />
     <Compile Include="QueryGeneration\N1QlHelpersTests.cs" />
     <Compile Include="QueryGeneration\NestTests.cs" />
     <Compile Include="QueryGeneration\ConditionalExpressionTests.cs" />

--- a/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Linq;
 using System.Linq.Expressions;
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
 using Couchbase.Linq.QueryGeneration;
+using Moq;
 using Newtonsoft.Json.Serialization;
+using Remotion.Linq;
 
 namespace Couchbase.Linq.Tests
 {
@@ -11,10 +14,28 @@ namespace Couchbase.Linq.Tests
     public class N1QLTestBase
     {
         private IContractResolver _contractResolver = new DefaultContractResolver();
+        public IContractResolver ContractResolver
+        {
+            get { return _contractResolver; }
+        }
 
         protected virtual bool IsClusterRequired
         {
             get { return false; }
+        }
+
+        private BucketQueryExecutorEmulator _queryExecutor;
+        protected virtual BucketQueryExecutorEmulator QueryExecutor
+        {
+            get
+            {
+                if (_queryExecutor == null)
+                {
+                    _queryExecutor = new BucketQueryExecutorEmulator(this);
+                }
+
+                return _queryExecutor;
+            }
         }
 
         public N1QLTestBase()
@@ -39,6 +60,15 @@ namespace Couchbase.Linq.Tests
             var visitor = new N1QlQueryModelVisitor(queryGenerationContext);
             visitor.VisitQueryModel(queryModel);
             return visitor.GetQuery();
+        }
+
+        protected virtual IQueryable<T> CreateQueryable<T>(string bucketName)
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns(bucketName);
+
+            return new BucketQueryable<T>(mockBucket.Object, 
+                QueryParserHelper.CreateQueryParser(), QueryExecutor);
         }
 
         protected void InitializeCluster(IContractResolver contractResolver = null)

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/AggregateTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/AggregateTests.cs
@@ -1,0 +1,358 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Core;
+using Couchbase.Linq.Tests.Documents;
+using Moq;
+using NUnit.Framework;
+
+// ReSharper disable StringCompareIsCultureSpecific.1
+// ReSharper disable StringCompareToIsCultureSpecific
+// ReSharper disable StringIndexOfIsCultureSpecific.1
+namespace Couchbase.Linq.Tests.QueryGeneration
+{
+    [TestFixture]
+    class AggregateTests : N1QLTestBase
+    {
+
+        #region Simple Aggregates
+
+        [Test]
+        public void Test_Avg()
+        {
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Beer>("default").Average(p => p.Abv);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT AVG(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Count()
+        {
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Beer>("default").Count();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT COUNT(*) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_CountProperty()
+        {
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Beer>("default").Select(p => p.Name).Count();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT COUNT(`Extent1`.`name`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_CountDistinct()
+        {
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Beer>("default").Select(p => p.Name).Distinct().Count();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT COUNT(DISTINCT `Extent1`.`name`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_LongCount()
+        {
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Beer>("default").LongCount();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT COUNT(*) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Min()
+        {
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Beer>("default").Min(p => p.Abv);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT MIN(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Max()
+        {
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Beer>("default").Max(p => p.Abv);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT MAX(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Sum()
+        {
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Beer>("default").Sum(p => p.Abv);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT SUM(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
+        #region "Group By"
+
+        [Test]
+        public void Test_SimpleGroupBy()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = 
+                from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                group beer by beer.BreweryId
+                into g
+                select g.Key;
+
+            const string expected =
+                "SELECT `Extent1`.`brewery_id` " +
+                "FROM `default` as `Extent1` " +
+                "GROUP BY `Extent1`.`brewery_id`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_MultiPartGroupBy()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = 
+                from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                group beer by new {beer.BreweryId, beer.Category}
+                into g
+                select new {g.Key.BreweryId, g.Key.Category};
+
+            const string expected =
+                "SELECT `Extent1`.`brewery_id` as `BreweryId`, `Extent1`.`category` as `Category` " + 
+                "FROM `default` as `Extent1` " +
+                "GROUP BY `Extent1`.`brewery_id`, `Extent1`.`category`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_SimpleGroupByWithAggregate()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = 
+                from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                group beer by beer.BreweryId
+                into g
+                select new {breweryId = g.Key, avgAbv = g.Average(p => p.Abv)};
+
+            const string expected =
+                "SELECT `Extent1`.`brewery_id` as `breweryId`, AVG(`Extent1`.`abv`) as `avgAbv` " +
+                "FROM `default` as `Extent1` " +
+                "GROUP BY `Extent1`.`brewery_id`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_MultiPartGroupByWithAggregate()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = 
+                from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                group beer by new { beer.BreweryId, beer.Category }
+                into g
+                select new { g.Key.BreweryId, g.Key.Category, avgAbv = g.Average(p => p.Abv) };
+
+            const string expected =
+                "SELECT `Extent1`.`brewery_id` as `BreweryId`, `Extent1`.`category` as `Category`, AVG(`Extent1`.`abv`) as `avgAbv` " +
+                "FROM `default` as `Extent1` " +
+                "GROUP BY `Extent1`.`brewery_id`, `Extent1`.`category`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_GroupByAfterJoin()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals
+                    N1Ql.Key(brewery)
+                group beer by brewery.Name
+                into g
+                select new {breweryName = g.Key, avgAbv = g.Average(p => p.Abv)};
+
+            const string expected =
+                "SELECT `Extent2`.`name` as `breweryName`, AVG(`Extent1`.`abv`) as `avgAbv` " +
+                "FROM `default` as `Extent1` " +
+                "INNER JOIN `default` as `Extent2` ON KEYS `Extent1`.`brewery_id` " +
+                "GROUP BY `Extent2`.`name`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
+        #region Group Ordering
+
+        [Test]
+        public void Test_OrderByKey()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1Ql.Key(brewery)
+                group beer by brewery.Name
+                into g
+                orderby g.Key
+                select new { breweryName = g.Key, avgAbv = g.Average(p => p.Abv) };
+
+            const string expected =
+                "SELECT `Extent2`.`name` as `breweryName`, AVG(`Extent1`.`abv`) as `avgAbv` " +
+                "FROM `default` as `Extent1` " +
+                "INNER JOIN `default` as `Extent2` ON KEYS `Extent1`.`brewery_id` " +
+                "GROUP BY `Extent2`.`name` " +
+                "ORDER BY `Extent2`.`name` ASC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_OrderByAggregate()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1Ql.Key(brewery)
+                group beer by brewery.Name
+                into g
+                orderby g.Average(p => p.Abv) descending 
+                select new { breweryName = g.Key, avgAbv = g.Average(p => p.Abv) };
+
+            const string expected =
+                "SELECT `Extent2`.`name` as `breweryName`, AVG(`Extent1`.`abv`) as `avgAbv` " +
+                "FROM `default` as `Extent1` " +
+                "INNER JOIN `default` as `Extent2` ON KEYS `Extent1`.`brewery_id` " +
+                "GROUP BY `Extent2`.`name` " +
+                "ORDER BY AVG(`Extent1`.`abv`) DESC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
+        #region Having
+
+        [Test]
+        public void Test_HavingByKey()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1Ql.Key(brewery)
+                group beer by brewery.Name
+                into g
+                where string.Compare(g.Key, "N") >= 0 
+                select new { breweryName = g.Key, avgAbv = g.Average(p => p.Abv) };
+
+            const string expected =
+                "SELECT `Extent2`.`name` as `breweryName`, AVG(`Extent1`.`abv`) as `avgAbv` " +
+                "FROM `default` as `Extent1` " +
+                "INNER JOIN `default` as `Extent2` ON KEYS `Extent1`.`brewery_id` " +
+                "GROUP BY `Extent2`.`name` " +
+                "HAVING (`Extent2`.`name` >= 'N')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_HavingByAggregate()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
+                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1Ql.Key(brewery)
+                group beer by brewery.Name
+                into g
+                where g.Average(p => p.Abv) >= 6
+                select new { breweryName = g.Key, avgAbv = g.Average(p => p.Abv) };
+
+            const string expected =
+                "SELECT `Extent2`.`name` as `breweryName`, AVG(`Extent1`.`abv`) as `avgAbv` " +
+                "FROM `default` as `Extent1` " +
+                "INNER JOIN `default` as `Extent2` ON KEYS `Extent1`.`brewery_id` " +
+                "GROUP BY `Extent2`.`name` " +
+                "HAVING (AVG(`Extent1`.`abv`) >= 6)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
+    }
+}

--- a/Src/Couchbase.Linq/BucketQueryExecuter.cs
+++ b/Src/Couchbase.Linq/BucketQueryExecuter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Couchbase.Core;
+using Couchbase.Linq.Operators;
 using Couchbase.Linq.QueryGeneration;
 using Couchbase.N1QL;
 using Newtonsoft.Json;
@@ -54,7 +55,7 @@ namespace Couchbase.Linq
             if (queryModel.ResultOperators.Any(p => p is AnyResultOperator))
             {
                 // Need to extract the value from an object
-                var result = ExecuteSingle<AnyAllResult>(queryModel, true);
+                var result = ExecuteSingle<SimpleResult<bool>>(queryModel, true);
 
                 // For an Any operation, no result row means that the Any should return false
                 return (T)(object)(result != null ? result.result : false);
@@ -62,13 +63,19 @@ namespace Couchbase.Linq
             else if (queryModel.ResultOperators.Any(p => p is AllResultOperator))
             {
                 // Need to extract the value from an object
-                var result = ExecuteSingle<AnyAllResult>(queryModel, true);
+                var result = ExecuteSingle<SimpleResult<bool>>(queryModel, true);
 
                 // For an All operation, no result row means that the All should return true
                 return (T)(object)(result != null ? result.result : true);
             }
-
-            return ExecuteCollection<T>(queryModel).Single();
+            else if (queryModel.ResultOperators.Any(p => p is ExplainResultOperator))
+            {
+                return ExecuteSingle<T>(queryModel, false);
+            }
+            else
+            {
+                return ExecuteSingle<SimpleResult<T>>(queryModel, false).result;
+            }
         }
 
         public T ExecuteSingle<T>(QueryModel queryModel, bool returnDefaultWhenEmpty)
@@ -86,9 +93,9 @@ namespace Couchbase.Linq
         /// <summary>
         /// Used to extract the result row from an Any or All operation
         /// </summary>
-        private class AnyAllResult
+        private class SimpleResult<T>
         {
-            public bool result { get; set; }
+            public T result { get; set; }
         }
 
     }

--- a/Src/Couchbase.Linq/BucketQueryable.cs
+++ b/Src/Couchbase.Linq/BucketQueryable.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Linq.Expressions;
 using Couchbase.Core;
 using Remotion.Linq;
@@ -16,10 +17,15 @@ namespace Couchbase.Linq
             get { return _bucket.Name; }
         }
 
-        public BucketQueryable(IQueryParser queryParser, IQueryExecutor executor)
+        public BucketQueryable(IBucket bucket, IQueryParser queryParser, IQueryExecutor executor)
             : base(queryParser, executor)
         {
-            // Is this constructor necessary?
+            if (bucket == null)
+            {
+                throw new ArgumentNullException("bucket");
+            }
+
+            _bucket = bucket;
         }
 
         public BucketQueryable(IQueryProvider provider)
@@ -37,6 +43,11 @@ namespace Couchbase.Linq
         public BucketQueryable(IBucket bucket)
             : base(QueryParserHelper.CreateQueryParser(), new BucketQueryExecuter(bucket))
         {
+            if (bucket == null)
+            {
+                throw new ArgumentNullException("bucket");
+            }
+
             _bucket = bucket;
         }
     }

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -72,6 +72,8 @@
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="IDbContext.cs" />
     <Compile Include="QueryGeneration\Expressions\StringComparisonExpression.cs" />
+    <Compile Include="QueryGeneration\ExpressionTransformers\MultiKeyExpressionTransfomer.cs" />
+    <Compile Include="QueryGeneration\ExpressionTransformers\KeyExpressionTransfomer.cs" />
     <Compile Include="QueryGeneration\IN1QlQueryModelVisitor.cs" />
     <Compile Include="Clauses\NestClause.cs" />
     <Compile Include="Clauses\NestExpressionNode.cs" />

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/KeyExpressionTransfomer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/KeyExpressionTransfomer.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
+
+namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
+{
+    /// <summary>
+    /// Transforms references to the Key property of an IGrouping into another expression.
+    /// Used to convert references to the Key of a GroupBy statement to directly access the property
+    /// used to make the key.  This is done after a grouping subquery is flattened into the main N1QL query.
+    /// </summary>
+    class KeyExpressionTransfomer : IExpressionTransformer<MemberExpression>
+    {
+        public ExpressionType[] SupportedExpressionTypes
+        {
+            get
+            {
+                return new[]
+                {
+                    ExpressionType.MemberAccess
+                };
+            }
+        }
+
+        private readonly QuerySourceReferenceExpression _querySourceReference;
+        private readonly PropertyInfo _keyPropertyInfo;
+        private readonly Expression _replacementExpression;
+
+        /// <summary>
+        /// Creates a new KeyExpressionTransformer
+        /// </summary>
+        /// <param name="querySourceReference">QuerySourceReferenceExpression that references an IQuerySource returning an IGrouping</param>
+        /// <param name="replacementExpression">Expression to replace any reference to the Key property of the IGrouping</param>
+        public KeyExpressionTransfomer(QuerySourceReferenceExpression querySourceReference, Expression replacementExpression)
+        {
+            if (querySourceReference == null)
+            {
+                throw new ArgumentNullException("querySourceReference");
+            }
+            if (replacementExpression == null)
+            {
+                throw new ArgumentNullException("replacementExpression");
+            }
+
+            _querySourceReference = querySourceReference;
+            _keyPropertyInfo = querySourceReference.ReferencedQuerySource.ItemType.GetProperty("Key");
+            _replacementExpression = replacementExpression;
+        }
+
+        public Expression Transform(MemberExpression expression)
+        {
+            if (expression.Expression.Equals(_querySourceReference) && (expression.Member == _keyPropertyInfo))
+            {
+                return _replacementExpression;
+            }
+
+            return expression;
+        }
+
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/MultiKeyExpressionTransfomer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/MultiKeyExpressionTransfomer.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
+
+namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
+{
+    /// <summary>
+    /// Transforms references to the Key property of an IGrouping into another expression.
+    /// Used to convert references to the Key of a GroupBy statement to directly access the properties
+    /// used to make the key.  This is done after a grouping subquery is flattened into the main N1QL query.
+    /// The MultiKeyExpressionTransformer variant is used for multipart keys, where accessing members of the Key property.
+    /// </summary>
+    class MultiKeyExpressionTransfomer : IExpressionTransformer<MemberExpression>
+    {
+        public ExpressionType[] SupportedExpressionTypes
+        {
+            get
+            {
+                return new[]
+                {
+                    ExpressionType.MemberAccess
+                };
+            }
+        }
+
+        private readonly QuerySourceReferenceExpression _querySourceReference;
+        private readonly PropertyInfo _keyPropertyInfo;
+        private readonly NewExpression _newExpression;
+
+        /// <summary>
+        /// Creates a new KeyExpressionTransformer
+        /// </summary>
+        /// <param name="querySourceReference">QuerySourceReferenceExpression that references an IQuerySource returning an IGrouping</param>
+        /// <param name="newExpression">NewExpression which was used to create the multipart key for grouping</param>
+        public MultiKeyExpressionTransfomer(QuerySourceReferenceExpression querySourceReference, NewExpression newExpression)
+        {
+            if (querySourceReference == null)
+            {
+                throw new ArgumentNullException("querySourceReference");
+            }
+            if (newExpression == null)
+            {
+                throw new ArgumentNullException("newExpression");
+            }
+
+            _querySourceReference = querySourceReference;
+            _keyPropertyInfo = querySourceReference.ReferencedQuerySource.ItemType.GetProperty("Key");
+            _newExpression = newExpression;
+        }
+
+        public Expression Transform(MemberExpression expression)
+        {
+            var keyExpression = expression.Expression as MemberExpression;
+            
+            if ((keyExpression != null) && keyExpression.Expression.Equals(_querySourceReference)
+                && (keyExpression.Member == _keyPropertyInfo))
+            {
+                for (var i = 0; i < _newExpression.Members.Count; i++)
+                {
+                    if (_newExpression.Members[i] == expression.Member)
+                    {
+                        return _newExpression.Arguments[i];
+                    }
+                }
+            }
+
+            return expression;
+        }
+
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
@@ -48,6 +48,11 @@
         /// <summary>
         /// All operation performed on a Couchbase bucket as a subquery
         /// </summary>
-        SubqueryAll
+        SubqueryAll,
+
+        /// <summary>
+        /// Represents a simple aggregate against a group.  Query returned will be the aggregate function call only.
+        /// </summary>
+        Aggregate
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Serialization;
+using Remotion.Linq.Clauses.Expressions;
 
 namespace Couchbase.Linq.QueryGeneration
 {
@@ -17,6 +18,11 @@ namespace Couchbase.Linq.QueryGeneration
         public IMemberNameResolver MemberNameResolver { get; set; }
         public IMethodCallTranslatorProvider MethodCallTranslatorProvider { get; set; }
         public ParameterAggregator ParameterAggregator { get; set; }
+
+        /// <summary>
+        /// Stores a reference to the current grouping subquery
+        /// </summary>
+        public QuerySourceReferenceExpression GroupingQuerySource { get; set; }
 
         public N1QlQueryGenerationContext()
         {


### PR DESCRIPTION
Motivations
-----------
Allow LINQ group clauses and aggregates to generate valid N1QL statements.
Should support simple aggregates directly against a query, or more
advanced aggregates utilizing groups.  Should also support treating where
clauses after the group clause as HAVING statements.

Modifications
-------------
For simple aggregates, added AggregateFunction to QueryPartsAggregator.
This function wraps SelectParts in the select clause.

Added handling to N1QlQueryVisitor for group clauses.  When grouping is
performed in a subquery as part of the MainFromClause, the group is
flattened onto the main query.  Created KeyExpressionTransformer and
MultiKeyExpressionTransformer classes to transform references to the group
keys after the query has been flattened.  When where clauses are
encountered after flattening, they are added to HavingParts instead of
WhereParts on the QueryPartsAggregator.

Introduced a new N1QlQueryType, Aggregate, which returns a simple
statement such as COUNT(*) from the QueryPartsAggregator.  This is used
when ReLinq generates a subquery in the select clause to perform one part
of a grouped aggregate.

For testing, simple aggregates always return immediately and don't provide
a method to capture the query.  Added the BucketQueryExecutorEmulator
class and the CreateQueryable function to support capturing query text
after the call is complete.  Created tests for all new functionality.

Results
-------
LINQ can now be used to generate queries with GROUP BY and HAVING clauses,
as well as the standard COUNT, COUNT distinct, SUM, AVG, MIN, and MAX
aggregate functions.