### PR TITLE
Issue #85: Support for strongly typed select projections

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -61,6 +61,26 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void Map2PocoTests_StronglyTyped_Projections()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var context = new BucketContext(bucket);
+
+                    var beers = from b in context.Query<Beer>()
+                                select new Beer() { Name = b.Name, Abv = b.Abv };
+
+                    foreach (var b in beers.Take(10))
+                    {
+                        Console.WriteLine("{0} has {1} ABV", b.Name, b.Abv);
+                    }
+                }
+            }
+        }
+
+        [Test]
         public void Map2PocoTests_Simple_Projections_Where()
         {
             using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
@@ -893,7 +913,7 @@ namespace Couchbase.Linq.IntegrationTests
                         where beer.Type == "beer"
                         group beer by beer.BreweryId
                         into g
-                        orderby g.Count() descending 
+                        orderby g.Count() descending
                         select new { breweryid = g.Key, count = g.Count(), avgAbv = g.Average(p => p.Abv) };
 
                     foreach (var brewery in breweries)

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="BucketContextTests.cs" />
     <Compile Include="Clauses\NestClauseTests.cs" />
     <Compile Include="Clauses\UseKeysClauseTests.cs" />
+    <Compile Include="Documents\Address.cs" />
     <Compile Include="Documents\Airline.cs" />
     <Compile Include="Documents\BeerFiltered.cs" />
     <Compile Include="Documents\Beer.cs" />

--- a/Src/Couchbase.Linq.UnitTests/Documents/Address.cs
+++ b/Src/Couchbase.Linq.UnitTests/Documents/Address.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Couchbase.Linq.UnitTests.Documents
+{
+    class Address
+    {
+        [JsonProperty("address1")]
+        public string AddressLine1 { get; set; }
+    }
+}

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectTests.cs
@@ -28,6 +28,23 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         }
 
         [Test]
+        public void Test_Select_WithStronglyTypedProjection()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                    .Select(e => new Contact() { Age = e.Age, FirstName = e.FirstName });
+
+            const string expected = "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `fname` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
         public void Test_Select_All_Properties()
         {
             var mockBucket = new Mock<IBucket>();

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -49,10 +49,10 @@ namespace Couchbase.Linq.QueryGeneration
             return visitor.GetN1QlExpression();
         }
 
-        public static string GetN1QlSelectNewExpression(NewExpression expression, N1QlQueryGenerationContext queryGenerationContext)
+        public static string GetN1QlSelectNewExpression(Expression expression, N1QlQueryGenerationContext queryGenerationContext)
         {
             // Ensure that any date/time expressions are properly converted to Unix milliseconds as needed
-            expression = (NewExpression)TransformingExpressionTreeVisitor.Transform(expression,
+            expression = TransformingExpressionTreeVisitor.Transform(expression,
                 ExpressionTransformers.DateTimeTransformationRegistry.Default);
 
             var visitor = new N1QlExpressionTreeVisitor(queryGenerationContext);
@@ -111,9 +111,35 @@ namespace Couchbase.Linq.QueryGeneration
 
         protected override Expression VisitNewExpression(NewExpression expression)
         {
-            var arguments = expression.Arguments;
-            var members = expression.Members;
+            VisitNewObject(expression.Members, expression.Arguments);
 
+            return expression;
+        }
+
+        protected override Expression VisitMemberInitExpression(MemberInitExpression expression)
+        {
+            if (expression.NewExpression.Arguments.Count > 0)
+            {
+                throw new NotSupportedException("New Objects Must Be Initialized With A Parameterless Constructor");
+            }
+            if (expression.Bindings.Any(p => p.BindingType != MemberBindingType.Assignment))
+            {
+                throw new NotSupportedException("New Objects Must Be Initialized With Assignments Only");
+            }
+
+            var arguments = expression.Bindings.Cast<MemberAssignment>().Select(p => p.Expression).ToList();
+            var members = expression.Bindings.Select(p => p.Member).ToList();
+
+            VisitNewObject(members, arguments);
+
+            return expression;
+        }
+
+        /// <summary>
+        /// Shared logic for NewExpression and MemberInitExpression
+        /// </summary>
+        private void VisitNewObject(IList<MemberInfo> members, IList<Expression> arguments)
+        {
             _expression.Append('{');
 
             for (var i = 0; i < members.Count; i++)
@@ -125,7 +151,13 @@ namespace Couchbase.Linq.QueryGeneration
                     _expression.Append(", ");
                 }
 
-                _expression.AppendFormat("\"{0}\": ", members[i].Name);
+                string memberName;
+                if (!_queryGenerationContext.MemberNameResolver.TryResolveMemberName(members[i], out memberName))
+                {
+                    memberName = members[i].Name;
+                }
+
+                _expression.AppendFormat("\"{0}\": ", memberName);
 
                 var beforeSubExpressionLength = _expression.Length;
 
@@ -139,17 +171,43 @@ namespace Couchbase.Linq.QueryGeneration
             }
 
             _expression.Append('}');
-
-            return expression;
         }
 
         /// <summary>
-        /// Parses the new object that is part of the select expression with "as" based formatting
+        /// Parses the new object that is part of the select expression with "as" based formatting.
+        /// Can accept either a NewExpression or MemberInitExpression
         /// </summary>
-        private Expression VisitSelectNewExpression(NewExpression expression)
+        private Expression VisitSelectNewExpression(Expression expression)
         {
-            var arguments = expression.Arguments;
-            var members = expression.Members;
+            IList<Expression> arguments;
+            IList<MemberInfo> members;
+
+            var memberInitExpression = expression as MemberInitExpression;
+            if (memberInitExpression != null)
+            {
+                if (memberInitExpression.NewExpression.Arguments.Count > 0)
+                {
+                    throw new NotSupportedException("New Objects Must Be Initialized With A Parameterless Constructor");
+                }
+                if (memberInitExpression.Bindings.Any(p => p.BindingType != MemberBindingType.Assignment))
+                {
+                    throw new NotSupportedException("New Objects Must Be Initialized With Assignments Only");
+                }
+
+                arguments = memberInitExpression.Bindings.Cast<MemberAssignment>().Select(p => p.Expression).ToList();
+                members = memberInitExpression.Bindings.Select(p => p.Member).ToList();
+            }
+            else
+            {
+                var newExpression = expression as NewExpression;
+                if (newExpression == null)
+                {
+                    throw new NotSupportedException("Unsupported Select Clause Expression");
+                }
+
+                arguments = newExpression.Arguments;
+                members = newExpression.Members;
+            }
 
             for (var i = 0; i < members.Count; i++)
             {
@@ -165,7 +223,13 @@ namespace Couchbase.Linq.QueryGeneration
                 //only add 'as' part if the  previous visitexpression has generated something.
                 if (_expression.Length > expressionLength)
                 {
-                    _expression.AppendFormat(" as {0}", N1QlHelpers.EscapeIdentifier(members[i].Name));
+                    string memberName;
+                    if (!_queryGenerationContext.MemberNameResolver.TryResolveMemberName(members[i], out memberName))
+                    {
+                        memberName = members[i].Name;
+                    }
+
+                    _expression.AppendFormat(" as {0}", N1QlHelpers.EscapeIdentifier(memberName));
                 }
                 else if (i > 0)
                 {

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using Couchbase.Annotations;
 using Couchbase.Core.Serialization;
 using Couchbase.Linq.Clauses;
 using Couchbase.Linq.Operators;
@@ -241,18 +242,18 @@ namespace Couchbase.Linq.QueryGeneration
                     expression = "*";
                 }
             }
-            else if (selectClause.Selector.NodeType == ExpressionType.New)
+            else if ((selectClause.Selector.NodeType == ExpressionType.New) || (selectClause.Selector.NodeType == ExpressionType.MemberInit))
             {
                 if (_queryPartsAggregator.QueryType != N1QlQueryType.Array)
                 {
-                    var selector = selectClause.Selector as NewExpression;
+                    var selector = selectClause.Selector;
 
                     if (_groupingStatus == GroupingStatus.AfterGroupSubquery)
                     {
                         // SELECT clauses must be remapped to refer directly to the extents in the grouping subquery
                         // rather than refering to the output of the grouping subquery
 
-                        selector = (NewExpression) TransformingExpressionTreeVisitor.Transform(selector, _groupingExpressionTransformerRegistry);
+                        selector = TransformingExpressionTreeVisitor.Transform(selector, _groupingExpressionTransformerRegistry);
                     }
 
                     expression =


### PR DESCRIPTION
Motivation
----------
In some circumstances, it is desirable to project your documents onto
strongly typed POCOs which don't match your document structure.
Currently, the only way to select directly onto strongly typed POCOs is if
they are your documents.

Modifications
-------------
Added limited support for the MemberInitExpression in
N1QlExpressionTreeVisitor.  It is supported for both creating new objects
in the query ({"x": y} syntax) and in the main select clause (y as x
syntax).  This means it is also supported in array-based subqueries.

This implementation doesn't support constructor parameters, the
constructor must be parameterless.  Also, it doesn't support other forms
of MemberInitExpression such as list initialization.

Implemented appropriate unit tests.

Results
-------
Strongly typed POCOs can now be used in select projections.