### PR TITLE
Issue #68: Fix handling for queries without a new object select projection

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -188,6 +188,25 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void Map2PocoTests_Explain_QueryWithPropertyExtraction()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var context = new BucketContext(bucket);
+
+                    var explanation = (from b in context.Query<Beer>()
+                                       where b.Type == "beer"
+                                       select b.Abv).
+                        Explain();
+
+                    Console.WriteLine(explanation);
+                }
+            }
+        }
+
+        [Test]
         public void Map2PocoTests_NewObjectsInArray()
         {
             using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
@@ -211,6 +230,50 @@ namespace Couchbase.Linq.IntegrationTests
                     {
                         Console.WriteLine("Brewery {0} has address parts {1}", brewery.name,
                             String.Join(", ", brewery.list.Select(p => p.part)));
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void NoProjection_Meta()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var context = new BucketContext(bucket);
+
+                    var beers = (from b in context.Query<Beer>()
+                                 where b.Type == "beer"
+                                 select N1QlFunctions.Meta(b)).
+                        Take(10);
+
+                    foreach (var b in beers)
+                    {
+                        Console.WriteLine(b);
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void NoProjection_Number()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var context = new BucketContext(bucket);
+
+                    var beers = (from b in context.Query<Beer>()
+                                 where b.Type == "beer"
+                                 select b.Abv).
+                        Take(10);
+
+                    foreach (var b in beers)
+                    {
+                        Console.WriteLine(b);
                     }
                 }
             }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
@@ -140,7 +140,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
                 select g.Key;
 
             const string expected =
-                "SELECT `Extent1`.`brewery_id` " +
+                "SELECT `Extent1`.`brewery_id` as `result` " +
                 "FROM `default` as `Extent1` " +
                 "GROUP BY `Extent1`.`brewery_id`";
 

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/MetaTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/MetaTests.cs
@@ -24,7 +24,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
                 .Select(p => N1QlFunctions.Meta(p));
 
-            const string expected = "SELECT META(`Extent1`) FROM `default` as `Extent1`";
+            const string expected = "SELECT META(`Extent1`) as `result` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 


### PR DESCRIPTION
Motivation
----------
Queries that don't include a new object in the select projection (i.e.
`select new {...}`) are failing to deserialize.  The result is returned by
N1QL as an array of objects with a $1 property, and the expected value is
stored in this property.  However, LINQ deserialization is expecting an
array of the plain value, without the intermediate wrapper object.

Modifications
-------------
Added a property to N1QlQueryModelVisitor, ResultExtractionRequired, which
indicates to the BucketQueryExecutor that a property extraction is
required during deserialization.  This property is always named "result".
BucketQueryExecutor now uses this property to recognize that it needs to
deserialize an array of SimpleResult<T> instead of any array of T, then
extracts the result property.

Repurposed "ArrayPropertyExtractionPart", which was formerly used to
perform a similar function when dealing with array subqueries and Any/All.
It is now "PropertyExtractionPart", and is used for array subqueries as
well as main queries where property extraction is required.

Previously, aggregates were manually having property extraction performed
on them.  They now use the new property extraction approach, which
simplifies the system and should make things less confusing going forward.