### PR TITLE
Issue #88: Support for string enumeration comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ NuGet will install the package and all dependencies. Once you have the resolved 
 - [Any and All](https://github.com/couchbaselabs/Linq2Couchbase/blob/master/docs/any-all.md)
 - [Testing For NULL And MISSING Attributes](https://github.com/couchbaselabs/Linq2Couchbase/blob/master/docs/null-missing-valued.md)
 - [The META Keyword](https://github.com/couchbaselabs/Linq2Couchbase/blob/master/docs/meta-keyword.md)
+- [Working With Enumerations](https://github.com/couchbaselabs/Linq2Couchbase/blob/master/docs/enum.md)
 
 ##Building From Source##
 

--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -99,6 +99,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BeerSample.cs" />
+    <Compile Include="Documents\BeerStyle.cs" />
+    <Compile Include="Documents\BeerWithEnum.cs" />
     <Compile Include="QueryTests.cs" />
     <Compile Include="BucketContextTests.cs" />
     <Compile Include="Documents\BeerFiltered.cs" />

--- a/Src/Couchbase.Linq.IntegrationTests/Documents/BeerStyle.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/Documents/BeerStyle.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Couchbase.Linq.IntegrationTests.Documents
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum BeerStyle
+    {
+        Porter,
+
+        [EnumMember(Value="Oatmeal Stout")]
+        OatmealStout,
+
+        [EnumMember(Value="Pumpkin Beer")]
+        PumpkinBeer
+    }
+}

--- a/Src/Couchbase.Linq.IntegrationTests/Documents/BeerWithEnum.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/Documents/BeerWithEnum.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
+
+namespace Couchbase.Linq.IntegrationTests.Documents
+{
+    public class BeerWithEnum
+    {
+        [Key]
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("abv")]
+        public decimal Abv { get; set; }
+
+        [JsonProperty("ibu")]
+        public decimal Ibu { get; set; }
+
+        [JsonProperty("srm")]
+        public decimal Srm { get; set; }
+
+        [JsonProperty("upc")]
+        public decimal Upc { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("brewery_id")]
+        public string BreweryId { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("style")]
+        public BeerStyle? Style { get; set; }
+
+        [JsonProperty("category")]
+        public string Category { get; set; }
+
+        [JsonProperty("updated")]
+        public DateTime Updated { get; set; }
+    }
+}

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -144,6 +144,32 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void Map2PocoTests_Simple_Projections_WhereEnum()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var context = new BucketContext(bucket);
+
+                    var beers = (from b in context.Query<BeerWithEnum>()
+                                 where (b.Type == "beer") && (b.Style == BeerStyle.OatmealStout)
+                                 select new { name = b.Name, style = b.Style })
+                                .Take(10).ToList();
+
+                    Assert.IsNotEmpty(beers);
+
+                    foreach (var b in beers)
+                    {
+                        Assert.AreEqual(BeerStyle.OatmealStout, b.style);
+
+                        Console.WriteLine("{0} has style {1}", b.name, b.style);
+                    }
+                }
+            }
+        }
+
+        [Test]
         public void Map2PocoTests_Simple_Projections_Limit()
         {
             using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Proxies\DocumentProxyTypeCreatorTests.cs" />
     <Compile Include="Proxies\DocumentProxyDataMapperTests.cs" />
     <Compile Include="Proxies\DocumentProxyTests.cs" />
+    <Compile Include="QueryGeneration\EnumTests.cs" />
     <Compile Include="QueryGeneration\ArrayIndexTests.cs" />
     <Compile Include="QueryGeneration\AggregateTests.cs" />
     <Compile Include="BucketQueryExecutorEmulator.cs" />

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/EnumTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/EnumTests.cs
@@ -1,0 +1,434 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Core;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.QueryGeneration
+{
+    [TestFixture]
+    class EnumTests : N1QLTestBase
+    {
+        #region No enum converter
+
+        [Test]
+        public void Test_NoEnumConverter_WhereEqual()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<IntegerDoc>(mockBucket.Object)
+                .Where(p => p.Value == IntegerEnum.Value0);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` = 0)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_NoEnumConverter_WhereEqualReversed()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<IntegerDoc>(mockBucket.Object)
+                .Where(p => IntegerEnum.Value0 == p.Value);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` = 0)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_NoEnumConverter_WhereNotEqual()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<IntegerDoc>(mockBucket.Object)
+                .Where(p => p.Value != IntegerEnum.Value1);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` != 1)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_NoEnumConverter_WhereNotEqualReversed()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<IntegerDoc>(mockBucket.Object)
+                .Where(p => IntegerEnum.Value1 != p.Value);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` != 1)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
+        #region No enum converter on nullable value
+
+        [Test]
+        public void Test_NoEnumConverterOnNullable_WhereEqual()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<IntegerNullableDoc>(mockBucket.Object)
+                .Where(p => p.Value == IntegerEnum.Value0);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` = 0)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_NoEnumConverterOnNullable_WhereEqualToNull()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<IntegerNullableDoc>(mockBucket.Object)
+                .Where(p => p.Value == null);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` IS NULL)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_NoEnumConverterOnNullable_WhereEqualReversed()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<IntegerNullableDoc>(mockBucket.Object)
+                .Where(p => IntegerEnum.Value0 == p.Value);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` = 0)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_NoEnumConverterOnNullable_WhereNotEqual()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<IntegerNullableDoc>(mockBucket.Object)
+                .Where(p => p.Value != IntegerEnum.Value0);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` != 0)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_NoEnumConverterOnNullable_WhereNotEqualToNull()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<IntegerNullableDoc>(mockBucket.Object)
+                .Where(p => p.Value != null);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` IS NOT NULL)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_NoEnumConverterOnNullable_WhereNotEqualReversed()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<IntegerNullableDoc>(mockBucket.Object)
+                .Where(p => IntegerEnum.Value0 != p.Value);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` != 0)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
+        #region StringEnumConverter
+
+        [Test]
+        public void Test_StringEnumConverter_WhereEqual()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<StringDoc>(mockBucket.Object)
+                .Where(p => p.Value == StringEnum.Value0);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` = 'Value0')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_StringEnumConverter_WhereEqualReversed()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<StringDoc>(mockBucket.Object)
+                .Where(p => StringEnum.Value0 == p.Value);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` = 'Value0')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_StringEnumConverter_WhereNotEqual()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<StringDoc>(mockBucket.Object)
+                .Where(p => p.Value != StringEnum.Value0);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` != 'Value0')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_StringEnumConverter_WhereEqualToValueWithEnumMemberAttribute()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<StringDoc>(mockBucket.Object)
+                .Where(p => p.Value == StringEnum.Value1);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` = 'Value 1')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_StringEnumConverter_WhereNotEqualReversed()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<StringDoc>(mockBucket.Object)
+                .Where(p => StringEnum.Value0 != p.Value);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` != 'Value0')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
+        #region StringEnumConverter on nullable value
+
+        [Test]
+        public void Test_StringEnumConverterOnNullable_WhereEqual()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<StringNullableDoc>(mockBucket.Object)
+                .Where(p => p.Value == StringEnum.Value0);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` = 'Value0')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_StringEnumConverterOnNullable_WhereEqualToNull()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<StringNullableDoc>(mockBucket.Object)
+                .Where(p => p.Value == null);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` IS NULL)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_StringEnumConverterOnNullable_WhereEqualReversed()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<StringNullableDoc>(mockBucket.Object)
+                .Where(p => StringEnum.Value0 == p.Value);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` = 'Value0')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_StringEnumConverterOnNullable_WhereNotEqual()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<StringNullableDoc>(mockBucket.Object)
+                .Where(p => p.Value != StringEnum.Value0);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` != 'Value0')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_StringEnumConverterOnNullable_WhereNotEqualToNull()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<StringNullableDoc>(mockBucket.Object)
+                .Where(p => p.Value != null);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` IS NOT NULL)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_StringEnumConverterOnNullable_WhereNotEqualReversed()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<StringNullableDoc>(mockBucket.Object)
+                .Where(p => StringEnum.Value0 != p.Value);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`Value` != 'Value0')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private enum IntegerEnum
+        {
+            Value0 = 0,
+            Value1 = 1
+        }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        private enum StringEnum
+        {
+            Value0 = 0,
+
+            [EnumMember(Value="Value 1")]
+            Value1 = 1
+        }
+
+        // ReSharper disable ClassNeverInstantiated.Local
+        // ReSharper disable UnusedAutoPropertyAccessor.Local
+        private class IntegerDoc
+        {
+            public IntegerEnum Value { get; set; }
+        }
+
+        private class IntegerNullableDoc
+        {
+            public IntegerEnum? Value { get; set; }
+        }
+
+        private class StringDoc
+        {
+            public StringEnum Value { get; set; }
+        }
+
+        private class StringNullableDoc
+        {
+            public StringEnum? Value { get; set; }
+        }
+        // ReSharper restore UnusedAutoPropertyAccessor.Local
+        // ReSharper restore ClassNeverInstantiated.Local
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -95,6 +95,7 @@
     <Compile Include="QueryGeneration\Expressions\StringComparisonExpression.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\DateTimeComparisonExpressionTransformer.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\DateTimeTransformationRegistry.cs" />
+    <Compile Include="QueryGeneration\ExpressionTransformers\EnumComparisonExpressionTransformer.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\MultiKeyExpressionTransfomer.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\KeyExpressionTransfomer.cs" />
     <Compile Include="QueryGeneration\IN1QlQueryModelVisitor.cs" />

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/EnumComparisonExpressionTransformer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/EnumComparisonExpressionTransformer.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+
+namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
+{
+    /// <summary>
+    /// Recognizes == and != comparisons between a enumeration property and an enumeration constant.
+    /// By default, LINQ does this comparison using the base type of the enumeration, converting the
+    /// enumeration property to the base type and comparing to the raw number.  This converts the
+    /// comparison to be directly between two values of the enumeration type.  This allows
+    /// <see cref="N1QlExpressionTreeVisitor"/> to handle different serialization approaches for the
+    /// enumeration constant.
+    /// </summary>
+    internal class EnumComparisonExpressionTransformer : IExpressionTransformer<BinaryExpression>
+    {
+        public ExpressionType[] SupportedExpressionTypes
+        {
+            get
+            {
+                return new[]
+                {
+                    ExpressionType.Equal,
+                    ExpressionType.NotEqual
+                };
+            }
+        }
+
+        public Expression Transform(BinaryExpression expression)
+        {
+            Expression newExpression = null;
+
+            if (IsEnumConversion(expression.Left) && (expression.Right.NodeType == ExpressionType.Constant))
+            {
+                newExpression = MakeEnumComparisonExpression(
+                    ((UnaryExpression) expression.Left).Operand,
+                    ((ConstantExpression)expression.Right).Value,
+                    expression.NodeType);
+            }
+            else if (IsEnumConversion(expression.Right) && (expression.Left.NodeType == ExpressionType.Constant))
+            {
+                newExpression = MakeEnumComparisonExpression(
+                    ((UnaryExpression)expression.Right).Operand,
+                    ((ConstantExpression)expression.Left).Value,
+                    expression.NodeType);
+            }
+
+            return newExpression ?? expression;
+        }
+
+        private bool IsEnumConversion(Expression expression)
+        {
+            if (expression.NodeType != ExpressionType.Convert)
+            {
+                return false;
+            }
+
+            var convertExpression = (UnaryExpression) expression;
+            var type = convertExpression.Operand.Type;
+
+            // If type is Nullable<T>, extract the inner type to see if it is an enumeration
+            if (type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(Nullable<>)))
+            {
+                type = type.GetGenericArguments()[0];
+            }
+
+            return type.IsEnum;
+        }
+
+        private BinaryExpression MakeEnumComparisonExpression(Expression operand, object enumValue,
+            ExpressionType comparisonType)
+        {
+            var isNullable = false;
+            var enumType = operand.Type;
+
+            // If type is Nullable<T>, the inner type is the enumeration type
+            if (enumType.IsGenericType && (enumType.GetGenericTypeDefinition() == typeof (Nullable<>)))
+            {
+                enumType = enumType.GetGenericArguments()[0];
+                isNullable = true;
+            }
+
+            string name = null;
+            if (enumValue != null)
+            {
+                // enumValue == null if this is a Nullable type and it doesn't have a value
+
+                name = Enum.GetName(enumType, enumValue);
+
+                if (name == null)
+                {
+                    // Don't bother converting for undefined enumeration values, we'll use the original expression instead
+
+                    return null;
+                }
+            }
+
+            Expression comparisonValue;
+
+            if (name != null)
+            {
+                comparisonValue = Expression.Constant(enumType.GetField(name).GetValue(null));
+
+                if (isNullable)
+                {
+                    comparisonValue = Expression.Convert(comparisonValue, typeof(Nullable<>).MakeGenericType(enumType));
+                }
+            }
+            else
+            {
+                comparisonValue = Expression.Constant(null);
+            }
+            
+            return Expression.MakeBinary(comparisonType, operand, comparisonValue);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -668,6 +668,18 @@ namespace Couchbase.Linq.QueryGeneration
 
                 _expression.Append(']');
             }
+            else if (namedParameter.Value.GetType().IsEnum)
+            {
+                // Use the type serializer to format the value as JSON.
+                // This allows different serialization converters to work on the value.
+                // Then convert back to get the raw type being stored, such as a string or integer.
+                // Then we can write this value to N1QL by visiting it as a constant expression.
+
+                var jsonString = _queryGenerationContext.Serializer.Serialize(namedParameter.Value);
+                var jsonValue = _queryGenerationContext.Serializer.Deserialize<object>(jsonString, 0, jsonString.Length);
+
+                return Visit(System.Linq.Expressions.Expression.Constant(jsonValue));
+            }
             else
             {
                 _expression.AppendFormat("{0}", namedParameter.Value);

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Couchbase.Linq.Clauses;
 using Couchbase.Linq.Extensions;
 using Couchbase.Linq.Operators;
+using Couchbase.Linq.QueryGeneration.ExpressionTransformers;
 using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
 using Remotion.Linq.Parsing.Structure;
 using Remotion.Linq.Parsing.Structure.NodeTypeProviders;
@@ -34,6 +35,10 @@ namespace Couchbase.Linq
 
 
             var transformerRegistry = ExpressionTransformerRegistry.CreateDefault();
+
+            //Register transformer to handle enum == and != comparisons
+            transformerRegistry.Register(new EnumComparisonExpressionTransformer());
+
             var processor = ExpressionTreeParser.CreateDefaultProcessor(transformerRegistry);
             var expressionTreeParser = new ExpressionTreeParser(nodeTypeProvider, processor);
             var queryParser = new QueryParser(expressionTreeParser);

--- a/docs/enum.md
+++ b/docs/enum.md
@@ -1,0 +1,53 @@
+Working With Enumerations
+=========================
+
+For the most part, enumeration properties are supported transparently.  LINQ queries can filter based on enumeration values just like other properties:
+
+	using (var cluster = new Cluster()) {
+		using (var bucket = cluster.OpenBucket("beer-sample")) {
+			var context = new BucketContext(bucket);
+
+			var query = from beer in context.Query<Beer>()
+						where beer.Style == BeerStyle.Porter
+						select beer;
+
+			foreach (var doc in query) {
+				// do work
+			}
+		}
+	}
+
+	// Note: this example assumes the Beer document is configured with Style as enumeration property
+
+So long as you are using the standard JSON serializer, which serializes the enumeration value as a number, there are no special concerns to be addressed.
+
+##Non-Standard JSON Converters##
+
+If a non-standard JSON converter is being used, there are some additional limitations.  A common example of this would be the [Json.Net StringEnumConverter](http://www.newtonsoft.com/json/help/html/t_newtonsoft_json_converters_stringenumconverter.htm).  This converter serializes the enumeration as a string, rather than as an integer.
+
+In this case, there are some additional rules that must be followed.
+
+1. Only equals (==) and not equals (!=) comparisons are supported.  Greater than, less than, etc are not supported.
+2. The custom serializer must be directly applied to the enumeration itself, not to the document or the property.
+
+For example, this is supported:
+
+	[JsonConverter(typeof(StringEnumConverter))]
+	public enum MyEnum
+	{
+		[EnumMember(Value="Value 1")]
+		Value1,
+
+		[EnumMember(Value="Value 2")]
+		Value2
+	}
+
+However, this approach is not:
+
+	public class MyDocument
+	{
+		// This is not supported, because we are changing how this property is serialized,
+	    // rather than changing how the enumeration is serialized
+		[JsonConverter(typeof(StringEnumConverter))]
+		public MyEnum EnumValue { get; set; }
+	}


### PR DESCRIPTION
Motivation
----------
A common use case for enumerations is to store them in the JSON document
as strings rather than integers.  With Json.Net, this is usually done with
StringEnumConverter.  In order to filter N1QL documents based on these
enumerations in WHERE clauses, the outputed N1QL query must compare using
the string representation instead of the integer representation.

Modifications
-------------
Whenever a == or != comparison is performed against an enumeration
constant, convert the expression in EnumComparisonExpressionTransformer
to use the enumeration type instead of the base integer type.  This allows
the constant to be recognized as an enumeration constant later by
N1QlExpressionTreeVisitor.

When an enumeration constant is encountered by N1QlExpressionTreeVisitor,
use the configured ITypeSerializer to determine how to output the value to
N1Ql.  This is done by first serializing to JSON, then deserializing back
to a .Net type.  This gets a string or integer value, depending on how the
type serializer is configured.  This can then be output to the N1QL query
like any other constant.

Results
-------
Equal and not equal comparisons of enumeration values are now supported
when using a StringEnumConverter.  This should theoretically extend to any
other non-standard JSON conversion, so long as the non-standard
serialization is applied directly at the enumeration type.  It would not
work, for example, if a custom serializer was applied to the document
itself that changed how the enumeration property is serialized.

Note that greater than and less than comparisons are not supported with
StringEnumConverter.  They are still supported when working with numeric
serialization.  However, they simply don't translate to N1QL from .Net as
a string, because the .Net comparison greater than or less than comparison
would still be based on the numeric value.  In N1QL, it would be based on
the string value from the serialization layer.