### PR TITLE
Make BucketExtensions.Queryable internal

### DIFF
--- a/Src/Couchbase.Linq/Extensions/BucketExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/BucketExtensions.cs
@@ -7,7 +7,7 @@ namespace Couchbase.Linq.Extensions
 {
     public static class BucketExtensions
     {
-        public static IQueryable<T> Queryable<T>(this IBucket bucket)
+        internal static IQueryable<T> Queryable<T>(this IBucket bucket)
         {
             //TODO refactor so ClientConfiguration is injectable
             return EntityFilterManager.ApplyFilters(new BucketQueryable<T>(bucket, new ClientConfiguration()));


### PR DESCRIPTION
Motivation
----------
The public API for querying is the BucketContext; Queryable is only for
use internally within the test suite to bypass some of the "layers".

Modifications
-------------
Made BucketExtensions.Queryable internal.

Result
------
BucketExntensions.Queryable is no longer a public API; use BucketContext
instead.