### PR TITLE
Support for date/time constants and comparisons

### DIFF
--- a/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
+++ b/Src/Couchbase.Linq.Tests/BeerSampleTests.cs
@@ -100,6 +100,25 @@ namespace Couchbase.Linq.Tests
         }
 
         [Test]
+        public void Map2PocoTests_Simple_Projections_WhereDateTime()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var beers = from b in bucket.Queryable<Beer>()
+                                where (b.Type == "beer") && (b.Updated >= new DateTime(2010, 1, 1))
+                                select new { name = b.Name, updated = b.Updated };
+
+                    foreach (var b in beers.Take(20))
+                    {
+                        Console.WriteLine("{0} last updated {1:g}", b.name, b.updated);
+                    }
+                }
+            }
+        }
+
+        [Test]
         public void Map2PocoTests_Simple_Projections_Limit()
         {
             using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))

--- a/Src/Couchbase.Linq.Tests/BucketQueryExecutorEmulator.cs
+++ b/Src/Couchbase.Linq.Tests/BucketQueryExecutorEmulator.cs
@@ -61,7 +61,8 @@ namespace Couchbase.Linq.Tests
             var queryGenerationContext = new N1QlQueryGenerationContext()
             {
                 MemberNameResolver = new JsonNetMemberNameResolver(Test.ContractResolver),
-                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider(),
+                Serializer = new Core.Serialization.DefaultSerializer()
             };
 
             var visitor = new N1QlQueryModelVisitor(queryGenerationContext);

--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="QueryGeneration\ArrayIndexTests.cs" />
     <Compile Include="QueryGeneration\AggregateTests.cs" />
     <Compile Include="BucketQueryExecutorEmulator.cs" />
+    <Compile Include="QueryGeneration\NullHandlingTests.cs" />
     <Compile Include="QueryGeneration\N1QlHelpersTests.cs" />
     <Compile Include="QueryGeneration\NestTests.cs" />
     <Compile Include="QueryGeneration\ConditionalExpressionTests.cs" />

--- a/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.Tests/N1QLTestBase.cs
@@ -54,7 +54,8 @@ namespace Couchbase.Linq.Tests
             var queryGenerationContext = new N1QlQueryGenerationContext()
             {
                 MemberNameResolver = new JsonNetMemberNameResolver(_contractResolver),
-                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider(),
+                Serializer = new Core.Serialization.DefaultSerializer()
             };
 
             var visitor = new N1QlQueryModelVisitor(queryGenerationContext);

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/ConstantExpressionTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/ConstantExpressionTests.cs
@@ -157,5 +157,23 @@ namespace Couchbase.Linq.Tests.QueryGeneration
 
             Assert.AreEqual(expected, n1QlQuery);
         }
+
+        [Test]
+        public void Test_DateTime()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                .Select(e => new { e.FirstName, Value = new DateTime(2000, 12, 1, 1, 23, 45, 67, DateTimeKind.Utc) });
+
+            const string expected =
+                "SELECT `Extent1`.`fname` as `FirstName`, \"2000-12-01T01:23:45.067Z\" as `Value` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
     }
 }

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/NullHandlingTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/NullHandlingTests.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Core;
+using Couchbase.Linq.Tests.Documents;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.Tests.QueryGeneration
+{
+    [TestFixture]
+    class NullHandlingTests : N1QLTestBase
+    {
+        
+        [Test]
+        public void Test_HasValue()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Class1>(mockBucket.Object)
+                    .Where(e => e.Updated.HasValue)
+                    .Select(e => new { e.Updated});
+
+            const string expected =
+                "SELECT `Extent1`.`Updated` as `Updated` FROM `default` as `Extent1` WHERE (`Extent1`.`Updated` IS NOT NULL)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_NotHasValue()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Class1>(mockBucket.Object)
+                    .Where(e => !e.Updated.HasValue)
+                    .Select(e => new { e.Updated });
+
+            const string expected =
+                "SELECT `Extent1`.`Updated` as `Updated` FROM `default` as `Extent1` WHERE NOT (`Extent1`.`Updated` IS NOT NULL)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Value()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Class1>(mockBucket.Object)
+                    .Where(e => e.Updated.Value < new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+                    .Select(e => new { e.Updated });
+
+            const string expected =
+                "SELECT `Extent1`.`Updated` as `Updated` FROM `default` as `Extent1` " + 
+                "WHERE (STR_TO_MILLIS(`Extent1`.`Updated`) < STR_TO_MILLIS(\"2000-01-01T00:00:00Z\"))";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #region Helpers
+
+        private class Class1
+        {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public DateTime? Updated { get; set; }
+        }
+
+        #endregion
+
+    }
+}

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/StringTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/StringTests.cs
@@ -716,7 +716,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             {
                 MemberNameResolver =
                     new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()),
-                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider(),
+                Serializer = new Core.Serialization.DefaultSerializer()
             };
 
             var visitor = new Mock<N1QlExpressionTreeVisitor>(queryGenerationContext)
@@ -750,7 +751,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             {
                 MemberNameResolver =
                     new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()),
-                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider(),
+                Serializer = new Core.Serialization.DefaultSerializer()
             };
 
             var visitor = new Mock<N1QlExpressionTreeVisitor>(queryGenerationContext)
@@ -784,7 +786,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             {
                 MemberNameResolver =
                     new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()),
-                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider(),
+                Serializer = new Core.Serialization.DefaultSerializer()
             };
 
             var visitor = new Mock<N1QlExpressionTreeVisitor>(queryGenerationContext)
@@ -818,7 +821,8 @@ namespace Couchbase.Linq.Tests.QueryGeneration
             {
                 MemberNameResolver =
                     new JsonNetMemberNameResolver(new Newtonsoft.Json.Serialization.DefaultContractResolver()),
-                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+                MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider(),
+                Serializer = new Core.Serialization.DefaultSerializer()
             };
 
             var visitor = new Mock<N1QlExpressionTreeVisitor>(queryGenerationContext)

--- a/Src/Couchbase.Linq.Tests/QueryGeneration/WhereClauseTests.cs
+++ b/Src/Couchbase.Linq.Tests/QueryGeneration/WhereClauseTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Couchbase.Core;
 using Couchbase.Linq.Extensions;
 using Couchbase.Linq.Tests.Documents;
@@ -204,6 +205,27 @@ namespace Couchbase.Linq.Tests.QueryGeneration
 
             const string expected =
                 "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (`Extent1`.`fname` IS NOT NULL)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Where_With_DateComparison()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .Where(e => e.Updated >= new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+                    .Select(e => new { e.Name });
+
+
+            const string expected =
+                "SELECT `Extent1`.`name` as `Name` FROM `default` as `Extent1` " +
+                "WHERE (STR_TO_MILLIS(`Extent1`.`updated`) >= STR_TO_MILLIS(\"2010-01-01T00:00:00Z\"))";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq/BucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/BucketQueryExecutor.cs
@@ -96,7 +96,8 @@ namespace Couchbase.Linq
             //"pluggable" resolver and translator via configuration.
             var memberNameResolver = new JsonNetMemberNameResolver(_configuration.SerializationSettings.ContractResolver);
             var methodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider();
-            var query = N1QlQueryModelVisitor.GenerateN1QlQuery(queryModel, memberNameResolver,methodCallTranslatorProvider);
+            var query = N1QlQueryModelVisitor.GenerateN1QlQuery(queryModel, memberNameResolver,
+                methodCallTranslatorProvider, _configuration.Serializer.Invoke());
 
             Log.Debug(m => m("Generated query: {0}", query));
 

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -72,6 +72,8 @@
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="IBucketContext.cs" />
     <Compile Include="QueryGeneration\Expressions\StringComparisonExpression.cs" />
+    <Compile Include="QueryGeneration\ExpressionTransformers\DateTimeComparisonExpressionTransformer.cs" />
+    <Compile Include="QueryGeneration\ExpressionTransformers\DateTimeTransformationRegistry.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\MultiKeyExpressionTransfomer.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\KeyExpressionTransfomer.cs" />
     <Compile Include="QueryGeneration\IN1QlQueryModelVisitor.cs" />
@@ -118,6 +120,7 @@
     <Compile Include="QueryGeneration\MethodCallTranslators\MathMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\SubqueryMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\SubstringMethodCallTranslator.cs" />
+    <Compile Include="QueryGeneration\MethodCallTranslators\UnixMillisecondsMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\N1QLExpressionTreeVisitor.cs" />
     <Compile Include="QueryGeneration\N1QlExtentNameProvider.cs" />
     <Compile Include="QueryGeneration\N1QLFromQueryPart.cs" />
@@ -134,6 +137,7 @@
     <Compile Include="N1QL.cs" />
     <Compile Include="QueryGeneration\UnclaimedGroupJoin.cs" />
     <Compile Include="QueryParserHelper.cs" />
+    <Compile Include="UnixMillisecondsDateTime.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Couchbase.Linq.nuspec">

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
+
+namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
+{
+    /// <summary>
+    /// Converts any DateTime constants or properties to Unix milliseconds before comparing them.
+    /// This way the <see cref="MethodCallTranslators.UnixMillisecondsMethodCallTranslator">UnixMillisecondsMethodCallTranslator</see>
+    /// will later interpret the calls as STR_TO_MILLIS() calls in N1QL.  N1QL can't directly compare
+    /// date/time values unless they're converted to Unix milliseconds first.
+    /// </summary>
+    class DateTimeComparisonExpressionTransformer : IExpressionTransformer<BinaryExpression>
+    {
+        private static readonly MethodInfo FromDateTimeMethod =
+            typeof (UnixMillisecondsDateTime).GetMethod("FromDateTime", new[] { typeof(DateTime) });
+        private static readonly MethodInfo FromDateTimeNullableMethod =
+            typeof(UnixMillisecondsDateTime).GetMethod("FromDateTime", new[] { typeof(DateTime?) });
+
+        public ExpressionType[] SupportedExpressionTypes
+        {
+            get
+            {
+                return new[]
+                {
+                    ExpressionType.GreaterThan,
+                    ExpressionType.GreaterThanOrEqual,
+                    ExpressionType.LessThan,
+                    ExpressionType.LessThanOrEqual,
+                    ExpressionType.Equal,
+                    ExpressionType.NotEqual
+                };
+            }
+        }
+
+        public Expression Transform(BinaryExpression expression)
+        {
+            var constantExpression = expression.Right as ConstantExpression;
+            if ((constantExpression != null) && (constantExpression.Value == null))
+            {
+                // Testing for null, so don't do transformation
+
+                return expression;
+            }
+
+            var left = TransformSide(expression.Left);
+            var right = TransformSide(expression.Right);
+
+            if ((left != expression.Left) || (right != expression.Right))
+            {
+                return Expression.MakeBinary(expression.NodeType, left, right);
+            }
+            else
+            {
+                return expression;
+            }
+        }
+
+        private Expression TransformSide(Expression side)
+        {
+            if (side.Type == typeof (DateTime))
+            {
+                return Expression.Call(FromDateTimeMethod, side);
+            }
+            else if (side.Type == typeof(DateTime?))
+            {
+                return Expression.Call(FromDateTimeNullableMethod, side);
+            }
+            else
+            {
+                return side;
+            }
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeTransformationRegistry.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeTransformationRegistry.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
+
+namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
+{
+    /// <summary>
+    /// Default registry of expression transformers used to convert DateTime expressions as needed for N1QL
+    /// </summary>
+    class DateTimeTransformationRegistry
+    {
+        /// <summary>
+        /// Default registry of expression transformers used to convert DateTime expressions as needed for N1QL
+        /// </summary>
+        public static ExpressionTransformerRegistry Default { get; set; }
+
+        static DateTimeTransformationRegistry()
+        {
+            var registry = new ExpressionTransformerRegistry();
+            registry.Register(new DateTimeComparisonExpressionTransformer());
+
+            Default = registry;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/UnixMillisecondsMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/UnixMillisecondsMethodCallTranslator.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
+{
+    class UnixMillisecondsMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (UnixMillisecondsDateTime).GetMethod("FromDateTime", new[] { typeof (DateTime) }),
+            typeof (UnixMillisecondsDateTime).GetMethod("FromDateTime", new[] { typeof (DateTime?) }),
+            typeof (UnixMillisecondsDateTime).GetMethod("ToDateTime", new[] { typeof (UnixMillisecondsDateTime) }),
+            typeof (UnixMillisecondsDateTime).GetMethod("ToDateTime", new[] { typeof (UnixMillisecondsDateTime?) })
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var argument = methodCallExpression.Arguments[0];
+            var methodCallArgument = argument as MethodCallExpression;
+
+            if ((methodCallArgument != null) && SupportMethods.Contains(methodCallArgument.Method))
+            {
+                // Two method calls are reversing each other, so just skip them both
+
+                return expressionTreeVisitor.VisitExpression(methodCallArgument.Arguments[0]);
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            if (methodCallExpression.Method.Name == "FromDateTime")
+            {
+                expression.Append("STR_TO_MILLIS(");
+            }
+            else
+            {
+                expression.Append("MILLIS_TO_STR(");
+            }
+
+            expressionTreeVisitor.VisitExpression(argument);
+
+            expression.Append(')');            
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -701,31 +701,5 @@ namespace Couchbase.Linq.QueryGeneration
 
             return expression;
         }
-
-        //public Expression VisitAndEnsureDateTimeFormat(Expression expression, N1QlDateTimeFormat expectedDateTimeFormat)
-        //{
-        //    if ((expression.Type != typeof (DateTime)) && (expression.Type != typeof (DateTime?)))
-        //    {
-        //        return VisitExpression(expression);
-        //    }
-
-        //    var result = expression;
-
-        //    if ((expectedDateTimeFormat == N1QlDateTimeFormat.IsoString) &&
-        //        (DateTimeFormat == N1QlDateTimeFormat.UnixMilliseconds))
-        //    {
-        //        _expression.Append("STR_TO_MILLIS(");
-        //        result = VisitExpression(expression);
-        //        _expression.Append(')');
-
-        //        DateTimeFormat = N1QlDateTimeFormat.IsoString;
-        //    }
-        //    else if ((expectedDateTimeFormat == N1QlDateTimeFormat.UnixMilliseconds))
-        //    {
-                
-        //    }
-
-        //    return result;
-        //}
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using Couchbase.Core.Serialization;
 using Couchbase.Linq.Clauses;
 using Couchbase.Linq.Operators;
 using Couchbase.Linq.QueryGeneration.ExpressionTransformers;
@@ -44,14 +45,16 @@ namespace Couchbase.Linq.QueryGeneration
         /// </summary>
         private ExpressionTransformerRegistry _groupingExpressionTransformerRegistry;
 
-        public N1QlQueryModelVisitor(IMemberNameResolver memberNameResolver, IMethodCallTranslatorProvider methodCallTranslatorProvider)
+        public N1QlQueryModelVisitor(IMemberNameResolver memberNameResolver, IMethodCallTranslatorProvider methodCallTranslatorProvider,
+            ITypeSerializer serializer)
         {
             _queryGenerationContext = new N1QlQueryGenerationContext()
             {
                 //MemberNameResolver = new JsonNetMemberNameResolver(ClusterHelper.Get().Configuration.SerializationSettings.ContractResolver),
                 //MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
                 MemberNameResolver = memberNameResolver,
-                MethodCallTranslatorProvider = methodCallTranslatorProvider
+                MethodCallTranslatorProvider = methodCallTranslatorProvider,
+                Serializer = serializer
             };
         }
 
@@ -76,9 +79,10 @@ namespace Couchbase.Linq.QueryGeneration
             }
         }
 
-        public static string GenerateN1QlQuery(QueryModel queryModel, IMemberNameResolver memberNameResolver, IMethodCallTranslatorProvider methodCallTranslatorProvider)
+        public static string GenerateN1QlQuery(QueryModel queryModel, IMemberNameResolver memberNameResolver,
+            IMethodCallTranslatorProvider methodCallTranslatorProvider, ITypeSerializer serializer)
         {
-            var visitor = new N1QlQueryModelVisitor(memberNameResolver, methodCallTranslatorProvider);
+            var visitor = new N1QlQueryModelVisitor(memberNameResolver, methodCallTranslatorProvider, serializer);
             visitor.VisitQueryModel(queryModel);
             return visitor.GetQuery();
         }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Couchbase.Core.Serialization;
 using Newtonsoft.Json.Serialization;
 using Remotion.Linq.Clauses.Expressions;
 
@@ -18,6 +19,7 @@ namespace Couchbase.Linq.QueryGeneration
         public IMemberNameResolver MemberNameResolver { get; set; }
         public IMethodCallTranslatorProvider MethodCallTranslatorProvider { get; set; }
         public ParameterAggregator ParameterAggregator { get; set; }
+        public ITypeSerializer Serializer { get; set; }
 
         /// <summary>
         /// Stores a reference to the current grouping subquery

--- a/Src/Couchbase.Linq/UnixMillisecondsDateTime.cs
+++ b/Src/Couchbase.Linq/UnixMillisecondsDateTime.cs
@@ -103,15 +103,5 @@ namespace Couchbase.Linq
         {
             return left._dateTime <= right._dateTime;
         }
-
-        //public static implicit operator UnixMillisecondsDateTime(DateTime dateTime)
-        //{
-        //    return FromDateTime(dateTime);
-        //}
-
-        //public static implicit operator DateTime(UnixMillisecondsDateTime unixMillisecondsDateTime)
-        //{
-        //    return ToDateTime(unixMillisecondsDateTime);
-        //}
     }
 }

--- a/Src/Couchbase.Linq/UnixMillisecondsDateTime.cs
+++ b/Src/Couchbase.Linq/UnixMillisecondsDateTime.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Used internally during query generation to represent a DateTime in unix milliseconds format.
+    /// This class is not instantiated or used, it only exists in Expression trees.
+    /// </summary>
+    internal struct UnixMillisecondsDateTime
+    {
+        private readonly DateTime _dateTime;
+
+        private UnixMillisecondsDateTime(DateTime dateTime)
+        {
+            _dateTime = dateTime;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj.GetType() != typeof (UnixMillisecondsDateTime))
+            {
+                return false;
+            }
+
+            return _dateTime == ((UnixMillisecondsDateTime) obj)._dateTime;
+        }
+
+        public override int GetHashCode()
+        {
+            return _dateTime.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            // ReSharper disable once SpecifyACultureInStringConversionExplicitly
+            return _dateTime.ToString();
+        }
+
+        public static UnixMillisecondsDateTime FromDateTime(DateTime dateTime)
+        {
+            return new UnixMillisecondsDateTime(dateTime);
+        }
+
+        public static UnixMillisecondsDateTime? FromDateTime(DateTime? dateTime)
+        {
+            if (dateTime.HasValue)
+            {
+                return new UnixMillisecondsDateTime(dateTime.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public static DateTime ToDateTime(UnixMillisecondsDateTime unixMillisecondsDateTime)
+        {
+            return unixMillisecondsDateTime._dateTime;
+        }
+
+        public static DateTime? ToDateTime(UnixMillisecondsDateTime? unixMillisecondsDateTime)
+        {
+            if (unixMillisecondsDateTime.HasValue)
+            {
+                return unixMillisecondsDateTime.Value._dateTime;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public static bool operator ==(UnixMillisecondsDateTime left, UnixMillisecondsDateTime right)
+        {
+            return left._dateTime == right._dateTime;
+        }
+
+        public static bool operator !=(UnixMillisecondsDateTime left, UnixMillisecondsDateTime right)
+        {
+            return left._dateTime != right._dateTime;
+        }
+
+        public static bool operator >(UnixMillisecondsDateTime left, UnixMillisecondsDateTime right)
+        {
+            return left._dateTime > right._dateTime;
+        }
+
+        public static bool operator <(UnixMillisecondsDateTime left, UnixMillisecondsDateTime right)
+        {
+            return left._dateTime < right._dateTime;
+        }
+
+        public static bool operator >=(UnixMillisecondsDateTime left, UnixMillisecondsDateTime right)
+        {
+            return left._dateTime >= right._dateTime;
+        }
+
+        public static bool operator <=(UnixMillisecondsDateTime left, UnixMillisecondsDateTime right)
+        {
+            return left._dateTime <= right._dateTime;
+        }
+
+        //public static implicit operator UnixMillisecondsDateTime(DateTime dateTime)
+        //{
+        //    return FromDateTime(dateTime);
+        //}
+
+        //public static implicit operator DateTime(UnixMillisecondsDateTime unixMillisecondsDateTime)
+        //{
+        //    return ToDateTime(unixMillisecondsDateTime);
+        //}
+    }
+}


### PR DESCRIPTION
Motivation
----------
Working with date/time values in documents is a very common use case.  For
example, querying documents modified since a certain date.  Or invoices
within a certain date range.  To support this via LINQ, support for
including date/time constants and for comparing these constants to
document properties is needed.

Modifications
-------------
Before visiting expressions with the N1QL expression tree visitor, they
are first passed through a TransformingExpressionTreeVisitor registered
with a DateTimeComparisonExpressionTransformer.  This converts any
DateTime values on binary comparison expressions to method calls that
convert them to UnixMilliseconds objects.

UnixMilliseconds structures act in .Net as a simple wrapper for a
DateTime, since that is still the most efficient way to work with them in
.Net.  However, the UnixMillisecondsMethodCallTranslator can now detect
this conversion and treat it as a call to STR_TO_MILLIS in N1QL.

The UnixMilliseconds structure is declared internal, and isn't designed
for public use.  It's only intended for use inside expression trees.
However, it does have some basic methods in case they are needed for unit
testing.

For constants, the configured ITypeSerializer for Couchbase is used to
serialize the constant to a string (normally ISO8601) before writing to
the N1QL query.

Results
-------
Date/time constants may now be freely placed in N1QL queries as ISO8601
strings via LINQ.  These constants and/or document properties can now be
used on either side of <, >, <=, >=, =, and <> operators.

Notes
-----
For this basic implementation where only comparisons are supported, using
a TransformingExpressionTreeVisitor may be a bit overkill.  However, it
should provide a more powerful platform for supporting more advanced
functionality in the future, such as date arithmetic.