### PR TITLE
Issue #62: Fix N1Ql namespace conflict with Couchbase SDK

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
@@ -48,7 +48,7 @@ namespace Couchbase.Linq.IntegrationTests
             var db = new BeerSample();
             var query = from beer in db.Beers
                         join brewery in db.Breweries
-                        on beer.BreweryId equals N1Ql.Key(brewery)
+                        on beer.BreweryId equals N1QlFunctions.Key(brewery)
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 
             foreach (var beer in query)

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -157,7 +157,7 @@ namespace Couchbase.Linq.IntegrationTests
 
                     var beers = (from b in context.Query<Beer>()
                         where b.Type == "beer"
-                        select new {name = b.Name, meta = N1Ql.Meta(b)}).
+                        select new {name = b.Name, meta = N1QlFunctions.Meta(b)}).
                         Take(10);
 
                     foreach (var b in beers)
@@ -427,7 +427,7 @@ namespace Couchbase.Linq.IntegrationTests
                     var context = new BucketContext(bucket);
 
                     var beers = (from b in context.Query<Beer>()
-                        where b.Type == "beer" && N1Ql.Meta(b).Type == "json"
+                        where b.Type == "beer" && N1QlFunctions.Meta(b).Type == "json"
                         select new {name = b.Name}).
                         Take(10);
 
@@ -449,7 +449,7 @@ namespace Couchbase.Linq.IntegrationTests
 
                     var beers = (from b in context.Query<Beer>()
                         where b.Type == "beer"
-                        select new {name = b.Name, id = N1Ql.Meta(b).Id}).
+                        select new {name = b.Name, id = N1QlFunctions.Meta(b).Id}).
                         Take(10);
 
                     foreach (var b in beers)
@@ -490,7 +490,7 @@ namespace Couchbase.Linq.IntegrationTests
 
                     var beers = from beer in context.Query<Beer>()
                         join brewery in context.Query<Brewery>()
-                            on beer.BreweryId equals N1Ql.Key(brewery)
+                            on beer.BreweryId equals N1QlFunctions.Key(brewery)
                         select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
 
                     foreach (var b in beers.Take(10))
@@ -512,7 +512,7 @@ namespace Couchbase.Linq.IntegrationTests
 
                     var beers = from beer in context.Query<Beer>()
                         join brewery in context.Query<Brewery>()
-                            on beer.BreweryId equals N1Ql.Key(brewery)
+                            on beer.BreweryId equals N1QlFunctions.Key(brewery)
                         where brewery.Geo.Longitude > -80
                         orderby beer.Name
                         select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
@@ -536,7 +536,7 @@ namespace Couchbase.Linq.IntegrationTests
 
                     var beers = from beer in context.Query<Beer>().Where(p => p.Type == "beer")
                         join brewery in context.Query<Brewery>().Where(p => p.Type == "brewery")
-                            on beer.BreweryId equals N1Ql.Key(brewery)
+                            on beer.BreweryId equals N1QlFunctions.Key(brewery)
                         where brewery.Geo.Longitude > -80
                         orderby beer.Name
                         select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
@@ -560,7 +560,7 @@ namespace Couchbase.Linq.IntegrationTests
 
                     var beers = from beer in context.Query<Beer>()
                         join breweryGroup in context.Query<Brewery>()
-                            on beer.BreweryId equals N1Ql.Key(breweryGroup) into bg
+                            on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
                         from brewery in bg.DefaultIfEmpty()
                         select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
 
@@ -583,7 +583,7 @@ namespace Couchbase.Linq.IntegrationTests
 
                     var beers = from beer in context.Query<Beer>()
                         join breweryGroup in context.Query<Brewery>()
-                            on beer.BreweryId equals N1Ql.Key(breweryGroup) into bg
+                            on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
                         from brewery in bg.DefaultIfEmpty()
                         where beer.Abv > 4
                         orderby brewery.Name, beer.Name
@@ -608,7 +608,7 @@ namespace Couchbase.Linq.IntegrationTests
 
                     var beers = from beer in context.Query<Beer>().Where(p => p.Type == "beer")
                         join breweryGroup in context.Query<Brewery>().Where(p => p.Type == "brewery")
-                            on beer.BreweryId equals N1Ql.Key(breweryGroup) into bg
+                            on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
                         from brewery in bg.DefaultIfEmpty()
                         where beer.Abv > 4
                         orderby brewery.Name, beer.Name
@@ -742,7 +742,7 @@ namespace Couchbase.Linq.IntegrationTests
                 {
                     var context = new BucketContext(bucket);
 
-                    var avg = context.Query<Beer>().Where(p => p.Type == "beer" && N1Ql.IsValued(p.Abv)).Average(p => p.Abv);
+                    var avg = context.Query<Beer>().Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv)).Average(p => p.Abv);
 
                     Console.WriteLine("Average ABV of all beers is {0}", avg);
                 }
@@ -852,7 +852,7 @@ namespace Couchbase.Linq.IntegrationTests
 
                     var breweries =
                         from beer in context.Query<Beer>()
-                        join brewery in context.Query<Brewery>() on beer.BreweryId equals N1Ql.Key(brewery)
+                        join brewery in context.Query<Brewery>() on beer.BreweryId equals N1QlFunctions.Key(brewery)
                         where beer.Type == "beer"
                         group beer by new { breweryid = beer.BreweryId, breweryName = brewery.Name }
                         into g

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
@@ -224,7 +224,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var query =
                 from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
                 join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals
-                    N1Ql.Key(brewery)
+                    N1QlFunctions.Key(brewery)
                 group beer by brewery.Name
                 into g
                 select new {breweryName = g.Key, avgAbv = g.Average(p => p.Abv)};
@@ -252,7 +252,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query =
                 from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
-                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1Ql.Key(brewery)
+                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1QlFunctions.Key(brewery)
                 group beer by brewery.Name
                 into g
                 orderby g.Key
@@ -278,7 +278,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query =
                 from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
-                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1Ql.Key(brewery)
+                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1QlFunctions.Key(brewery)
                 group beer by brewery.Name
                 into g
                 orderby g.Average(p => p.Abv) descending 
@@ -308,7 +308,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query =
                 from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
-                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1Ql.Key(brewery)
+                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1QlFunctions.Key(brewery)
                 group beer by brewery.Name
                 into g
                 where string.Compare(g.Key, "N") >= 0 
@@ -334,7 +334,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query =
                 from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
-                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1Ql.Key(brewery)
+                join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object) on beer.BreweryId equals N1QlFunctions.Key(brewery)
                 group beer by brewery.Name
                 into g
                 where g.Average(p => p.Abv) >= 6

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/IsMissingTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/IsMissingTests.cs
@@ -21,7 +21,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Where(p => N1Ql.IsMissing(p.Age));
+                .Where(p => N1QlFunctions.IsMissing(p.Age));
 
             const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`age` IS MISSING";
 
@@ -37,7 +37,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Where(p => N1Ql.IsMissing(p, "test"));
+                .Where(p => N1QlFunctions.IsMissing(p, "test"));
 
             const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`test` IS MISSING";
 
@@ -53,7 +53,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Where(p => N1Ql.IsNotMissing(p.Age));
+                .Where(p => N1QlFunctions.IsNotMissing(p.Age));
 
             const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`age` IS NOT MISSING";
 
@@ -69,7 +69,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Where(p => N1Ql.IsNotMissing(p, "test"));
+                .Where(p => N1QlFunctions.IsNotMissing(p, "test"));
 
             const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`test` IS NOT MISSING";
 
@@ -85,7 +85,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Select(p => new {age = N1Ql.IsMissing(p.Age) ? 10 : p.Age});
+                .Select(p => new {age = N1QlFunctions.IsMissing(p.Age) ? 10 : p.Age});
 
             const string expected = "SELECT CASE WHEN `Extent1`.`age` IS MISSING THEN 10 ELSE `Extent1`.`age` END as `age` FROM `default` as `Extent1`";
 
@@ -101,7 +101,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Where(p => N1Ql.IsValued(p.Age));
+                .Where(p => N1QlFunctions.IsValued(p.Age));
 
             const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`age` IS VALUED";
 
@@ -117,7 +117,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Where(p => N1Ql.IsValued(p, "test"));
+                .Where(p => N1QlFunctions.IsValued(p, "test"));
 
             const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`test` IS VALUED";
 
@@ -133,7 +133,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Where(p => N1Ql.IsNotValued(p.Age));
+                .Where(p => N1QlFunctions.IsNotValued(p.Age));
 
             const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`age` IS NOT VALUED";
 
@@ -149,7 +149,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Where(p => N1Ql.IsNotValued(p, "test"));
+                .Where(p => N1QlFunctions.IsNotValued(p, "test"));
 
             const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`test` IS NOT VALUED";
 
@@ -165,7 +165,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Select(p => new { age = N1Ql.IsNotValued(p.Age) ? 10 : p.Age });
+                .Select(p => new { age = N1QlFunctions.IsNotValued(p.Age) ? 10 : p.Age });
 
             const string expected = "SELECT CASE WHEN `Extent1`.`age` IS NOT VALUED THEN 10 ELSE `Extent1`.`age` END as `age` FROM `default` as `Extent1`";
 

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/JoinTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/JoinTests.cs
@@ -23,7 +23,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
                         join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object)
-                        on beer.BreweryId equals N1Ql.Key(brewery)
+                        on beer.BreweryId equals N1QlFunctions.Key(brewery)
                         select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
 
             const string expected = "SELECT `Extent1`.`name` as `Name`, `Extent1`.`abv` as `Abv`, `Extent2`.`name` as `BreweryName` " +
@@ -44,7 +44,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
                         join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object)
-                        on beer.BreweryId equals N1Ql.Key(brewery)
+                        on beer.BreweryId equals N1QlFunctions.Key(brewery)
                         where brewery.Geo.Longitude > -80
                         orderby beer.Name
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
@@ -69,7 +69,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object).Where(p => p.Type == "beer")
                         join brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object).Where(p => p.Type == "brewery")
-                        on beer.BreweryId equals N1Ql.Key(brewery)
+                        on beer.BreweryId equals N1QlFunctions.Key(brewery)
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 
             const string expected = "SELECT `Extent1`.`name` as `Name`, `Extent1`.`abv` as `Abv`, `Extent2`.`name` as `BreweryName` " +
@@ -91,7 +91,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
                         join breweryGroup in QueryFactory.Queryable<Brewery>(mockBucket.Object)
-                        on beer.BreweryId equals N1Ql.Key(breweryGroup) into bg
+                        on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
                         from brewery in bg.DefaultIfEmpty()
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 
@@ -113,7 +113,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object)
                         join breweryGroup in QueryFactory.Queryable<Brewery>(mockBucket.Object)
-                        on beer.BreweryId equals N1Ql.Key(breweryGroup) into bg
+                        on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
                         from brewery in bg.DefaultIfEmpty()
                         where beer.Abv > 4
                         orderby brewery.Name, beer.Name
@@ -139,7 +139,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query = from beer in QueryFactory.Queryable<Beer>(mockBucket.Object).Where(p => p.Type == "beer")
                         join breweryGroup in QueryFactory.Queryable<Brewery>(mockBucket.Object).Where(p => p.Type == "brewery")
-                        on beer.BreweryId equals N1Ql.Key(breweryGroup) into bg
+                        on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
                         from brewery in bg.DefaultIfEmpty()
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/MetaTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/MetaTests.cs
@@ -22,7 +22,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Select(p => N1Ql.Meta(p));
+                .Select(p => N1QlFunctions.Meta(p));
 
             const string expected = "SELECT META(`Extent1`) FROM `default` as `Extent1`";
 
@@ -38,7 +38,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Select(c=> new {c.Age, Meta = N1Ql.Meta(c)});
+                .Select(c=> new {c.Age, Meta = N1QlFunctions.Meta(c)});
 
 
             const string expected = "SELECT `Extent1`.`age` as `Age`, META(`Extent1`) as `Meta` FROM `default` as `Extent1`";
@@ -51,7 +51,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         [Test]
         public void Test_Meta_Fakeable()
         {
-            // Confirms that the N1Ql.Meta operation can be faked for unit testing in a client application
+            // Confirms that the N1QlFunctions.Meta operation can be faked for unit testing in a client application
 
             var metadata = new DocumentMetadata()
             {
@@ -65,7 +65,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var data = (new List<Brewery> {mockObject.Object}).AsQueryable();
 
-            var query = from p in data select N1Ql.Meta(p).Id;
+            var query = from p in data select N1QlFunctions.Meta(p).Id;
 
             Assert.AreEqual(metadata.Id, query.First());
         }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/WhereClauseTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/WhereClauseTests.cs
@@ -40,7 +40,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var query =
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
                     .Where(e => e.Email == "something@gmail.com")
-                    .Where(g => N1Ql.IsMissing(g.Age))
+                    .Where(g => N1QlFunctions.IsMissing(g.Age))
                     .OrderBy(e => e.Age)
                     .Select(e => new {age = e.Age, name = e.FirstName});
 

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -136,7 +136,7 @@
     <Compile Include="QueryGeneration\ParameterAggregator.cs" />
     <Compile Include="QueryGeneration\QueryPartsAggregator.cs" />
     <Compile Include="Metadata\DocumentMetadata.cs" />
-    <Compile Include="N1QL.cs" />
+    <Compile Include="N1QlFunctions.cs" />
     <Compile Include="QueryGeneration\UnclaimedGroupJoin.cs" />
     <Compile Include="QueryParserHelper.cs" />
     <Compile Include="UnixMillisecondsDateTime.cs" />

--- a/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
@@ -90,7 +90,7 @@ namespace Couchbase.Linq.Extensions
             // Create a dictionary on the inner sequence, based on document key
             // This ensures that the inner sequence is only enumerated once
             // And that lookups are fast
-            var innerDictionary = inner.ToDictionary(p => N1Ql.Key(p));
+            var innerDictionary = inner.ToDictionary(p => N1QlFunctions.Key(p));
 
             return outer
                 .Select(outerDocument =>
@@ -148,7 +148,7 @@ namespace Couchbase.Linq.Extensions
                 throw new ArgumentNullException("keys");
             }
 
-            return items.Where(p => keys.Contains(N1Ql.Key(p)));
+            return items.Where(p => keys.Contains(N1QlFunctions.Key(p)));
         }
 
         #endregion

--- a/Src/Couchbase.Linq/Metadata/IDocumentMetadataProvider.cs
+++ b/Src/Couchbase.Linq/Metadata/IDocumentMetadataProvider.cs
@@ -6,7 +6,7 @@
     /// <remarks>
     /// Used by a unit test to fake the results of a META operation in a Linq2Couchbase query
     /// </remarks>
-    /// <seealso cref="N1Ql.Meta" />
+    /// <seealso cref="N1QlFunctions.Meta" />
     public interface IDocumentMetadataProvider
     {
 

--- a/Src/Couchbase.Linq/N1QlFunctions.cs
+++ b/Src/Couchbase.Linq/N1QlFunctions.cs
@@ -6,7 +6,7 @@ namespace Couchbase.Linq
     /// <summary>
     /// Implements static helper methods for N1QL queries 
     /// </summary>
-    public static class N1Ql
+    public static class N1QlFunctions
     {
 
         /// <summary>

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsMissingMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsMissingMethodCallTranslator.cs
@@ -11,7 +11,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class IsMissingMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
-            typeof (N1Ql).GetMethods().Where(p => (p.Name == "IsMissing") || (p.Name == "IsNotMissing")).ToArray();
+            typeof (N1QlFunctions).GetMethods().Where(p => (p.Name == "IsMissing") || (p.Name == "IsNotMissing")).ToArray();
 
         public IEnumerable<MethodInfo> SupportMethods
         {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsValuedMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsValuedMethodCallTranslator.cs
@@ -11,7 +11,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class IsValuedMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
-            typeof (N1Ql).GetMethods().Where(p => (p.Name == "IsValued") || (p.Name == "IsNotValued")).ToArray();
+            typeof (N1QlFunctions).GetMethods().Where(p => (p.Name == "IsValued") || (p.Name == "IsNotValued")).ToArray();
 
         public IEnumerable<MethodInfo> SupportMethods
         {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
@@ -11,7 +11,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class KeyMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
-            typeof (N1Ql).GetMethod("Key")
+            typeof (N1QlFunctions).GetMethod("Key")
         };
 
         public IEnumerable<MethodInfo> SupportMethods

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MetaMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MetaMethodCallTranslator.cs
@@ -11,7 +11,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class MetaMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
-            typeof (N1Ql).GetMethod("Meta")
+            typeof (N1QlFunctions).GetMethod("Meta")
         };
 
         public IEnumerable<MethodInfo> SupportMethods

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -710,7 +710,7 @@ namespace Couchbase.Linq.QueryGeneration
         /// </summary>
         /// <param name="joinClause">Join clause being visited</param>
         /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator.  JoinType is defaulted to INNER JOIN.</returns>
-        /// <remarks>The InnerKeySelector must be selecting the N1Ql.Key of the InnerSequence</remarks>
+        /// <remarks>The InnerKeySelector must be selecting the N1QlFunctions.Key of the InnerSequence</remarks>
         private N1QlFromQueryPart ParseJoinClause(JoinClause joinClause)
         {
             switch (joinClause.InnerSequence.NodeType)
@@ -747,7 +747,7 @@ namespace Couchbase.Linq.QueryGeneration
         /// <param name="joinClause">Join clause being visited</param>
         /// <param name="constantExpression">Constant expression that is the InnerSequence of the JoinClause</param>
         /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator.  JoinType is defaulted to INNER JOIN.</returns>
-        /// <remarks>The InnerKeySelector must be selecting the N1Ql.Key of the InnerSequence</remarks>
+        /// <remarks>The InnerKeySelector must be selecting the N1QlFunctions.Key of the InnerSequence</remarks>
         private N1QlFromQueryPart VisitConstantExpressionJoinClause(JoinClause joinClause, ConstantExpression constantExpression)
         {
             string bucketName = null;
@@ -768,15 +768,15 @@ namespace Couchbase.Linq.QueryGeneration
 
             var keyExpression = joinClause.InnerKeySelector as MethodCallExpression;
             if ((keyExpression == null) ||
-                (keyExpression.Method != typeof(N1Ql).GetMethod("Key")) ||
+                (keyExpression.Method != typeof(N1QlFunctions).GetMethod("Key")) ||
                 (keyExpression.Arguments.Count != 1))
             {
-                throw new NotSupportedException("N1QL Join Selector Must Be A Call To N1Ql.Key");
+                throw new NotSupportedException("N1QL Join Selector Must Be A Call To N1QlFunctions.Key");
             }
 
             if (!(keyExpression.Arguments[0] is QuerySourceReferenceExpression))
             {
-                throw new NotSupportedException("N1QL Join Selector Call To N1Ql.Key Must Reference The Inner Sequence");
+                throw new NotSupportedException("N1QL Join Selector Call To N1QlFunctions.Key Must Reference The Inner Sequence");
             }
 
             return new N1QlFromQueryPart()

--- a/docs/meta-keyword.md
+++ b/docs/meta-keyword.md
@@ -13,7 +13,7 @@ There is additionally meta-data stored within couchbase for each document (TTL a
 The simplest usage of the META() function is to query it directly:
 
     var query = (from meta in context.Query<DocumentMetadata>()
-                 select N1Ql.Meta(meta)).
+                 select N1QlFunctions.Meta(meta)).
 				 Take(1);
 
 In this example, we are simply retrieving the meta-data from the first document returned in the beer-sample bucket. The "raw" results would look something like this:
@@ -39,13 +39,13 @@ Here is another example where you want to return the meta-data along with a fiel
 
 	 var beers = (from b in context.Query<Beer>()
                   where b.Type == "beer"
-                  select new {name = b.Name, meta = N1Ql.Meta(b)}); 
+                  select new {name = b.Name, meta = N1QlFunctions.Meta(b)});
 
 And another example where you only want to return the "id" portion of the meta-data in your projection:
 
 	var beers = (from b in context.Query<Beer>()
                  where b.Type == "beer"
-                 select new {name = b.Name, id = N1Ql.Meta(b).Id});
+                 select new {name = b.Name, id = N1QlFunctions.Meta(b).Id});
 
 The important thing to remember about the META function is that it is another tool available to you use in your queries!
 


### PR DESCRIPTION
Motivation
----------
The N1Ql class in Linq2Couchbase is conflicting with the Couchbase.N1Ql
namespace from the SDK.  If both Couchbase and Couchbase.Linq namespaces
are imported, the compiler is having trouble differentiating when
referencing N1Ql.

Modifications
-------------
Renamed N1Ql to N1QlFunctions.  This name is consistent with Entity
Framework, which has previously used EntityFunctions and now uses
DbFunctions and SqlFunctions.

Results
-------
The namespace conflict is now fixed.