### PR TITLE
Update to Couchbase SDK 2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ The official Language Integrated Query (LINQ) provider for querying Couchbase Se
 The Linq2Couchbase project has the following dependencies:
 
 - Couchbase Server 4.0 or greater with the query service enabled on at least one node
-- Couchbase .NET SDK 2.2.0 or greater
+- Couchbase .NET SDK 2.2.2 or greater
 - Common.Logging 3.3.0 or greater
 - Common.Logging.Core 3.3.0 or greater
 - JSON.NET 7.0.1 or greater
-- re-linq 1.15.15.0 (re-linq 2.0 is not currently supported!)
+- re-linq 2.0.1
 
 If you are using NuGet, then the dependencies (other than Couchbase server) will be installed for you via the package manager. 
 
@@ -50,17 +50,7 @@ NuGet will install the package and all dependencies. Once you have the resolved 
 
 ##Building From Source##
 
-The 1.0 release of Linq2Couchbase uses the NuGet package manager for handling dependencies.  However, the release currently in development is making use of some Couchbase SDK features that are not yet released.  Therefore, if working with the latest code the Couchbase SDK must be downloaded separately.
-
-You may clone the SDK repository from https://github.com/couchbase/couchbase-net-client.  This repository should be placed beside the Linq2Couchbase repository, so your folder structure looks like this:
-
-    <somepath>/couchbase-net-client
-    <somepath>/Linq2Couchbase
-
-Make sure you have the master branch of the SDK.  Then compile the couchbase-net-client solution in the Debug configuration.  This will create the libraries needed for Linq2Couchcbase to compile.
-
-This will be changed to use NuGet once the new SDK changes have been released, and before the next version of Linq2Couchbase is available.
-
+Linq2Couchbase uses the NuGet package manager for handling dependencies.  To build from the source, simply clone the GitHub repository and build in Visual Studio.  The NuGet package manager should download all required dependencies.
 
 ##Project management##
 

--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -61,9 +61,9 @@
       <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.0\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.2.1.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\couchbase-net-client\Src\Couchbase\bin\Debug\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.2.2.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.2.2\lib\net45\Couchbase.NetClient.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>

--- a/Src/Couchbase.Linq.IntegrationTests/packages.config
+++ b/Src/Couchbase.Linq.IntegrationTests/packages.config
@@ -4,7 +4,7 @@
   <package id="Common.Logging" version="3.3.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.0" targetFramework="net45" />
   <package id="Common.Logging.Log4Net1213" version="3.3.0" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.2.1" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.2.2" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -57,9 +57,9 @@
       <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.0\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.2.1.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\couchbase-net-client\Src\Couchbase\bin\Debug\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.2.2.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.2.2\lib\net45\Couchbase.NetClient.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>

--- a/Src/Couchbase.Linq.UnitTests/packages.config
+++ b/Src/Couchbase.Linq.UnitTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Common.Logging" version="3.3.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.0" targetFramework="net45" />
   <package id="Common.Logging.Log4Net1213" version="3.3.0" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.2.1" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.2.2" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -51,9 +51,9 @@
       <HintPath>..\packages\Common.Logging.Core.3.3.0\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.2.1.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\couchbase-net-client\Src\Couchbase\bin\Debug\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.2.2.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.2.2\lib\net45\Couchbase.NetClient.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Src/Couchbase.Linq/packages.config
+++ b/Src/Couchbase.Linq/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Common.Logging" version="3.3.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.0" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.2.1" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.2.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Motivation
----------
Features are required from SDK 2.2.2, but when they were developed 2.2.2
wasn't released yet.  Therefore, we still have relative path references to
the SDK, instead of using the NuGet package.

Modifications
-------------
Updated NuGet references to SDK 2.2.2, and modified the assembly
references to use the NuGet package instead of a relative path to the SDK
repository.

Results
-------
The Linq2Couchbase repository can now be cloned and built without also
cloning the SDK.  This also ensures that testing is done with the correct
NuGet version of the SDK.