### PR TITLE
Issue #83: Make DocumentFilterManager public

### DIFF
--- a/Src/Couchbase.Linq/Filters/DocumentFilterManager.cs
+++ b/Src/Couchbase.Linq/Filters/DocumentFilterManager.cs
@@ -7,7 +7,7 @@ namespace Couchbase.Linq.Filters
     /// <summary>
     /// Static class to cache and execute <see cref="IDocumentFilter{T}">IDocumentFilter</see> objects based on the type being queried
     /// </summary>
-    class DocumentFilterManager
+    public class DocumentFilterManager
     {
 
         /// <summary>


### PR DESCRIPTION
Motivation
----------
Make DocumentFilterManager public so that domain POCO's do not have to
have attributes explicilty defined.

Modifications
-------------
Change scope of DocumentFilterManager from internal to public.