### PR TITLE
Issue #89: Fixed prefiltered array ALL subqueries

### DIFF
--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -395,6 +395,16 @@ namespace Couchbase.Linq.QueryGeneration
                     prefixedExtents = true;
                     _queryGenerationContext.ExtentNameProvider.Prefix = _queryPartsAggregator.PropertyExtractionPart + ".";
                 }
+                else if (_queryPartsAggregator.QueryType == N1QlQueryType.ArrayAll)
+                {
+                    // We're dealing with an array-type subquery
+                    // If there is any pre-filtering on the array using a Where clause, these statements will be
+                    // referencing the query source using the default extent name.  When we apply the SATISFIES clause
+                    // we'll need to use a new extent name to reference the results of the internal WHERE clause.
+
+                    _queryPartsAggregator.PropertyExtractionPart =
+                        _queryGenerationContext.ExtentNameProvider.GenerateNewExtentName(queryModel.MainFromClause);
+                }
 
                 var allResultOperator = (AllResultOperator) resultOperator;
                 _queryPartsAggregator.WhereAllPart = GetN1QlExpression(allResultOperator.Predicate);

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlExtentNameProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlExtentNameProvider.cs
@@ -100,6 +100,25 @@ namespace Couchbase.Linq.QueryGeneration
             return GetNextExtentName();
         }
 
+        /// <summary>
+        /// Change the extent name of a query source to a newly generated name, replacing any previously generated name.
+        /// </summary>
+        /// <param name="querySource">IQuerySource for which to get a new extent name</param>
+        /// <returns>The escaped extent name for the N1QL query</returns>
+        public string GenerateNewExtentName(IQuerySource querySource)
+        {
+            if (querySource == null)
+            {
+                throw new ArgumentNullException("querySource");
+            }
+
+            // Remove the extent name, if already generated
+            _extentDictionary.Remove(querySource);
+
+            // Generate and return a new extent name
+            return GetExtentName(querySource);
+        }
+
         private string GetNextExtentName()
         {
             return N1QlHelpers.EscapeIdentifier(string.Format(ExtentNameFormat, ++_extentIndex));


### PR DESCRIPTION
Motivation
----------
Query standards for extent names changed slightly for Couchbase Server
4.1.  We can no longer reuse extent names outside of an ARRAY statement
that were defined inside the ARRAY statement.  This was occuring when a
nested array was being filtered with a Where clause and then had an All
result operator applied to it.

Modifications
-------------
Added new feature to the ExtentNameProvider, GenerateNewExtentName.  This
is used to create a new name for an existing extent.  This allows us to
reference the original IQuerySource in the All predicate, but do so using
a different extent name.

We then store this extent name in
QueryPartsAggretator.PropertyExtractionPart so that it can be used
building the EVERY clause.

Results
-------
Filtered nested arrays can now have a All result operator applied to them
when running against Couchbase Server 4.1.