### PR TITLE
Issue #43, LINQ-15: Upgraded to Relinq 2.0

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -81,9 +81,9 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Remotion.Linq, Version=1.15.15.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Remotion.Linq.1.15.15.0\lib\portable-net45+wp80+wpa81+win\Remotion.Linq.dll</HintPath>
+    <Reference Include="Remotion.Linq, Version=2.0.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.0.1\lib\net45\Remotion.Linq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Src/Couchbase.Linq.IntegrationTests/packages.config
+++ b/Src/Couchbase.Linq.IntegrationTests/packages.config
@@ -9,5 +9,5 @@
   <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Remotion.Linq" version="1.15.15.0" targetFramework="net45" />
+  <package id="Remotion.Linq" version="2.0.1" targetFramework="net45" />
 </packages>

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -77,9 +77,9 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Remotion.Linq, Version=1.15.15.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Remotion.Linq.1.15.15.0\lib\portable-net45+wp80+wpa81+win\Remotion.Linq.dll</HintPath>
+    <Reference Include="Remotion.Linq, Version=2.0.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.0.1\lib\net45\Remotion.Linq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Src/Couchbase.Linq.UnitTests/packages.config
+++ b/Src/Couchbase.Linq.UnitTests/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
   <package id="Common.Logging" version="3.3.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.0" targetFramework="net45" />
@@ -9,5 +8,5 @@
   <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Remotion.Linq" version="1.15.15.0" targetFramework="net45" />
+  <package id="Remotion.Linq" version="2.0.1" targetFramework="net45" />
 </packages>

--- a/Src/Couchbase.Linq.Views/Couchbase.Linq.Views.csproj
+++ b/Src/Couchbase.Linq.Views/Couchbase.Linq.Views.csproj
@@ -32,8 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Remotion.Linq">
-      <HintPath>..\packages\Remotion.Linq.1.15.15.0\lib\portable-net45+wp80+wpa81+win\Remotion.Linq.dll</HintPath>
+    <Reference Include="Remotion.Linq, Version=2.0.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.0.1\lib\net45\Remotion.Linq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -57,7 +58,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Src/Couchbase.Linq.Views/QueryGeneration/ViewExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq.Views/QueryGeneration/ViewExpressionTreeVisitor.cs
@@ -7,7 +7,7 @@ using Remotion.Linq.Parsing;
 
 namespace Couchbase.Linq.Views.QueryGeneration
 {
-    public class ViewExpressionTreeVisitor : ThrowingExpressionTreeVisitor
+    public class ViewExpressionTreeVisitor : ThrowingExpressionVisitor
     {
         protected override Exception CreateUnhandledItemException<T>(T unhandledItem, string visitMethod)
         {

--- a/Src/Couchbase.Linq.Views/packages.config
+++ b/Src/Couchbase.Linq.Views/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Remotion.Linq" version="1.15.15.0" targetFramework="net45" />
+  <package id="Remotion.Linq" version="2.0.1" targetFramework="net45" />
 </packages>

--- a/Src/Couchbase.Linq/Clauses/NestExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/NestExpressionNode.cs
@@ -11,8 +11,8 @@ namespace Couchbase.Linq.Clauses
     {
         public static readonly MethodInfo[] SupportedMethods =
         {
-            GetSupportedMethod(() => QueryExtensions.Nest<object, object, object>(null, null, o => null, (o, p) => null)),
-            GetSupportedMethod(() => QueryExtensions.LeftOuterNest<object, object, object>(null, null, o => null, (o, p) => null))
+            typeof(QueryExtensions).GetMethod("Nest"),
+            typeof(QueryExtensions).GetMethod("LeftOuterNest")
         };
 
         private readonly ResolvedExpressionCache<Expression> _cachedKeySelector;
@@ -88,13 +88,13 @@ namespace Couchbase.Linq.Clauses
             return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
         }
 
-        protected override QueryModel ApplyNodeSpecificSemantics(QueryModel queryModel,
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
             ClauseGenerationContext clauseGenerationContext)
         {
             var nestClause = new NestClause(
-                ResultSelector.Parameters[1].Name, 
-                ResultSelector.Parameters[1].Type, 
-                InnerSequence, 
+                ResultSelector.Parameters[1].Name,
+                ResultSelector.Parameters[1].Type,
+                InnerSequence,
                 GetResolvedKeySelector(clauseGenerationContext),
                 IsLeftOuterNest);
 
@@ -103,8 +103,6 @@ namespace Couchbase.Linq.Clauses
 
             var selectClause = queryModel.SelectClause;
             selectClause.Selector = GetResolvedResultSelector(clauseGenerationContext);
-
-            return queryModel;
         }
     }
 }

--- a/Src/Couchbase.Linq/Clauses/UseKeysExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/UseKeysExpressionNode.cs
@@ -11,7 +11,7 @@ namespace Couchbase.Linq.Clauses
     {
         public static readonly MethodInfo[] SupportedMethods =
         {
-            GetSupportedMethod(() => QueryExtensions.UseKeys<object>(null, null))
+            typeof (QueryExtensions).GetMethod("UseKeys")
         };
 
         public UseKeysExpressionNode(MethodCallExpressionParseInfo parseInfo, Expression keys)
@@ -33,12 +33,10 @@ namespace Couchbase.Linq.Clauses
             return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
         }
 
-        protected override QueryModel ApplyNodeSpecificSemantics(QueryModel queryModel,
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
             ClauseGenerationContext clauseGenerationContext)
         {
             queryModel.BodyClauses.Add(new UseKeysClause(Keys));
-
-            return queryModel;
         }
     }
 }

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -59,8 +59,9 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Remotion.Linq">
-      <HintPath>..\packages\Remotion.Linq.1.15.15.0\lib\portable-net45+wp80+wpa81+win\Remotion.Linq.dll</HintPath>
+    <Reference Include="Remotion.Linq, Version=2.0.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.0.1\lib\net45\Remotion.Linq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Couchbase.Linq.Metadata;
-using Remotion.Linq.Parsing.ExpressionTreeVisitors;
+using Remotion.Linq.Parsing.ExpressionVisitors;
 
 namespace Couchbase.Linq.Extensions
 {
@@ -27,8 +27,8 @@ namespace Couchbase.Linq.Extensions
         /// <returns>Modified IQueryable</returns>
         public static IQueryable<TResult> Nest<TOuter, TInner, TResult>(
             this IQueryable<TOuter> outer,
-            IEnumerable<TInner> inner, 
-            Expression<Func<TOuter, IEnumerable<string>>> keySelector, 
+            IEnumerable<TInner> inner,
+            Expression<Func<TOuter, IEnumerable<string>>> keySelector,
             Expression<Func<TOuter, IEnumerable<TInner>, TResult>> resultSelector)
         {
             if (inner == null)
@@ -58,7 +58,7 @@ namespace Couchbase.Linq.Extensions
                     throw new NotSupportedException("Inner Sequence Items Must Implement IDocumentMetadataProvider To Function With EnumerableQuery<T>");
                 }
 
-                var methodCall = 
+                var methodCall =
                     Expression.Call(
                         typeof(EnumerableExtensions).GetMethod("Nest")
                             .MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
@@ -251,7 +251,7 @@ namespace Couchbase.Linq.Extensions
         private static IQueryable<T> CreateQuery<T, TR>(
             this IQueryable<T> source, Expression<Func<IQueryable<T>, TR> > expression)
         {
-            var queryExpression = ReplacingExpressionTreeVisitor.Replace(
+            var queryExpression = ReplacingExpressionVisitor.Replace(
                 expression.Parameters[0],
                 source.Expression,
                 expression.Body);

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
@@ -5,7 +5,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
 
 namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
 {

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeTransformationRegistry.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeTransformationRegistry.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
 
 namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
 {

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/KeyExpressionTransfomer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/KeyExpressionTransfomer.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Remotion.Linq.Clauses.Expressions;
-using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
 
 namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
 {

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/MultiKeyExpressionTransfomer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/MultiKeyExpressionTransfomer.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Remotion.Linq.Clauses.Expressions;
-using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
 
 namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
 {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ConcatMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ConcatMethodCallTranslator.cs
@@ -55,9 +55,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                     expression.Append(" || ");
                 }
 
-                expressionTreeVisitor.VisitExpression(argument);
+                expressionTreeVisitor.Visit(argument);
             }
-            
+
             expression.Append(')');
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ContainsMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ContainsMethodCallTranslator.cs
@@ -32,12 +32,12 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("(");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
             expression.Append(" LIKE '%");
 
             var indexInsertStarted = expression.Length;
 
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[0]);
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
 
             var indexInsertEnded = expression.Length;
 

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsMissingMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsMissingMethodCallTranslator.cs
@@ -20,7 +20,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                 return SupportedMethodsStatic;
             }
         }
-            
+
         public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
         {
             if (methodCallExpression == null)
@@ -30,7 +30,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
             var expression = expressionTreeVisitor.Expression;
 
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[0]);
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
 
             if (methodCallExpression.Arguments.Count > 1)
             {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsValuedMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsValuedMethodCallTranslator.cs
@@ -20,7 +20,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                 return SupportedMethodsStatic;
             }
         }
-            
+
         public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
         {
             if (methodCallExpression == null)
@@ -30,7 +30,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
             var expression = expressionTreeVisitor.Expression;
 
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[0]);
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
 
             if (methodCallExpression.Arguments.Count > 1)
             {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
@@ -32,7 +32,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("META(");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[0]);
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
             expression.Append(").Id");
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ListIndexMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ListIndexMethodCallTranslator.cs
@@ -33,9 +33,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
             var expression = expressionTreeVisitor.Expression;
 
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
             expression.Append('[');
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[0]);
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
             expression.Append(']');
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MathMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MathMethodCallTranslator.cs
@@ -113,7 +113,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                     expression.Append(", ");
                 }
 
-                expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[i]);
+                expressionTreeVisitor.Visit(methodCallExpression.Arguments[i]);
             }
             
             expression.Append(')');

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MetaMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MetaMethodCallTranslator.cs
@@ -32,7 +32,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("META(");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[0]);
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
             expression.Append(')');
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringCapitalizationMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringCapitalizationMethodCallTranslator.cs
@@ -34,7 +34,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append(methodCallExpression.Method.Name == "ToLower" ? "LOWER(" : "UPPER(");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
             expression.Append(")");
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringIndexOfMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringIndexOfMethodCallTranslator.cs
@@ -34,9 +34,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("POSITION(");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
             expression.Append(", ");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[0]);
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
             expression.Append(")");
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringLengthMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringLengthMethodCallTranslator.cs
@@ -33,7 +33,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("LENGTH(");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
             expression.Append(")");
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringReplaceMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringReplaceMethodCallTranslator.cs
@@ -34,11 +34,11 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("REPLACE(");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
             expression.Append(", ");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[0]);
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
             expression.Append(", ");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[1]);
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[1]);
             expression.Append(")");
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
@@ -33,7 +33,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("SPLIT(");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
 
             if (methodCallExpression.Arguments[0].Type != typeof(char[]))
             {
@@ -54,7 +54,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
                     expression.Append(", ");
 
-                    expressionTreeVisitor.VisitExpression(Expression.Constant(chars[0], typeof(char)));
+                    expressionTreeVisitor.Visit(Expression.Constant(chars[0], typeof(char)));
                 }
             }
             catch (NotSupportedException ex)

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
@@ -37,7 +37,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
             expression.Append(methodCallExpression.Method.Name == "TrimStart" ? "LTRIM(" :
                 methodCallExpression.Method.Name == "TrimEnd" ? "RTRIM(" : "TRIM(");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
 
             if (methodCallExpression.Arguments.Count > 0)
             {
@@ -55,7 +55,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                     {
                         expression.Append(", ");
 
-                        expressionTreeVisitor.VisitExpression(Expression.Constant(new String(chars), typeof (string)));
+                        expressionTreeVisitor.Visit(Expression.Constant(new String(chars), typeof (string)));
                     }
                 }
                 catch (NotSupportedException ex)

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubqueryMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubqueryMethodCallTranslator.cs
@@ -34,7 +34,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
             // Do not process ToArray, ToList, or AsEnumerable.  Instead just visit the list in the first argument.
 
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[0]);
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
 
             return methodCallExpression;
         }

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubstringMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubstringMethodCallTranslator.cs
@@ -35,14 +35,14 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("SUBSTR(");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
             expression.Append(", ");
-            expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[0]);
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
 
             if (methodCallExpression.Arguments.Count > 1)
             {
                 expression.Append(", ");
-                expressionTreeVisitor.VisitExpression(methodCallExpression.Arguments[1]);
+                expressionTreeVisitor.Visit(methodCallExpression.Arguments[1]);
             }
             else if (methodCallExpression.Method.Name == "get_Chars")
             {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ToStringMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ToStringMethodCallTranslator.cs
@@ -36,14 +36,14 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
             if (methodCallExpression.Object.Type == typeof (string))
             {
-                expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+                expressionTreeVisitor.Visit(methodCallExpression.Object);
             }
             else
             {
                 var expression = expressionTreeVisitor.Expression;
 
                 expression.Append("TOSTRING(");
-                expressionTreeVisitor.VisitExpression(methodCallExpression.Object);
+                expressionTreeVisitor.Visit(methodCallExpression.Object);
                 expression.Append(")");
             }
 

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/UnixMillisecondsMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/UnixMillisecondsMethodCallTranslator.cs
@@ -40,7 +40,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             {
                 // Two method calls are reversing each other, so just skip them both
 
-                return expressionTreeVisitor.VisitExpression(methodCallArgument.Arguments[0]);
+                return expressionTreeVisitor.Visit(methodCallArgument.Arguments[0]);
             }
 
             var expression = expressionTreeVisitor.Expression;
@@ -54,9 +54,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                 expression.Append("MILLIS_TO_STR(");
             }
 
-            expressionTreeVisitor.VisitExpression(argument);
+            expressionTreeVisitor.Visit(argument);
 
-            expression.Append(')');            
+            expression.Append(')');
 
             return methodCallExpression;
         }

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -1,7 +1,7 @@
 ﻿using Couchbase.Linq.Clauses;
 using Couchbase.Linq.Extensions;
 using Couchbase.Linq.Operators;
-using Remotion.Linq.Parsing.ExpressionTreeVisitors.Transformation;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
 using Remotion.Linq.Parsing.Structure;
 using Remotion.Linq.Parsing.Structure.NodeTypeProviders;
 

--- a/Src/Couchbase.Linq/packages.config
+++ b/Src/Couchbase.Linq/packages.config
@@ -5,5 +5,5 @@
   <package id="Common.Logging.Core" version="3.3.0" targetFramework="net45" />
   <package id="CouchbaseNetClient" version="2.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Remotion.Linq" version="1.15.15.0" targetFramework="net45" />
+  <package id="Remotion.Linq" version="2.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Motivation
----------
Relinq 2.0 is not backwards compatible with Relinq 1.0.  Other frameworks,
such as Entity Framework 7, are using Relinq 2.0.  In order to be
compatible for side-by-side use, we must also use Relinq 2.0.

Modifications
-------------
Updated to Nuget to Relinq 2.0.1.  Made lots of adjustments to consume the
new Relinq API.  Most of the changes were changes to names, such as all of
the ExpressionTreeVisitors becoming ExpressionVisitors.  There were also
some method signature changes.

Te other significant change was testing or special Relinq Expressions.
They used to have special expression type values.  Now they are all
Extension expression types, and we need to detect using the .Net type.

Results
-------
System now uses Relinq 2.0, and should be compatible with EntityFramework
7 and other libraries using Relinq 2.0.  All tests pass, except for the
one in outstanding issue #89, which was failing before the upgrade.