### PR TITLE
LINQ-20: Add Save and Remove to IBucketContext

### DIFF
--- a/Src/Couchbase.Linq.Tests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.Tests/BucketContextTests.cs
@@ -1,0 +1,102 @@
+﻿using Couchbase.Core;
+using Couchbase.IO;
+using Couchbase.Linq.Tests.Documents;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.Tests
+{
+    [TestFixture]
+    public class BucketContextTests
+    {
+        [Test]
+        public void GetDocumentId_When_Id_Field_DoesNotExist_Throw_MissingIndentifier_Exception()
+        {
+            var route = new Route();
+            var bucket = new Mock<IBucket>();
+            var ctx = new BucketContext(bucket.Object);
+            Assert.Throws<DocumentIdMissingException>(()=>ctx.GetDocumentId(route));
+        }
+
+        [Test]
+        public void GetDocumentId_When_DocId_Exists_Use_It()
+        {
+            var beer = new Beer();
+            var bucket = new Mock<IBucket>();
+            var ctx = new BucketContext(bucket.Object);
+            var id = ctx.GetDocumentId(beer);
+            Assert.AreEqual("name", id);
+        }
+
+       [Test]
+        public void Save_When_Write_Is_Succesful_Return_Success()
+        {
+            var beer = new Beer();
+            var bucket = new Mock<IBucket>();
+            var result = new Mock<IOperationResult<Beer>> ();
+            result.Setup(x => x.Status).Returns(ResponseStatus.Success);
+            bucket.Setup(x => x.Upsert(It.IsAny<string>(), It.IsAny<Beer>())).Returns(result.Object);
+            var ctx = new BucketContext(bucket.Object);
+            ctx.Save(beer);
+        }
+
+       [Test]
+       public void Save_When_DocId_Is_Not_Defined_Throw_DocumentIdMissingException()
+       {
+           var brewery = new Brewery();
+           var bucket = new Mock<IBucket>();
+           var result = new Mock<IOperationResult<Brewery>>();
+           result.Setup(x => x.Status).Returns(ResponseStatus.Success);
+           bucket.Setup(x => x.Upsert(It.IsAny<string>(), It.IsAny<Brewery>())).Returns(result.Object);
+           var ctx = new BucketContext(bucket.Object);
+           Assert.Throws<DocumentIdMissingException>(()=>ctx.Save(brewery));
+       }
+
+       [Test]
+       public void Remove_When_Write_Is_Succesful_Return_Success()
+       {
+           var beer = new Beer();
+           var bucket = new Mock<IBucket>();
+           var result = new Mock<IOperationResult<Beer>>();
+           result.Setup(x => x.Status).Returns(ResponseStatus.Success);
+           bucket.Setup(x => x.Remove(It.IsAny<string>())).Returns(result.Object);
+           var ctx = new BucketContext(bucket.Object);
+           ctx.Remove(beer);
+       }
+
+       [Test]
+       public void Remove_When_DocId_Is_Not_Defined_Throw_DocumentIdMissingException()
+       {
+           var brewery = new Brewery();
+           var bucket = new Mock<IBucket>();
+           var result = new Mock<IOperationResult<Brewery>>();
+           result.Setup(x => x.Status).Returns(ResponseStatus.Success);
+           bucket.Setup(x => x.Upsert(It.IsAny<string>(), It.IsAny<Brewery>())).Returns(result.Object);
+           var ctx = new BucketContext(bucket.Object);
+           Assert.Throws<DocumentIdMissingException>(() => ctx.Remove(brewery));
+       }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/Src/Couchbase.Linq.Tests/BucketContextTests_Integrated.cs
+++ b/Src/Couchbase.Linq.Tests/BucketContextTests_Integrated.cs
@@ -1,21 +1,19 @@
 ﻿using System;
 using System.Linq;
-using Couchbase.Core;
 using Couchbase.Linq.Tests.Documents;
-using Couchbase.N1QL;
 using NUnit.Framework;
 
 namespace Couchbase.Linq.Tests
 {
     [TestFixture]
-    public class DbContextTests
+    // ReSharper disable once InconsistentNaming
+    public class BucketContextTests_Integrated
     {
         [TestFixtureSetUp]
         public void TestFixtureSetUp()
         {
             ClusterHelper.Initialize(TestConfigurations.DefaultConfig());
         }
-
 
         [Test]
         public void Test_Basic_Query()
@@ -31,7 +29,6 @@ namespace Couchbase.Linq.Tests
             }
         }
 
-        /// <exception cref="InitializationException">Thrown if Initialize is not called before accessing this method.</exception>
         [Test]
         public void BeerSampleContext_Tests()
         {
@@ -45,7 +42,6 @@ namespace Couchbase.Linq.Tests
             }
         }
 
-        /// <exception cref="InitializationException">Thrown if Initialize is not called before accessing this method.</exception>
         [Test]
         public void BeerSample_Tests()
         {
@@ -61,7 +57,6 @@ namespace Couchbase.Linq.Tests
             }
         }
     }
-
 }
 
 #region [ License information          ]

--- a/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
+++ b/Src/Couchbase.Linq.Tests/Couchbase.Linq.Tests.csproj
@@ -82,6 +82,7 @@
       <HintPath>..\packages\Remotion.Linq.1.15.15.0\lib\portable-net45+wp80+wpa81+win\Remotion.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
@@ -95,9 +96,10 @@
   <ItemGroup>
     <Compile Include="BeerSample.cs" />
     <Compile Include="BeerSampleTests.cs" />
+    <Compile Include="BucketContextTests.cs" />
     <Compile Include="Clauses\NestClauseTests.cs" />
     <Compile Include="Clauses\UseKeysClauseTests.cs" />
-    <Compile Include="DbContextTests.cs" />
+    <Compile Include="BucketContextTests_Integrated.cs" />
     <Compile Include="Documents\Airline.cs" />
     <Compile Include="Documents\BeerFiltered.cs" />
     <Compile Include="Documents\Beer.cs" />

--- a/Src/Couchbase.Linq.Tests/Documents/Beer.cs
+++ b/Src/Couchbase.Linq.Tests/Documents/Beer.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using Newtonsoft.Json;
 
 namespace Couchbase.Linq.Tests.Documents
 {
     public class Beer
     {
+        [Key]
         [JsonProperty("name")]
         public string Name { get; set; }
 

--- a/Src/Couchbase.Linq/BucketContext.cs
+++ b/Src/Couchbase.Linq/BucketContext.cs
@@ -1,8 +1,13 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Reflection;
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
+using Couchbase.IO;
 using Couchbase.Linq.Filters;
+using Couchbase.Linq.Utils;
+using Newtonsoft.Json;
 
 namespace Couchbase.Linq
 {
@@ -51,6 +56,95 @@ namespace Couchbase.Linq
         public string BucketName
         {
             get { return _bucket.Name; }
+        }
+
+        /// <summary>
+        /// Saves the specified document.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="document">The document.</param>
+        /// <exception cref="DocumentIdMissingException">The document id could not be found.</exception>
+        /// <exception cref="AmbiguousMatchException">More than one of the requested attributes was found.</exception>
+        /// <exception cref="TypeLoadException">A custom attribute type cannot be loaded.</exception>
+        /// <exception cref="Exception">An internal exception was thrown.</exception>
+        public void Save<T>(T document)
+        {
+            var id = GetDocumentId(document);
+            var result = _bucket.Upsert(id, document);
+            if (!result.Success)
+            {
+                if (result.Exception != null)
+                {
+                    // ReSharper disable once ThrowingSystemException
+                    throw result.Exception;
+                }
+            }
+        }
+
+        /// <exception cref="DocumentIdMissingException">The document id could not be found.</exception>
+        /// <exception cref="AmbiguousMatchException">More than one of the requested attributes was found. </exception>
+        /// <exception cref="TypeLoadException">A custom attribute type cannot be loaded. </exception>
+        /// <exception cref="DocumentNotFoundException">No document Id was found.</exception>
+        /// <exception cref="Exception">An internal exception was thrown.</exception>
+        public void Remove<T>(T document)
+        {
+            var id = GetDocumentId(document);
+            var result = _bucket.Remove(id);
+            if (!result.Success)
+            {
+                if (result.Status == ResponseStatus.KeyNotFound)
+                {
+                    // ReSharper disable once HeapView.ObjectAllocation
+                    throw new DocumentNotFoundException(string.Format("{0}{1}", ExceptionMsgs.DocumentNotFound, id));
+                }
+                if (result.Exception != null)
+                {
+                    // ReSharper disable once ThrowingSystemException
+                    throw result.Exception;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the document identifier. Assumes that at least one property on the document has a
+        /// <see cref="KeyAttribute"/> which defines the unique indentifier field for the document.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="document">The document.</param>
+        /// <returns></returns>
+        /// <exception cref="DocumentIdMissingException">The document document id could not be found.</exception>
+        /// <exception cref="AmbiguousMatchException">More than one of the requested attributes was found.</exception>
+        /// <exception cref="TypeLoadException">A custom attribute type cannot be loaded.</exception>
+        internal string GetDocumentId<T>(T document)
+        {
+            var idName = string.Empty;
+            var type = typeof(T);
+
+            var properties = type.GetProperties();
+            foreach (var propertyInfo in properties)
+            {
+                var attribute = (KeyAttribute)Attribute.
+                    GetCustomAttribute(propertyInfo, typeof(KeyAttribute));
+
+                if (attribute != null)
+                {
+                    var jsonPropertyAttribute = (JsonPropertyAttribute)Attribute.
+                        GetCustomAttribute(propertyInfo, typeof(JsonPropertyAttribute));
+
+                    if (jsonPropertyAttribute != null)
+                    {
+                        idName = jsonPropertyAttribute.PropertyName;
+                        break;
+                    }
+                    idName = propertyInfo.Name;
+                    break;
+                }
+            }
+            if (string.IsNullOrWhiteSpace(idName))
+            {
+                throw new DocumentIdMissingException(ExceptionMsgs.DocumentIdMissing);
+            }
+            return idName;
         }
     }
 }

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -59,6 +59,7 @@
       <HintPath>..\packages\Remotion.Linq.1.15.15.0\lib\portable-net45+wp80+wpa81+win\Remotion.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
@@ -72,8 +73,10 @@
     <Compile Include="Clauses\UseKeysExpressionNode.cs" />
     <Compile Include="Clauses\UseKeysClause.cs" />
     <Compile Include="BucketContext.cs" />
+    <Compile Include="DocumentNotFoundException.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="IBucketContext.cs" />
+    <Compile Include="DocumentIdMissingException.cs" />
     <Compile Include="QueryGeneration\Expressions\StringComparisonExpression.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\DateTimeComparisonExpressionTransformer.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\DateTimeTransformationRegistry.cs" />
@@ -136,6 +139,7 @@
     <Compile Include="QueryGeneration\UnclaimedGroupJoin.cs" />
     <Compile Include="QueryParserHelper.cs" />
     <Compile Include="UnixMillisecondsDateTime.cs" />
+    <Compile Include="Utils\ExceptionMsgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -144,6 +148,7 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Src/Couchbase.Linq/DocumentIdMissingException.cs
+++ b/Src/Couchbase.Linq/DocumentIdMissingException.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Thrown if an identifier property can be found in a document. The identifier maps
+    /// to the primary key for the document in couchbase. Use <see cref=""/>
+    /// </summary>
+    public class DocumentIdMissingException : Exception
+    {
+        public DocumentIdMissingException(string message)
+            : base(message)
+        {
+        }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/Src/Couchbase.Linq/DocumentNotFoundException.cs
+++ b/Src/Couchbase.Linq/DocumentNotFoundException.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Thrown if a given key cannot be found in the bucket.
+    /// </summary>
+    public class DocumentNotFoundException : Exception
+    {
+        public DocumentNotFoundException(string message)
+            : base(message)
+        {
+        }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -25,5 +25,19 @@ namespace Couchbase.Linq
         /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
         /// <returns></returns>
         IQueryable<T> Query<T>();
+
+        /// <summary>
+        /// Saves the specified document.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="document">The document.</param>
+        void Save<T>(T document);
+
+        /// <summary>
+        /// Removes the specified document.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="document">The document.</param>
+        void Remove<T>(T document);
     }
 }

--- a/Src/Couchbase.Linq/Utils/ExceptionMsgs.cs
+++ b/Src/Couchbase.Linq/Utils/ExceptionMsgs.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.Utils
+{
+    public class ExceptionMsgs
+    {
+        public const string DocumentNotFound = "Document not found for Id: ";
+
+        public const string DocumentIdMissing = "No document Id was found; please use DocIdAttribute to define an id.";
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion


### PR DESCRIPTION
Motivation
----------
Adds an additional WRITE API for users who do not want to do change
tracking (forthecoming).

Modifications
-------------
Added Save and Remove to IBucketContext and provided implementation in
BucketContext. Added a DocId attribute so the the key for the document Add
Save and Remove to IBucketContextcan be defined from one of the fields; I
considered making a string field called "_id" the default key-field, but
removed that logic - it may come back though. I split the
BucketContextTests into integrated and UT test classes. Finally, added a
couple of exceptions for handling specific use cases such as KeyNotFound
and when a key (id) field cannot be found. Note that Save and Remove throw
exceptions; so either it succeeded or it failed and the app needs to
handle the exception and failure case.

Result
------
You can now Save and Remove documents from the BucketContext.