### PR TITLE
Refactor error handling for Remove and Save

### DIFF
--- a/Src/Couchbase.Linq.Tests/App.config
+++ b/Src/Couchbase.Linq.Tests/App.config
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+  <configSections>
+    <sectionGroup name="common">
+      <section name="logging" type="Common.Logging.ConfigurationSectionHandler, Common.Logging" />
+    </sectionGroup>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+    <sectionGroup name="couchbaseClients">
+      <section name="couchbase" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+    </sectionGroup>
+  </configSections>
+  <couchbaseClients>
+  <couchbase enableConfigHeartBeat="false">
+      <servers>
+        <!-- changes in appSettings section should also be reflected here -->
+        <add uri="http://localhost:8091"></add>
+      </servers>
+      <buckets>
+        <add></add>
+      </buckets>
+    </couchbase>
+  </couchbaseClients>
+  <common>
+    <logging>
+      <!--<factoryAdapter type="Common.Logging.Log4Net.Log4NetLoggerFactoryAdapter, Common.Logging.Log4Net">
+        <arg key="configType" value="INLINE" />
+      </factoryAdapter>-->
+      <factoryAdapter type="Common.Logging.Simple.ConsoleOutLoggerFactoryAdapter, Common.Logging">
+        <arg key="level" value="OFF" />
+        <arg key="showLogName" value="true" />
+        <arg key="showDataTime" value="true" />
+        <arg key="dateTimeFormat" value="yyyy/MM/dd HH:mm:ss:fff" />
+      </factoryAdapter>
+    </logging>
+  </common>
+
+  <runtime>
+
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+
+      <dependentAssembly>
+
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+
+      </dependentAssembly>
+
+      <dependentAssembly>
+
+        <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
+
+        <bindingRedirect oldVersion="0.0.0.0-1.2.11.0" newVersion="1.2.11.0" />
+
+      </dependentAssembly>
+
+      <dependentAssembly>
+
+        <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
+
+        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
+
+      </dependentAssembly>
+
+      <dependentAssembly>
+
+        <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
+
+        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
+
+      </dependentAssembly>
+
+    </assemblyBinding>
+
+  </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+</configuration>

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -73,10 +73,11 @@
     <Compile Include="Clauses\UseKeysExpressionNode.cs" />
     <Compile Include="Clauses\UseKeysClause.cs" />
     <Compile Include="BucketContext.cs" />
+    <Compile Include="CouchbaseWriteException.cs" />
     <Compile Include="DocumentNotFoundException.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="IBucketContext.cs" />
-    <Compile Include="DocumentIdMissingException.cs" />
+    <Compile Include="KeyAttributeMissingException.cs" />
     <Compile Include="QueryGeneration\Expressions\StringComparisonExpression.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\DateTimeComparisonExpressionTransformer.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\DateTimeTransformationRegistry.cs" />

--- a/Src/Couchbase.Linq/CouchbaseWriteException.cs
+++ b/Src/Couchbase.Linq/CouchbaseWriteException.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Couchbase.IO;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Thrown if a write operation fails - use the InnerException, Message and ResponseStatus properties to determine what went wrong.
+    /// </summary>
+    public class CouchbaseWriteException : Exception
+    {
+        private readonly IOperationResult _failedResult;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CouchbaseWriteException"/> class.
+        /// </summary>
+        /// <param name="failedResult">The <see cref="IOperationResult"/> of the failed operation.</param>
+        public CouchbaseWriteException(IOperationResult failedResult)
+            : base(failedResult.Message, failedResult.Exception)
+        {
+            _failedResult = failedResult;
+        }
+
+        /// <summary>
+        /// Gets the failure <see cref="ResponseStatus"/>.
+        /// </summary>
+        /// <value>
+        /// The response status.
+        /// </value>
+        public ResponseStatus ResponseStatus
+        {
+            get { return _failedResult.Status; }
+        }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/Src/Couchbase.Linq/KeyAttributeMissingException.cs
+++ b/Src/Couchbase.Linq/KeyAttributeMissingException.cs
@@ -4,11 +4,11 @@ namespace Couchbase.Linq
 {
     /// <summary>
     /// Thrown if an identifier property can be found in a document. The identifier maps
-    /// to the primary key for the document in couchbase. Use <see cref=""/>
+    /// to the primary key for the document in couchbase.
     /// </summary>
-    public class DocumentIdMissingException : Exception
+    public class KeyAttributeMissingException : Exception
     {
-        public DocumentIdMissingException(string message)
+        public KeyAttributeMissingException(string message)
             : base(message)
         {
         }

--- a/Src/Couchbase.Linq/Utils/ExceptionMsgs.cs
+++ b/Src/Couchbase.Linq/Utils/ExceptionMsgs.cs
@@ -10,10 +10,10 @@ namespace Couchbase.Linq.Utils
     {
         public const string DocumentNotFound = "Document not found for Id: ";
 
-        public const string DocumentIdMissing = "No document Id was found; please use DocIdAttribute to define an id.";
+        public const string KeyAttributeMissing = "No KeyAttribute could be found for the document. Please " +
+                                                  "mark a key property with a KeyAttribute";
     }
 }
-
 #region [ License information          ]
 
 /* ************************************************************


### PR DESCRIPTION
Motivation
----------
If BucketContext.Remove or Save fail throw a CouchbaseWriteException for
consistency. The CouchbaseWriteException is a wrapper around an
IOperationResult implementation and exposes the ResponseStatus and Message
fields.

Modifications
-------------
Add CouchbaseWriteException class, refactor Save and Remove to throw it
when an operation results in a non-success. Also, added PropertyInfo
caching for KeyAttribute property and fixed bug in GetDocumentId which
returned the name of the key field and not the actual value of the key.

Results
-------
If Save or Remove fail, a CouchbaseWriteException will be thrown with the
information from the IOperationResult.