### PR TITLE
Support IExtendedTypeSerializer member name resolution

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/BucketQueryExecutorEmulator.cs
+++ b/Src/Couchbase.Linq.UnitTests/BucketQueryExecutorEmulator.cs
@@ -60,7 +60,7 @@ namespace Couchbase.Linq.UnitTests
         {
             var queryGenerationContext = new N1QlQueryGenerationContext()
             {
-                MemberNameResolver = new JsonNetMemberNameResolver(Test.ContractResolver),
+                MemberNameResolver = Test.MemberNameResolver,
                 MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider(),
                 Serializer = new Core.Serialization.DefaultSerializer()
             };

--- a/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
 using Couchbase.Linq.QueryGeneration;
+using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
 using Moq;
 using Newtonsoft.Json.Serialization;
 using Remotion.Linq;
@@ -13,10 +14,10 @@ namespace Couchbase.Linq.UnitTests
 // ReSharper disable once InconsistentNaming
     public class N1QLTestBase
     {
-        private IContractResolver _contractResolver = new DefaultContractResolver();
-        public IContractResolver ContractResolver
+        private IMemberNameResolver _memberNameResolver = new JsonNetMemberNameResolver(new DefaultContractResolver());
+        internal IMemberNameResolver MemberNameResolver
         {
-            get { return _contractResolver; }
+            get { return _memberNameResolver; }
         }
 
         private BucketQueryExecutorEmulator _queryExecutor;
@@ -39,7 +40,7 @@ namespace Couchbase.Linq.UnitTests
 
             var queryGenerationContext = new N1QlQueryGenerationContext()
             {
-                MemberNameResolver = new JsonNetMemberNameResolver(_contractResolver),
+                MemberNameResolver = MemberNameResolver,
                 MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider(),
                 Serializer = new Core.Serialization.DefaultSerializer()
             };
@@ -54,13 +55,13 @@ namespace Couchbase.Linq.UnitTests
             var mockBucket = new Mock<IBucket>();
             mockBucket.SetupGet(e => e.Name).Returns(bucketName);
 
-            return new BucketQueryable<T>(mockBucket.Object, 
+            return new BucketQueryable<T>(mockBucket.Object,
                 QueryParserHelper.CreateQueryParser(), QueryExecutor);
         }
 
         protected void SetContractResolver(IContractResolver contractResolver)
         {
-            _contractResolver = contractResolver;
+            _memberNameResolver = new JsonNetMemberNameResolver(contractResolver);
         }
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/StringTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/StringTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Couchbase.Core;
 using Couchbase.Linq.QueryGeneration;
 using Couchbase.Linq.QueryGeneration.Expressions;
+using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
 using Couchbase.Linq.UnitTests.Documents;
 using Moq;
 using NUnit.Framework;

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -115,10 +115,11 @@
     <Compile Include="BucketQueryExecutor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueryFactory.cs" />
-    <Compile Include="QueryGeneration\IMemberNameResolver.cs" />
+    <Compile Include="QueryGeneration\MemberNameResolvers\IMemberNameResolver.cs" />
     <Compile Include="QueryGeneration\IMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\IMethodCallTranslatorProvider.cs" />
-    <Compile Include="QueryGeneration\JsonNetMemberNameResolver.cs" />
+    <Compile Include="QueryGeneration\MemberNameResolvers\ExtendedTypeSerializerMemberNameResolver.cs" />
+    <Compile Include="QueryGeneration\MemberNameResolvers\JsonNetMemberNameResolver.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\ConcatMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\ListIndexMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\ContainsMethodCallTranslator.cs" />

--- a/Src/Couchbase.Linq/QueryGeneration/MemberNameResolvers/ExtendedTypeSerializerMemberNameResolver.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MemberNameResolvers/ExtendedTypeSerializerMemberNameResolver.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Couchbase.Core.Serialization;
+using Newtonsoft.Json.Serialization;
+
+namespace Couchbase.Linq.QueryGeneration.MemberNameResolvers
+{
+    /// <summary>
+    /// Implementation of <see cref="IMemberNameResolver"/> which uses an <see cref="IExtendedTypeSerializer"/>
+    /// to resolve member names.
+    /// </summary>
+    internal class ExtendedTypeSerializerMemberNameResolver : IMemberNameResolver
+    {
+        private readonly IExtendedTypeSerializer _serializer;
+
+        public ExtendedTypeSerializerMemberNameResolver(IExtendedTypeSerializer serializer)
+        {
+            if (serializer == null)
+            {
+                throw new ArgumentNullException("serializer");
+            }
+
+            _serializer = serializer;
+        }
+
+        public bool TryResolveMemberName(MemberInfo member, out string memberName)
+        {
+            memberName = null;
+
+            if (member == null)
+                return false;
+
+            memberName = _serializer.GetMemberName(member);
+
+            return memberName != null;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/MemberNameResolvers/IMemberNameResolver.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MemberNameResolvers/IMemberNameResolver.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
-namespace Couchbase.Linq.QueryGeneration
+namespace Couchbase.Linq.QueryGeneration.MemberNameResolvers
 {
     internal interface IMemberNameResolver
     {

--- a/Src/Couchbase.Linq/QueryGeneration/MemberNameResolvers/JsonNetMemberNameResolver.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MemberNameResolvers/JsonNetMemberNameResolver.cs
@@ -3,8 +3,16 @@ using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json.Serialization;
 
-namespace Couchbase.Linq.QueryGeneration
+namespace Couchbase.Linq.QueryGeneration.MemberNameResolvers
 {
+    /// <summary>
+    /// Implementation of <see cref="IMemberNameResolver"/> which uses a Newtonsoft.Json
+    /// <see cref="IContractResolver"/> to resolve member names.
+    /// </summary>
+    /// <remarks>
+    /// Used for backwards compatibility with older implementations of <see cref="Couchbase.Core.Serialization.ITypeSerializer"/>
+    /// which don't have a GetMemberName implementation like <see cref="Couchbase.Core.Serialization.IExtendedTypeSerializer"/>.
+    /// </remarks>
     internal class JsonNetMemberNameResolver : IMemberNameResolver
     {
         private readonly IContractResolver _contractResolver;

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -6,6 +6,7 @@ using Couchbase.Core.Serialization;
 using Couchbase.Linq.Clauses;
 using Couchbase.Linq.Operators;
 using Couchbase.Linq.QueryGeneration.ExpressionTransformers;
+using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Core.Serialization;
+using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
 using Newtonsoft.Json.Serialization;
 using Remotion.Linq.Clauses.Expressions;
 


### PR DESCRIPTION
Motivation
----------
The current implementation for resolving the names of members (such as
properties) only supports Newtonsoft.Json based contract resolvers.  It
uses obsolete settings from the SDK ClientConfiguration.  This basically
limits support to clients that don't use a custom ITypeSerializer
implementation.

Modifications
-------------
If ClientConfiguration.Serializer returns an IExtendedTypeSerializer, use
the provided GetMemberName method to resolve member names.  This is done
through ExtendedTypeSerializerMemberNameResolver, which maps GetMemberName
to the IMemberNameResolver interface.

If ClientConfiguration.Serializer doesn't return an
IExtendedTypeSerializer, fallback to the former implementation of
JsonNetMemberNameResolver.

Results
-------
Newer SDK users who implement IExtendedTypeSerializer for custom
serialization will now be fully compatible with Linq2Couchbase.

SDK users who were formerly using the SDK DefaultSerializer implementation
will use the new serializer.  However, the SDK implements the same logic
as JsonNetMemberNameResolver, so the change is transparent.

SDK users who implement an older ITypeSerializer will also see the
behavior unchanged until they update to an IExtendedTypeSerializer.