### PR TITLE
LINQ-9: Remove ClusterHelper reference from N1QLQueryModelVistor

### DIFF
--- a/Src/Couchbase.Linq/BucketQueryable.cs
+++ b/Src/Couchbase.Linq/BucketQueryable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
+using Couchbase.Configuration.Client;
 using Couchbase.Core;
 using Remotion.Linq;
 using Remotion.Linq.Parsing.Structure;
@@ -9,8 +10,8 @@ namespace Couchbase.Linq
 {
     internal class BucketQueryable<T> : QueryableBase<T>, IBucketQueryable<T>
     {
-
         private readonly IBucket _bucket;
+        private readonly ClientConfiguration _configuration;
 
         public string BucketName
         {
@@ -40,8 +41,8 @@ namespace Couchbase.Linq
             // Is this constructor necessary?
         }
 
-        public BucketQueryable(IBucket bucket)
-            : base(QueryParserHelper.CreateQueryParser(), new BucketQueryExecutor(bucket))
+        public BucketQueryable(IBucket bucket, ClientConfiguration configuration)
+            : base(QueryParserHelper.CreateQueryParser(), new BucketQueryExecutor(bucket, configuration))
         {
             if (bucket == null)
             {
@@ -49,6 +50,7 @@ namespace Couchbase.Linq
             }
 
             _bucket = bucket;
+            _configuration = configuration;
         }
     }
 }

--- a/Src/Couchbase.Linq/DbContext.cs
+++ b/Src/Couchbase.Linq/DbContext.cs
@@ -51,7 +51,7 @@ namespace Couchbase.Linq
         /// <returns></returns>
         public IQueryable<T> Query<T>()
         {
-            return EntityFilterManager.ApplyFilters(new BucketQueryable<T>(_bucket));
+            return EntityFilterManager.ApplyFilters(new BucketQueryable<T>(_bucket, Configuration));
         }
 
         /// <summary>

--- a/Src/Couchbase.Linq/Extensions/BucketExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/BucketExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Couchbase.Configuration.Client;
 using Couchbase.Core;
 using Couchbase.Linq.Filters;
 
@@ -8,7 +9,8 @@ namespace Couchbase.Linq.Extensions
     {
         public static IQueryable<T> Queryable<T>(this IBucket bucket)
         {
-            return EntityFilterManager.ApplyFilters(new BucketQueryable<T>(bucket));
+            //TODO refactor so ClientConfiguration is injectable
+            return EntityFilterManager.ApplyFilters(new BucketQueryable<T>(bucket, new ClientConfiguration()));
         }
     }
 }

--- a/Src/Couchbase.Linq/QueryFactory.cs
+++ b/Src/Couchbase.Linq/QueryFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Couchbase.Configuration.Client;
 using Couchbase.Core;
 
 namespace Couchbase.Linq
@@ -7,7 +8,8 @@ namespace Couchbase.Linq
     {
         public static IQueryable<T> Queryable<T>(IBucket bucket)
         {
-            return new BucketQueryable<T>(bucket);
+            //TODO refactor so ClientConfiguration is injectable
+            return new BucketQueryable<T>(bucket, new ClientConfiguration());
         }
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -82,7 +82,7 @@ namespace Couchbase.Linq.QueryGeneration
 
                 case ExpressionType.Extension:
                     return VisitExtensionExpression(expression);
-                    
+
                 default:
                     return base.VisitExpression(expression);
             }
@@ -672,7 +672,6 @@ namespace Couchbase.Linq.QueryGeneration
                     VisitExpression(expression.Operand);
                     break;
             }
-            
             return expression;
         }
 


### PR DESCRIPTION
Motivation
----------
The Linq project had a hard reference to the ClusterHelper; this commit
removes the reference and instead allows the ClientConfiguration to be
injected as a reference.

Modification
------------
The CLusterHelper reference was removed and instead ClientConfiguration is
injected from the higher-level objects.

Result
------
ClusterHelper is now no longer a required reference; you do not need to
call ClusterHelper.Initialize() before executing a query.