### PR TITLE
Make QueryGeneration, Clauses, and Operators internal

### DIFF
--- a/Src/Couchbase.Linq/Clauses/NestClause.cs
+++ b/Src/Couchbase.Linq/Clauses/NestClause.cs
@@ -6,7 +6,7 @@ using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.Clauses
 {
-    public class NestClause : IBodyClause, IQuerySource
+    internal class NestClause : IBodyClause, IQuerySource
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="NestClause" /> class.

--- a/Src/Couchbase.Linq/Clauses/NestExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/NestExpressionNode.cs
@@ -7,7 +7,7 @@ using Remotion.Linq.Parsing.Structure.IntermediateModel;
 
 namespace Couchbase.Linq.Clauses
 {
-    public class NestExpressionNode : MethodCallExpressionNodeBase, IQuerySourceExpressionNode
+    internal class NestExpressionNode : MethodCallExpressionNodeBase, IQuerySourceExpressionNode
     {
         public static readonly MethodInfo[] SupportedMethods =
         {

--- a/Src/Couchbase.Linq/Clauses/UseKeysClause.cs
+++ b/Src/Couchbase.Linq/Clauses/UseKeysClause.cs
@@ -6,7 +6,7 @@ using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.Clauses
 {
-    public class UseKeysClause : IBodyClause
+    internal class UseKeysClause : IBodyClause
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="UseKeysClause" /> class.

--- a/Src/Couchbase.Linq/Clauses/UseKeysExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/UseKeysExpressionNode.cs
@@ -7,7 +7,7 @@ using Remotion.Linq.Parsing.Structure.IntermediateModel;
 
 namespace Couchbase.Linq.Clauses
 {
-    public class UseKeysExpressionNode : MethodCallExpressionNodeBase
+    internal class UseKeysExpressionNode : MethodCallExpressionNodeBase
     {
         public static readonly MethodInfo[] SupportedMethods =
         {

--- a/Src/Couchbase.Linq/Operators/ExplainExpressionNode.cs
+++ b/Src/Couchbase.Linq/Operators/ExplainExpressionNode.cs
@@ -9,7 +9,7 @@ namespace Couchbase.Linq.Operators
     /// <summary>
     /// Expression parser for N1QL "Explain" method.
     /// </summary>
-    public class ExplainExpressionNode : ResultOperatorExpressionNodeBase
+    internal class ExplainExpressionNode : ResultOperatorExpressionNodeBase
     {
         public static MethodInfo[] SupportedMethods =
         {

--- a/Src/Couchbase.Linq/Operators/ExplainResultOperator.cs
+++ b/Src/Couchbase.Linq/Operators/ExplainResultOperator.cs
@@ -6,7 +6,7 @@ using Remotion.Linq.Clauses.StreamedData;
 
 namespace Couchbase.Linq.Operators
 {
-    public class ExplainResultOperator : ValueFromSequenceResultOperatorBase
+    internal class ExplainResultOperator : ValueFromSequenceResultOperatorBase
     {
         public override StreamedValue ExecuteInMemory<T>(StreamedSequence input)
         {

--- a/Src/Couchbase.Linq/Properties/AssemblyInfo.cs
+++ b/Src/Couchbase.Linq/Properties/AssemblyInfo.cs
@@ -38,4 +38,9 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+// For writing tests against internal classes
 [assembly: InternalsVisibleTo("Couchbase.Linq.Tests")]
+
+// For using Moq against internal classes
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
@@ -11,7 +11,7 @@ namespace Couchbase.Linq.QueryGeneration
     /// Provides default method call translator provider for N1QL expressions.
     /// Uses classes implementing IMethodCallTranslator defined in Couchbase.Linq assembly
     /// </summary>
-    public class DefaultMethodCallTranslatorProvider : IMethodCallTranslatorProvider
+    internal class DefaultMethodCallTranslatorProvider : IMethodCallTranslatorProvider
     {
 
         #region Static

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
@@ -15,7 +15,7 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
     /// will later interpret the calls as STR_TO_MILLIS() calls in N1QL.  N1QL can't directly compare
     /// date/time values unless they're converted to Unix milliseconds first.
     /// </summary>
-    class DateTimeComparisonExpressionTransformer : IExpressionTransformer<BinaryExpression>
+    internal class DateTimeComparisonExpressionTransformer : IExpressionTransformer<BinaryExpression>
     {
         private static readonly MethodInfo FromDateTimeMethod =
             typeof (UnixMillisecondsDateTime).GetMethod("FromDateTime", new[] { typeof(DateTime) });

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeTransformationRegistry.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeTransformationRegistry.cs
@@ -10,7 +10,7 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
     /// <summary>
     /// Default registry of expression transformers used to convert DateTime expressions as needed for N1QL
     /// </summary>
-    class DateTimeTransformationRegistry
+    internal class DateTimeTransformationRegistry
     {
         /// <summary>
         /// Default registry of expression transformers used to convert DateTime expressions as needed for N1QL

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/KeyExpressionTransfomer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/KeyExpressionTransfomer.cs
@@ -15,7 +15,7 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
     /// Used to convert references to the Key of a GroupBy statement to directly access the property
     /// used to make the key.  This is done after a grouping subquery is flattened into the main N1QL query.
     /// </summary>
-    class KeyExpressionTransfomer : IExpressionTransformer<MemberExpression>
+    internal class KeyExpressionTransfomer : IExpressionTransformer<MemberExpression>
     {
         public ExpressionType[] SupportedExpressionTypes
         {

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/MultiKeyExpressionTransfomer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/MultiKeyExpressionTransfomer.cs
@@ -16,7 +16,7 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
     /// used to make the key.  This is done after a grouping subquery is flattened into the main N1QL query.
     /// The MultiKeyExpressionTransformer variant is used for multipart keys, where accessing members of the Key property.
     /// </summary>
-    class MultiKeyExpressionTransfomer : IExpressionTransformer<MemberExpression>
+    internal class MultiKeyExpressionTransfomer : IExpressionTransformer<MemberExpression>
     {
         public ExpressionType[] SupportedExpressionTypes
         {

--- a/Src/Couchbase.Linq/QueryGeneration/Expressions/StringComparisonExpression.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/Expressions/StringComparisonExpression.cs
@@ -10,7 +10,7 @@ namespace Couchbase.Linq.QueryGeneration.Expressions
     /// <summary>
     /// Represents a comparison between two strings
     /// </summary>
-    public class StringComparisonExpression : Expression
+    internal class StringComparisonExpression : Expression
     {
 
         public static readonly ExpressionType[] SupportedOperations =

--- a/Src/Couchbase.Linq/QueryGeneration/IMemberNameResolver.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/IMemberNameResolver.cs
@@ -2,7 +2,7 @@
 
 namespace Couchbase.Linq.QueryGeneration
 {
-    public interface IMemberNameResolver
+    internal interface IMemberNameResolver
     {
         bool TryResolveMemberName(MemberInfo member, out string memberName);
     }

--- a/Src/Couchbase.Linq/QueryGeneration/IMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/IMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration
 {
-    public interface IMethodCallTranslator
+    internal interface IMethodCallTranslator
     {
         IEnumerable<MethodInfo> SupportMethods { get; }
 

--- a/Src/Couchbase.Linq/QueryGeneration/IMethodCallTranslatorProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/IMethodCallTranslatorProvider.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration
 {
-    public interface IMethodCallTranslatorProvider
+    internal interface IMethodCallTranslatorProvider
     {
         IMethodCallTranslator GetTranslator(MethodCallExpression methodCallExpression);
     }

--- a/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
@@ -9,7 +9,7 @@ using Remotion.Linq;
 
 namespace Couchbase.Linq.QueryGeneration
 {
-    public interface IN1QlQueryModelVisitor : IQueryModelVisitor
+    internal interface IN1QlQueryModelVisitor : IQueryModelVisitor
     {
         void VisitNestClause(NestClause clause, QueryModel queryModel, int index);
 

--- a/Src/Couchbase.Linq/QueryGeneration/JsonNetMemberNameResolver.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/JsonNetMemberNameResolver.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace Couchbase.Linq.QueryGeneration
 {
-    public class JsonNetMemberNameResolver : IMemberNameResolver
+    internal class JsonNetMemberNameResolver : IMemberNameResolver
     {
         private readonly IContractResolver _contractResolver;
 

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ConcatMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ConcatMethodCallTranslator.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class ConcatMethodCallTranslator : IMethodCallTranslator
+    internal class ConcatMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
             typeof (string).GetMethod("Concat", new[] { typeof (object) }),

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ContainsMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ContainsMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class ContainsMethodCallTranslator : IMethodCallTranslator
+    internal class ContainsMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
             typeof (string).GetMethod("Contains")

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsMissingMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsMissingMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class IsMissingMethodCallTranslator : IMethodCallTranslator
+    internal class IsMissingMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
             typeof (N1Ql).GetMethods().Where(p => (p.Name == "IsMissing") || (p.Name == "IsNotMissing")).ToArray();

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsValuedMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsValuedMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class IsValuedMethodCallTranslator : IMethodCallTranslator
+    internal class IsValuedMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
             typeof (N1Ql).GetMethods().Where(p => (p.Name == "IsValued") || (p.Name == "IsNotValued")).ToArray();

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class KeyMethodCallTranslator : IMethodCallTranslator
+    internal class KeyMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
             typeof (N1Ql).GetMethod("Key")

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ListIndexMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ListIndexMethodCallTranslator.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class ListIndexMethodCallTranslator : IMethodCallTranslator
+    internal class ListIndexMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
             typeof (IList).GetMethod("get_Item"),

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MathMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MathMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class MathMethodCallTranslator : IMethodCallTranslator
+    internal class MathMethodCallTranslator : IMethodCallTranslator
     {
         /// <summary>
         /// Maps System.Math method call names to N1QL functions

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MetaMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MetaMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class MetaMethodCallTranslator : IMethodCallTranslator
+    internal class MetaMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
             typeof (N1Ql).GetMethod("Meta")

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringCapitalizationMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringCapitalizationMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class StringCapitalizationMethodCallTranslator : IMethodCallTranslator
+    internal class StringCapitalizationMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringIndexOfMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringIndexOfMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class StringIndexOfMethodCallTranslator : IMethodCallTranslator
+    internal class StringIndexOfMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringLengthMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringLengthMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class StringLengthMethodCallTranslator : IMethodCallTranslator
+    internal class StringLengthMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringReplaceMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringReplaceMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class StringReplaceMethodCallTranslator : IMethodCallTranslator
+    internal class StringReplaceMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class StringSplitMethodCallTranslator : IMethodCallTranslator
+    internal class StringSplitMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class StringTrimMethodCallTranslator : IMethodCallTranslator
+    internal class StringTrimMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubqueryMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubqueryMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class SubqueryMethodCallTranslator : IMethodCallTranslator
+    internal class SubqueryMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubstringMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubstringMethodCallTranslator.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class SubstringMethodCallTranslator : IMethodCallTranslator
+    internal class SubstringMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/UnixMillisecondsMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/UnixMillisecondsMethodCallTranslator.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
-    class UnixMillisecondsMethodCallTranslator : IMethodCallTranslator
+    internal class UnixMillisecondsMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
             typeof (UnixMillisecondsDateTime).GetMethod("FromDateTime", new[] { typeof (DateTime) }),

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -13,7 +13,7 @@ using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
 
 namespace Couchbase.Linq.QueryGeneration
 {
-    public class N1QlExpressionTreeVisitor : ThrowingExpressionTreeVisitor
+    internal class N1QlExpressionTreeVisitor : ThrowingExpressionTreeVisitor
     {
         private static readonly MethodInfo[] StringCompareMethods = {
            typeof(string).GetMethod("Compare", new[] { typeof(string), typeof(string) }),

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLFromQueryPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLFromQueryPart.cs
@@ -6,7 +6,7 @@ namespace Couchbase.Linq.QueryGeneration
     /// <summary>
     /// Represents the FROM part of a query
     /// </summary>
-    public class N1QlFromQueryPart
+    internal class N1QlFromQueryPart
     {
 
         /// <summary>

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLLetQueryPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLLetQueryPart.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represents an item in the LET part of a N1QL query
     /// </summary>
-    public class N1QlLetQueryPart
+    internal class N1QlLetQueryPart
     {
         /// <summary>
         /// Name of the value being assigned

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -15,7 +15,7 @@ using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
 
 namespace Couchbase.Linq.QueryGeneration
 {
-    public class N1QlQueryModelVisitor : QueryModelVisitorBase, IN1QlQueryModelVisitor
+    internal class N1QlQueryModelVisitor : QueryModelVisitorBase, IN1QlQueryModelVisitor
     {
         #region Constants
         private enum GroupingStatus

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represents the type of query or subquery being generated
     /// </summary>
-    public enum N1QlQueryType
+    internal enum N1QlQueryType
     {
         /// <summary>
         /// Main SELECT statement

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlExtentNameProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlExtentNameProvider.cs
@@ -10,7 +10,7 @@ namespace Couchbase.Linq.QueryGeneration
     /// <summary>
     /// Provides unique names to use in N1QL queries for each IQuerySource extent
     /// </summary>
-    public class N1QlExtentNameProvider
+    internal class N1QlExtentNameProvider
     {
         private const string ExtentNameFormat = "Extent{0}";
 

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlHelpers.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlHelpers.cs
@@ -9,7 +9,7 @@ namespace Couchbase.Linq.QueryGeneration
     /// <summary>
     /// Helpers for N1QL query generation
     /// </summary>
-    public static class N1QlHelpers
+    internal static class N1QlHelpers
     {
 
         /// <summary>

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
@@ -12,7 +12,7 @@ namespace Couchbase.Linq.QueryGeneration
     /// <summary>
     /// Used to pass query generation context between various classes
     /// </summary>
-    public class N1QlQueryGenerationContext
+    internal class N1QlQueryGenerationContext
     {
 
         public N1QlExtentNameProvider ExtentNameProvider { get; set; }

--- a/Src/Couchbase.Linq/QueryGeneration/NamedParameter.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/NamedParameter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Couchbase.Linq.QueryGeneration
 {
-    public sealed class NamedParameter
+    internal sealed class NamedParameter
     {
         public string Name { get; set; }
         public object Value { get; set; }

--- a/Src/Couchbase.Linq/QueryGeneration/ParameterAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ParameterAggregator.cs
@@ -2,7 +2,7 @@
 
 namespace Couchbase.Linq.QueryGeneration
 {
-    public sealed class ParameterAggregator
+    internal sealed class ParameterAggregator
     {
         private readonly List<NamedParameter> _parameters = new List<NamedParameter>();
 

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -7,7 +7,7 @@ using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.QueryGeneration
 {
-    public class QueryPartsAggregator
+    internal class QueryPartsAggregator
     {
         private static readonly ILog Log = LogManager.GetCurrentClassLogger();
 

--- a/Src/Couchbase.Linq/QueryGeneration/UnclaimedGroupJoin.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/UnclaimedGroupJoin.cs
@@ -7,7 +7,7 @@ using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.QueryGeneration
 {
-    class UnclaimedGroupJoin
+    internal class UnclaimedGroupJoin
     {
 
         public JoinClause JoinClause { get; set; }


### PR DESCRIPTION
Fixes issue #52

Motivation
----------
Reduce exposed API surface area.  Allow for the addition of more user
friendly extensibility points in the future.

Modifications
-------------
All public classes in the QueryGeneration, Clauses, and Operators
namespaces are now marked internal.  Added an InternalVisiblesTo attribute
for Moq to support tests that need to Mock any of these classes.