### PR TITLE
Fixed automated test binding redirects

### DIFF
--- a/Src/Couchbase.Linq.Tests/App.config
+++ b/Src/Couchbase.Linq.Tests/App.config
@@ -43,7 +43,7 @@
 
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
 
-        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
 
       </dependentAssembly>
 
@@ -52,6 +52,22 @@
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
 
         <bindingRedirect oldVersion="0.0.0.0-1.2.11.0" newVersion="1.2.11.0" />
+
+      </dependentAssembly>
+
+      <dependentAssembly>
+
+        <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
+
+        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
+
+      </dependentAssembly>
+
+      <dependentAssembly>
+
+        <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
+
+        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
 
       </dependentAssembly>
 


### PR DESCRIPTION
Motivation
------------
Most of the automated tests were failing with assembly version errors since recent updates to Nuget packages.

Modifications
---------------
Updated app.config for the test assembly to reference Newtonsoft.Json 7.0.0.0 and Common.Logging 3.3.0.0.