### PR TITLE
Fixed array subqueries using select expressions without new object

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/SubqueryTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/SubqueryTests.cs
@@ -193,6 +193,28 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         }
 
         [Test]
+        public void Test_ArraySubquerySelectExpression()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                from brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                select new { name = brewery.Name, addresses = brewery.Address.Select(p => "Address " + p) };
+
+            const string expected =
+                "SELECT `Extent1`.`name` as `name`, " +
+                "ARRAY ('Address ' || `Extent2`) FOR `Extent2` IN `Extent1`.`address` END as `addresses` " +
+                "FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
         public void Test_ArraySubqueryWithSortAscending()
         {
             SetContractResolver(new DefaultContractResolver());

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -267,7 +267,7 @@ namespace Couchbase.Linq.QueryGeneration
             {
                 expression = GetN1QlExpression(selectClause.Selector);
 
-                if ((_queryPartsAggregator.QueryType == N1QlQueryType.Subquery) || (_queryPartsAggregator.QueryType == N1QlQueryType.Array))
+                if (_queryPartsAggregator.QueryType == N1QlQueryType.Subquery)
                 {
                     // For LINQ, this subquery is expected to return a list of the specific property being selected
                     // But N1QL will always return a list of objects with a single property
@@ -362,7 +362,7 @@ namespace Couchbase.Linq.QueryGeneration
             else if (resultOperator is AnyResultOperator)
             {
                 _queryPartsAggregator.QueryType =
-                    _queryPartsAggregator.QueryType == N1QlQueryType.Array ? N1QlQueryType.ArrayAny : 
+                    _queryPartsAggregator.QueryType == N1QlQueryType.Array ? N1QlQueryType.ArrayAny :
                         _queryPartsAggregator.QueryType == N1QlQueryType.Subquery ? N1QlQueryType.SubqueryAny : N1QlQueryType.MainQueryAny;
 
                 if (_queryPartsAggregator.QueryType == N1QlQueryType.SubqueryAny)
@@ -547,7 +547,7 @@ namespace Couchbase.Linq.QueryGeneration
             {
                 return false;
             }
-            
+
             if (referencedQuerySource.FromExpression != queryModel.MainFromClause.FromExpression)
             {
                 return false;
@@ -689,7 +689,7 @@ namespace Couchbase.Linq.QueryGeneration
                 JoinType = "INNER UNNEST"
             };
         }
-        
+
         #endregion
 
         #region Join Clauses
@@ -751,7 +751,7 @@ namespace Couchbase.Linq.QueryGeneration
                         subQuery.QueryModel.MainFromClause.FromExpression as ConstantExpression);
 
                     VisitBodyClauses(subQuery.QueryModel.BodyClauses, subQuery.QueryModel);
-                    
+
                     return fromPart;
 
                 default:
@@ -858,7 +858,7 @@ namespace Couchbase.Linq.QueryGeneration
                                 genItemName,
                                 whereClauseString)
                     };
-                
+
                     _queryPartsAggregator.AddLetPart(letPart);
 
                     if (!nestClause.IsLeftOuterNest)


### PR DESCRIPTION
Motivation
------------
Array subqueries with simple select expressions are incorrectly including
"as `result`" in the query.

ex.
```
from brewery in QueryFactory.Queryable<Brewery>(mockBucket.Object)
select new { name = brewery.Name, addresses = brewery.Address.Select(p => "Address " + p) };
```

Modifications
---------------
Exclude array subqueries from the logic adding a PropertyExtractionPart to
the QueryPartsAggregator.  Added a unit test for this scenario.