### PR TITLE
Improved/fixed support for First and Single operators

### DIFF
--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -773,5 +773,187 @@ namespace Couchbase.Linq.Tests
                 }
             }
         }
+
+        [Test()]
+        public void First_Empty()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from beer in bucket.Queryable<Beer>()
+                        where beer.Type == "abcdefg"
+                        select new { beer.Name };
+
+                    Assert.Throws<InvalidOperationException>(() =>
+                    {
+                        // ReSharper disable once UnusedVariable
+                        var temp = beers.First();
+                    });
+                }
+            }
+        }
+
+        [Test()]
+        public void First_HasResult()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from beer in bucket.Queryable<Beer>()
+                                where beer.Type == "beer"
+                                select new { beer.Name };
+
+                    Console.WriteLine(beers.First().Name);
+                }
+            }
+        }
+
+        [Test()]
+        public void FirstOrDefault_Empty()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from beer in bucket.Queryable<Beer>()
+                                where beer.Type == "abcdefg"
+                                select new { beer.Name };
+
+                    var aBeer = beers.FirstOrDefault();
+                    Assert.IsNull(aBeer);
+                }
+            }
+        }
+
+        [Test()]
+        public void FirstOrDefault_HasResult()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from beer in bucket.Queryable<Beer>()
+                                where beer.Type == "beer"
+                                select new { beer.Name };
+
+                    var aBeer = beers.FirstOrDefault();
+                    Assert.IsNotNull(aBeer);
+                    Console.WriteLine(aBeer.Name);
+                }
+            }
+        }
+
+        [Test()]
+        public void Single_Empty()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from beer in bucket.Queryable<Beer>()
+                                where beer.Type == "abcdefg"
+                                select new { beer.Name };
+
+                    Assert.Throws<InvalidOperationException>(() =>
+                    {
+                        // ReSharper disable once UnusedVariable
+                        var temp = beers.Single();
+                    });
+                }
+            }
+        }
+
+        [Test()]
+        public void Single_HasResult()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from beer in bucket.Queryable<Beer>()
+                                where beer.Name == "21A IPA"
+                                select new { beer.Name };
+
+                    Console.WriteLine(beers.Single().Name);
+                }
+            }
+        }
+
+        [Test()]
+        public void Single_HasManyResults()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from beer in bucket.Queryable<Beer>()
+                                where beer.Type == "beer"
+                                select new { beer.Name };
+
+                    Assert.Throws<InvalidOperationException>(() =>
+                    {
+                        // ReSharper disable once UnusedVariable
+                        var temp = beers.Single();
+                    });
+                }
+            }
+        }
+
+        [Test()]
+        public void SingleOrDefault_Empty()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from beer in bucket.Queryable<Beer>()
+                                where beer.Type == "abcdefg"
+                                select new { beer.Name };
+
+                    var aBeer = beers.SingleOrDefault();
+                    Assert.IsNull(aBeer);
+                }
+            }
+        }
+
+        [Test()]
+        public void SingleOrDefault_HasResult()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from beer in bucket.Queryable<Beer>()
+                                where beer.Name == "21A IPA"
+                                select new { beer.Name };
+
+                    var aBeer = beers.SingleOrDefault();
+                    Assert.IsNotNull(aBeer);
+                    Console.WriteLine(aBeer.Name);
+                }
+            }
+        }
+
+        [Test()]
+        public void SingleOrDefault_HasManyResults()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from beer in bucket.Queryable<Beer>()
+                                where beer.Type == "beer"
+                                select new { beer.Name };
+
+                    Assert.Throws<InvalidOperationException>(() =>
+                    {
+                        // ReSharper disable once UnusedVariable
+                        var temp = beers.SingleOrDefault();
+                    });
+                }
+            }
+        }
     }
 }

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/TakeAndSkipTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/TakeAndSkipTests.cs
@@ -63,5 +63,71 @@ namespace Couchbase.Linq.Tests.QueryGeneration
 
             Assert.AreEqual(expected, n1QlQuery);
         }
+
+        [Test]
+        public void Test_First()
+        {
+            var temp = CreateQueryable<Contact>("default").First();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_FirstOrDefault()
+        {
+            var temp = CreateQueryable<Contact>("default").FirstOrDefault();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_FirstWithSkip()
+        {
+            var temp = CreateQueryable<Contact>("default").Skip(10).First();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1 OFFSET 10";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Single()
+        {
+            var temp = CreateQueryable<Contact>("default").Single();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 2";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_SingleOrDefault()
+        {
+            var temp = CreateQueryable<Contact>("default").SingleOrDefault();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 2";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_SingleWithSkip()
+        {
+            var temp = CreateQueryable<Contact>("default").Skip(10).Single();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 2 OFFSET 10";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -325,6 +325,19 @@ namespace Couchbase.Linq.QueryGeneration
                 _queryPartsAggregator.AddOffsetPart(" OFFSET {0}",
                     Convert.ToInt32(GetN1QlExpression(skipResultOperator.Count)));
             }
+            else if (resultOperator is FirstResultOperator)
+            {
+                // We can save query execution time with a short circuit for .First()
+
+                _queryPartsAggregator.AddLimitPart(" LIMIT {0}", 1);
+            }
+            else if (resultOperator is SingleResultOperator)
+            {
+                // We can save query execution time with a short circuit for .Single()
+                // But we have to get at least 2 results so we know if there was more than 1
+
+                _queryPartsAggregator.AddLimitPart(" LIMIT {0}", 2);
+            }
             else if (resultOperator is DistinctResultOperator)
             {
                 var distinctResultOperator = resultOperator as DistinctResultOperator;


### PR DESCRIPTION
Motivations
-----------
First and single operations can be optimized by not selecting more data
than necessary from the server.  They carry an implicit LIMIT 1 or LIMIT 2
when they are used.

Also, the First operator as implemented was throwing an error if there was
more than one result.  It's behavior was the same as Single.

Modifications
-------------
Include LIMIT 1 on all First operations and LIMIT 2 on all Single
operations.  Added query generation and beer-sample integration tests.