### PR TITLE
LINQ-13: Change IDBContext and DbContext to IBucketContext and BucketContext

### DIFF
--- a/Src/Couchbase.Linq.Tests/BeerSample.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSample.cs
@@ -10,7 +10,7 @@ namespace Couchbase.Linq.Tests
     /// <summary>
     /// A concrete DbContext for the beer-sample example bucket.
     /// </summary>
-    public class BeerSample : DbContext
+    public class BeerSample : BucketContext
     {
         /// <exception cref="InitializationException">Thrown if ClusterHelper.Initialize is not called before accessing this method.</exception>
         public BeerSample() : this(ClusterHelper.Get())

--- a/Src/Couchbase.Linq.Tests/DbContextTests.cs
+++ b/Src/Couchbase.Linq.Tests/DbContextTests.cs
@@ -20,7 +20,7 @@ namespace Couchbase.Linq.Tests
         [Test]
         public void Test_Basic_Query()
         {
-            var db = new DbContext(ClusterHelper.Get(), "beer-sample");
+            var db = new BucketContext(ClusterHelper.Get(), "beer-sample");
             var query = from x in db.Query<Beer>()
                 where x.Type == "beer"
                 select x;

--- a/Src/Couchbase.Linq/BucketContext.cs
+++ b/Src/Couchbase.Linq/BucketContext.cs
@@ -10,17 +10,17 @@ namespace Couchbase.Linq
     /// Provides a single point of entry to a Couchbase bucket which makes it easier to compose
     /// and execute queries and to group togather changes which will be submitted back into the bucket.
     /// </summary>
-    public class DbContext : IDbContext
+    public class BucketContext : IBucketContext
     {
         private readonly IBucket _bucket;
         protected BucketConfiguration BucketConfig;
 
-        public DbContext(Cluster cluster, string bucketName)
+        public BucketContext(Cluster cluster, string bucketName)
             : this(cluster, bucketName, string.Empty)
         {
         }
 
-        public DbContext(Cluster cluster, string bucketName, string password)
+        public BucketContext(Cluster cluster, string bucketName, string password)
         {
             Cluster = cluster;
             Configuration = Cluster.Configuration;
@@ -28,7 +28,7 @@ namespace Couchbase.Linq
         }
 
         /// <summary>
-        /// Gets a reference to the <see cref="Cluster" /> that the <see cref="IDbContext" /> is using.
+        /// Gets a reference to the <see cref="Cluster" /> that the <see cref="IBucketContext" /> is using.
         /// </summary>
         /// <value>
         /// The cluster.

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -68,9 +68,9 @@
   <ItemGroup>
     <Compile Include="Clauses\UseKeysExpressionNode.cs" />
     <Compile Include="Clauses\UseKeysClause.cs" />
-    <Compile Include="DbContext.cs" />
+    <Compile Include="BucketContext.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
-    <Compile Include="IDbContext.cs" />
+    <Compile Include="IBucketContext.cs" />
     <Compile Include="QueryGeneration\Expressions\StringComparisonExpression.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\MultiKeyExpressionTransfomer.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\KeyExpressionTransfomer.cs" />

--- a/Src/Couchbase.Linq/Extensions/BucketExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/BucketExtensions.cs
@@ -7,7 +7,7 @@ namespace Couchbase.Linq.Extensions
 {
     public static class BucketExtensions
     {
-        public static IQueryable<T> Queryable<T>(this IBucket bucket)
+        internal static IQueryable<T> Queryable<T>(this IBucket bucket)
         {
             //TODO refactor so ClientConfiguration is injectable
             return EntityFilterManager.ApplyFilters(new BucketQueryable<T>(bucket, new ClientConfiguration()));

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -8,10 +8,10 @@ namespace Couchbase.Linq
     /// Provides a single point of entry to a Couchbase bucket which makes it easier to compose
     /// and execute queries and to group togather changes which will be submitted back into the bucket.
     /// </summary>
-    public interface IDbContext : IBucketQueryable
+    public interface IBucketContext : IBucketQueryable
     {
         /// <summary>
-        /// Gets a reference to the <see cref="Cluster"/> that the <see cref="IDbContext"/> is using.
+        /// Gets a reference to the <see cref="Cluster"/> that the <see cref="IBucketContext"/> is using.
         /// </summary>
         /// <value>
         /// The cluster.


### PR DESCRIPTION

Motivation
----------
Make the Linq provider more "Couchbase" friendly. IDbCOntext and DbContext
were motivated by the EF/Linq for SQL providers for relational databases;
couchbase has documents and buckets, not tables and rows.

Modifications
-------------
Renamed IDbContext and DbContext to IBucketContext and BucketContext.

Result
------
IDbContext and DbContext are now IBucketContext and BucketContext.