### PR TITLE
Issue #76: Fixed string concatenation for non-strings and ToString

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/BinaryExpressionTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/BinaryExpressionTests.cs
@@ -327,6 +327,24 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         }
 
         [Test]
+        public void Test_StringAdditionNonString()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                    .Select(e => new { key = "constant-" + e.Age });
+
+            const string expected =
+                "SELECT ('constant-' || `Extent1`.`age`) as `key` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
         public void Test_StringConcat()
         {
             var mockBucket = new Mock<IBucket>();

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/StringTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/StringTests.cs
@@ -475,6 +475,44 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
         #endregion
 
+        #region ToString Tests
+
+        [Test]
+        public void Test_StringToString()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from contact in QueryFactory.Queryable<Contact>(mockBucket.Object)
+                        select new { FirstName = contact.FirstName.ToString() };
+
+            const string expected =
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_IntegerToString()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from contact in QueryFactory.Queryable<Contact>(mockBucket.Object)
+                        select new { Age = contact.Age.ToString() };
+
+            const string expected =
+                "SELECT TOSTRING(`Extent1`.`age`) as `Age` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
         #region Compare N1QL Format Tests
 
         [Test]

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -114,6 +114,7 @@
     <Compile Include="QueryGeneration\MethodCallTranslators\KeyMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\MetaMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\DefaultMethodCallTranslatorProvider.cs" />
+    <Compile Include="QueryGeneration\MethodCallTranslators\ToStringMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\StringSplitMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\StringIndexOfMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\StringReplaceMethodCallTranslator.cs" />

--- a/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
@@ -32,7 +32,7 @@ namespace Couchbase.Linq.QueryGeneration
                     });
 
             return query.ToDictionary(p => p.method, p => p.instance);
-        } 
+        }
 
         #endregion
 
@@ -73,9 +73,23 @@ namespace Couchbase.Linq.QueryGeneration
             {
                 return translator;
             }
-            
-            // Finally, check any interfaces that may have a matching 
-            return GetItemFromInterfaces(key);            
+
+            // Check any interfaces that may have a matching method
+            translator = GetItemFromInterfaces(key);
+            if (translator != null)
+            {
+                return translator;
+            }
+
+            // Finally, check base method if this is a virtual method
+            var baseMethod = key.GetBaseDefinition();
+            if ((baseMethod != null) && (baseMethod != key))
+            {
+                return GetItem(baseMethod);
+            }
+
+            // No match found
+            return null;
         }
 
         /// <summary>
@@ -140,7 +154,7 @@ namespace Couchbase.Linq.QueryGeneration
             {
                 throw new ArgumentNullException("key");
             }
-            
+
             if (key.IsStatic || (key.DeclaringType == null) || (!key.DeclaringType.IsClass))
             {
                 return null;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ToStringMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ToStringMethodCallTranslator.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
+{
+    internal class ToStringMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof (object).GetMethod("ToString")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+            if (methodCallExpression.Object == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            if (methodCallExpression.Object.Type == typeof (string))
+            {
+                expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+            }
+            else
+            {
+                var expression = expressionTreeVisitor.Expression;
+
+                expression.Append("TOSTRING(");
+                expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+                expression.Append(")");
+            }
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -92,7 +92,7 @@ namespace Couchbase.Linq.QueryGeneration
 
                 case ExpressionType.Extension:
                     return VisitExtensionExpression(expression);
-                    
+
                 default:
                     return base.VisitExpression(expression);
             }
@@ -132,7 +132,7 @@ namespace Couchbase.Linq.QueryGeneration
                 VisitExpression(arguments[i]);
 
                 if (_expression.Length == beforeSubExpressionLength)
-                {                    
+                {
                     // nothing was added for the value, so remove the part that was added originally
                     _expression.Length = beforeAppendLength;
                 }
@@ -250,13 +250,13 @@ namespace Couchbase.Linq.QueryGeneration
                     break;
 
                 case ExpressionType.Add:
-                    if ((expression.Left.Type != typeof (string)) || (expression.Right.Type != typeof (string)))
+                    if ((expression.Left.Type == typeof (string)) || (expression.Right.Type == typeof (string)))
                     {
-                    _expression.Append(" + ");
+                        _expression.Append(" || ");
                     }
                     else
                     {
-                        _expression.Append(" || ");
+                        _expression.Append(" + ");
                     }
                     break;
 
@@ -427,7 +427,7 @@ namespace Couchbase.Linq.QueryGeneration
                     return System.Linq.Expressions.Expression.Constant(operation == ExpressionType.LessThanOrEqual,
                         typeof (bool));
                 }
-            } 
+            }
             else if (number == -1)
             {
                 if ((operation == ExpressionType.GreaterThan) || (operation == ExpressionType.NotEqual))
@@ -459,7 +459,7 @@ namespace Couchbase.Linq.QueryGeneration
                     (operation == ExpressionType.NotEqual) || (operation == ExpressionType.GreaterThan) || (operation == ExpressionType.GreaterThanOrEqual),
                     typeof(bool));
             }
-            
+
             // If number == 0 we just leave operation unchanged
 
             return StringComparisonExpression.Create(operation, leftString, rightString);
@@ -575,7 +575,7 @@ namespace Couchbase.Linq.QueryGeneration
                 _expression.AppendFormat("'{0}'", namedParameter.Value.ToString().Replace("'", "''"));
             }
             else if (namedParameter.Value is char)
-            {                
+            {
                 _expression.AppendFormat("'{0}'", (char)namedParameter.Value != '\'' ? namedParameter.Value : "''");
             }
             else if (namedParameter.Value is bool)


### PR DESCRIPTION
Motivation
----------
When building compound keys for joins and nests, a common use case may be
to combine strings with non-string properties such as numbers and GUIDs.

Modifications
-------------
Changed handling of binary + expression to use string concatenation
operator if either operand is a string.  Previously it was only doing this
if both operands were strings.

Added a method call translator for .ToString() that uses the N1QL
TOSTRING() function.  This required making a tweak to the
DefaultMethodCallTranslatorProvider to check for method call translators
against virtual base methods.  This allowed registering the method call
translator only on Object.ToString while applying to all inherited
types.

Results
-------
String handling for non-string types now behaves in the way a user would
expect.