### PR TITLE
LINQ-12: "Narrow" the public API - make some public Types internal

### DIFF
--- a/Src/Couchbase.Linq/BucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/BucketQueryExecutor.cs
@@ -13,7 +13,7 @@ using Remotion.Linq.Clauses.ResultOperators;
 
 namespace Couchbase.Linq
 {
-    public class BucketQueryExecutor : IQueryExecutor
+    internal class BucketQueryExecutor : IQueryExecutor
     {
         private static readonly ILog Log = LogManager.GetLogger<BucketQueryExecutor>();
         private readonly IBucket _bucket;

--- a/Src/Couchbase.Linq/BucketQueryable.cs
+++ b/Src/Couchbase.Linq/BucketQueryable.cs
@@ -7,7 +7,7 @@ using Remotion.Linq.Parsing.Structure;
 
 namespace Couchbase.Linq
 {
-    public class BucketQueryable<T> : QueryableBase<T>, IBucketQueryable<T>
+    internal class BucketQueryable<T> : QueryableBase<T>, IBucketQueryable<T>
     {
 
         private readonly IBucket _bucket;

--- a/Src/Couchbase.Linq/QueryFactory.cs
+++ b/Src/Couchbase.Linq/QueryFactory.cs
@@ -3,7 +3,7 @@ using Couchbase.Core;
 
 namespace Couchbase.Linq
 {
-    public class QueryFactory
+    internal class QueryFactory
     {
         public static IQueryable<T> Queryable<T>(IBucket bucket)
         {

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -7,7 +7,7 @@ using Remotion.Linq.Parsing.Structure.NodeTypeProviders;
 
 namespace Couchbase.Linq
 {
-    public class QueryParserHelper
+    internal class QueryParserHelper
     {
         public static IQueryParser CreateQueryParser()
         {


### PR DESCRIPTION
Motivation
----------
The exposed public API of the Linq2Couchbase provider is the query API and
the DbContext; this makes other types that are not intended to be used in
a standalone internal.

Modifications
-------------
BucketQueryExecutor, BucketQueryable, QueryFactory, and QueryParserHelper
are no longer public Types.

Results
-------
It's now easier to make non-backward compatible changes as well as coax
users of the API torwards the intended public API.