### PR TITLE
Support for N1QL date functions

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -1176,5 +1176,93 @@ namespace Couchbase.Linq.IntegrationTests
                 }
             }
         }
+
+        #region "Date/time functions"
+
+        [Test()]
+        public void DateTime_DateAdd()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var context = new BucketContext(bucket);
+
+                    var beers = from beer in context.Query<Beer>()
+                                where (beer.Type == "beer")
+                                select new { beer.Name, Updated = N1QlFunctions.DateAdd(beer.Updated, -10, N1QlDatePart.Day) };
+
+                    foreach (var b in beers.Take(10))
+                    {
+                        Console.WriteLine("Beer {0} was updated 10 days after {1:g}", b.Name, b.Updated);
+                    }
+                }
+            }
+        }
+
+        [Test()]
+        public void DateTime_DateDiff()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var context = new BucketContext(bucket);
+
+                    var beers = from beer in context.Query<Beer>()
+                                where (beer.Type == "beer")
+                                select new { beer.Name, DaysOld = N1QlFunctions.DateDiff(DateTime.Now, beer.Updated, N1QlDatePart.Day) };
+
+                    foreach (var b in beers.Take(10))
+                    {
+                        Console.WriteLine("Beer {0} is {1} days old", b.Name, b.DaysOld);
+                    }
+                }
+            }
+        }
+
+        [Test()]
+        public void DateTime_DatePart()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var context = new BucketContext(bucket);
+
+                    var beers = from beer in context.Query<Beer>()
+                                where (beer.Type == "beer")
+                                select new { beer.Name, Year = N1QlFunctions.DatePart(beer.Updated, N1QlDatePart.Year) };
+
+                    foreach (var b in beers.Take(10))
+                    {
+                        Console.WriteLine("Beer {0} was updated in {1:0000}", b.Name, b.Year);
+                    }
+                }
+            }
+        }
+
+        [Test()]
+        public void DateTime_DateTrunc()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var context = new BucketContext(bucket);
+
+                    var beers = from beer in context.Query<Beer>()
+                                where (beer.Type == "beer")
+                                select new { beer.Name, Updated = N1QlFunctions.DateTrunc(beer.Updated, N1QlDatePart.Month) };
+
+                    foreach (var b in beers.Take(10))
+                    {
+                        Console.WriteLine("Beer {0} is in {1:MMMM yyyy}", b.Name, b.Updated);
+                    }
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -120,6 +120,7 @@
     <Compile Include="QueryGeneration\ArrayIndexTests.cs" />
     <Compile Include="QueryGeneration\AggregateTests.cs" />
     <Compile Include="BucketQueryExecutorEmulator.cs" />
+    <Compile Include="QueryGeneration\MethodCallTranslators\N1QlFunctionMethodCallTranslatorTests.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\StringComparisonExpressionTransformerTests.cs" />
     <Compile Include="QueryGeneration\NullHandlingTests.cs" />
     <Compile Include="QueryGeneration\N1QlHelpersTests.cs" />

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/MethodCallTranslators/N1QlFunctionMethodCallTranslatorTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/MethodCallTranslators/N1QlFunctionMethodCallTranslatorTests.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.QueryGeneration;
+using Couchbase.Linq.QueryGeneration.MethodCallTranslators;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.QueryGeneration.MethodCallTranslators
+{
+    class N1QlFunctionMethodCallTranslatorTests
+    {
+        #region Constructor
+
+        [Test]
+        public void Constructor_NoMethod_ThrowsArgumentNullException()
+        {
+            // Act/Assert
+
+            // ReSharper disable once ObjectCreationAsStatement
+            var result = Assert.Throws<ArgumentNullException>(() => new N1QlFunctionMethodCallTranslator(null, new N1QlFunctionAttribute("FUNC")));
+
+            Assert.AreEqual("methodInfo", result.ParamName);
+        }
+
+        [Test]
+        public void Constructor_InstanceMethod_ThrowsArgumentException()
+        {
+            // Arrange
+
+            var method = typeof (string).GetMethod("Clone");
+
+            // Act/Assert
+
+            // ReSharper disable once ObjectCreationAsStatement
+            var result = Assert.Throws<ArgumentException>(() => new N1QlFunctionMethodCallTranslator(method, new N1QlFunctionAttribute("FUNC")));
+
+            Assert.AreEqual("methodInfo", result.ParamName);
+        }
+
+        [Test]
+        public void Constructor_NoAttribute_ThrowsArgumentNullException()
+        {
+            // Arrange
+
+            var method = typeof(Methods).GetMethod("Method0");
+
+            // Act/Assert
+
+            // ReSharper disable once ObjectCreationAsStatement
+            var result = Assert.Throws<ArgumentNullException>(() => new N1QlFunctionMethodCallTranslator(method, null));
+
+            Assert.AreEqual("attribute", result.ParamName);
+        }
+
+        #endregion
+
+        #region Properties
+
+        [Test]
+        public void SupportedMethods_ReturnsMethodInfoFromConstructor()
+        {
+            // Arrange
+
+            var method = typeof(Methods).GetMethod("Method0");
+
+            var translator = new N1QlFunctionMethodCallTranslator(method, new N1QlFunctionAttribute("FUNC"));
+
+            // Act
+
+            var result = new List<MethodInfo>(translator.SupportMethods);
+
+            // Assert
+
+            Assert.Contains(method, result);
+        }
+
+        #endregion
+
+        #region Translate
+
+        [Test]
+        public void Translate_NoMethod_ThrowsArgumentNullException()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var method = typeof(Methods).GetMethod("Method0");
+
+            var transformer = new N1QlFunctionMethodCallTranslator(method, new N1QlFunctionAttribute("FUNC"));
+
+            // Act/Assert
+
+            var result = Assert.Throws<ArgumentNullException>(() => transformer.Translate(null, visitor.Object));
+
+            Assert.AreEqual("methodCallExpression", result.ParamName);
+        }
+
+        [Test]
+        public void Translate_MismatchedMethod_ThrowsArgumentException()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var method = typeof(Methods).GetMethod("Method1");
+            var expression = Expression.Call(typeof(Methods).GetMethod("Method0"));
+
+            var transformer = new N1QlFunctionMethodCallTranslator(method, new N1QlFunctionAttribute("FUNC"));
+
+            // Act/Assert
+
+            var result = Assert.Throws<ArgumentException>(() => transformer.Translate(expression, visitor.Object));
+
+            Assert.AreEqual("methodCallExpression", result.ParamName);
+        }
+
+        [Test]
+        public void Translate_NoVisitor_ThrowsArgumentNullException()
+        {
+            // Arrange
+
+            var method = typeof(Methods).GetMethod("Method0");
+            var expression = Expression.Call(method);
+
+            var transformer = new N1QlFunctionMethodCallTranslator(method, new N1QlFunctionAttribute("FUNC"));
+
+            // Act/Assert
+
+            var result = Assert.Throws<ArgumentNullException>(() => transformer.Translate(expression, null));
+
+            Assert.AreEqual("expressionTreeVisitor", result.ParamName);
+        }
+
+        [Test]
+        public void Translate_NoParameters_RendersCorrectly()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var method = typeof (Methods).GetMethod("Method0");
+            var expression = Expression.Call(method);
+
+            var transformer = new N1QlFunctionMethodCallTranslator(method, new N1QlFunctionAttribute("FUNC"));
+
+            // Act
+
+            transformer.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            Assert.AreEqual("FUNC()", result);
+        }
+
+        [Test]
+        public void Translate_OneParameter_RendersCorrectly()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var method = typeof(Methods).GetMethod("Method1");
+            var expression = Expression.Call(method,
+                Expression.Constant("arg1"));
+
+            var transformer = new N1QlFunctionMethodCallTranslator(method, new N1QlFunctionAttribute("FUNC"));
+
+            // Act
+
+            transformer.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            Assert.AreEqual("FUNC('arg1')", result);
+        }
+
+        [Test]
+        public void Translate_TwoParameters_RendersCorrectly()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var method = typeof (Methods).GetMethod("Method2");
+            var expression = Expression.Call(method,
+                Expression.Constant("arg1"),
+                Expression.Constant("arg2"));
+
+            var transformer = new N1QlFunctionMethodCallTranslator(method, new N1QlFunctionAttribute("FUNC"));
+
+            // Act
+
+            transformer.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            Assert.AreEqual("FUNC('arg1', 'arg2')", result);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        [SuppressMessage("ReSharper", "UnusedMember.Local")]
+        [SuppressMessage("ReSharper", "UnusedParameter.Local")]
+        private class Methods
+        {
+            public static string Method0()
+            {
+                throw new NotImplementedException();
+            }
+
+            public static string Method1(string param1)
+            {
+                throw new NotImplementedException();
+            }
+
+            public static string Method2(string param1, string param2)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -83,6 +84,10 @@
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="IBucketContext.cs" />
     <Compile Include="KeyAttributeMissingException.cs" />
+    <Compile Include="N1QlDatePart.cs" />
+    <Compile Include="N1QlFunctions.Core.cs" />
+    <Compile Include="N1QlFunctions.DateTime.cs" />
+    <Compile Include="N1QlFunctions.Metadata.cs" />
     <Compile Include="Proxies\DocumentCollection.cs" />
     <Compile Include="Proxies\DocumentNode.cs" />
     <Compile Include="Proxies\DocumentProxyTypeCreator.cs" />
@@ -130,6 +135,8 @@
     <Compile Include="QueryGeneration\MethodCallTranslators\KeyMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\MetaMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\DefaultMethodCallTranslatorProvider.cs" />
+    <Compile Include="N1QlFunctionAttribute.cs" />
+    <Compile Include="QueryGeneration\MethodCallTranslators\N1QlFunctionMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\ToStringMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\StringSplitMethodCallTranslator.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\StringIndexOfMethodCallTranslator.cs" />
@@ -153,7 +160,7 @@
     <Compile Include="QueryGeneration\ParameterAggregator.cs" />
     <Compile Include="QueryGeneration\QueryPartsAggregator.cs" />
     <Compile Include="Metadata\DocumentMetadata.cs" />
-    <Compile Include="N1QlFunctions.cs" />
+    <Compile Include="N1QlFunctions.Missing.cs" />
     <Compile Include="QueryGeneration\UnclaimedGroupJoin.cs" />
     <Compile Include="QueryParserHelper.cs" />
     <Compile Include="UnixMillisecondsDateTime.cs" />

--- a/Src/Couchbase.Linq/N1QlDatePart.cs
+++ b/Src/Couchbase.Linq/N1QlDatePart.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Represents date parts for calls to date related <see cref="N1QlFunctions"/>.
+    /// </summary>
+    /// <remarks>
+    /// Different date related functions are compatible with different date parts.
+    /// For details, see the N1QL documentation.
+    /// </remarks>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum N1QlDatePart
+    {
+        [EnumMember(Value = "millennium")]
+        Millennium,
+
+        [EnumMember(Value = "century")]
+        Century,
+
+        [EnumMember(Value = "decade")]
+        Decade,
+
+        [EnumMember(Value = "year")]
+        Year,
+
+        [EnumMember(Value = "quarter")]
+        Quarter,
+
+        [EnumMember(Value = "month")]
+        Month,
+
+        [EnumMember(Value = "week")]
+        Week,
+
+        [EnumMember(Value = "day")]
+        Day,
+
+        [EnumMember(Value = "hour")]
+        Hour,
+
+        [EnumMember(Value = "minute")]
+        Minute,
+
+        [EnumMember(Value = "second")]
+        Second,
+
+        [EnumMember(Value = "millisecond")]
+        Millisecond,
+
+        [EnumMember(Value = "doy")]
+        DayOfYear,
+
+        [EnumMember(Value = "dow")]
+        DayOfWeek,
+
+        [EnumMember(Value = "iso_week")]
+        IsoWeek,
+
+        [EnumMember(Value = "iso_year")]
+        IsoYear,
+
+        [EnumMember(Value = "iso_dow")]
+        IsoDayOfWeek,
+
+        [EnumMember(Value = "timezone")]
+        TimeZone,
+
+        [EnumMember(Value = "timezone_hour")]
+        TimeZoneOffsetHour,
+
+        [EnumMember(Value = "timezone_minute")]
+        TimeZoneOffsetMinute
+    }
+}

--- a/Src/Couchbase.Linq/N1QlFunctionAttribute.cs
+++ b/Src/Couchbase.Linq/N1QlFunctionAttribute.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Decorates a method that is converted to a N1QL function call.  Each parameter in .Net
+    /// is expected to correspond directly to a parameter in N1QL, in the same order.
+    /// </summary>
+    /// <remarks>
+    /// Should only be used to decorate static methods.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method)]
+    internal class N1QlFunctionAttribute : Attribute
+    {
+        /// <summary>
+        /// Name of the function in N1QL.
+        /// </summary>
+        public string N1QlFunctionName { get; set; }
+
+        /// <summary>
+        /// Creates a new N1QlFunctionAttribute.
+        /// </summary>
+        /// <param name="n1QlFunctionName">Name of the function in N1QL.</param>
+        public N1QlFunctionAttribute(string n1QlFunctionName)
+        {
+            if (string.IsNullOrEmpty(n1QlFunctionName))
+            {
+                throw new ArgumentNullException("n1QlFunctionName");
+            }
+
+            N1QlFunctionName = n1QlFunctionName;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/N1QlFunctions.Core.cs
+++ b/Src/Couchbase.Linq/N1QlFunctions.Core.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Implements static helper methods for N1QL queries
+    /// </summary>
+    public static partial class N1QlFunctions
+    {
+        /// <summary>
+        /// Shortcut for creating an error for methods that are only supported in N1QL, not in .Net.
+        /// </summary>
+        private static Exception NotSupportedError()
+        {
+            return new NotSupportedException("This method may only be used in lambda expressions for generating N1QL queries.");
+        }
+    }
+}

--- a/Src/Couchbase.Linq/N1QlFunctions.DateTime.cs
+++ b/Src/Couchbase.Linq/N1QlFunctions.DateTime.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq
+{
+    public partial class N1QlFunctions
+    {
+        /// <summary>
+        /// Adds an interval to a date/time, where the unit of interval is part.
+        /// </summary>
+        /// <param name="date">Date/time on which to perform arithmetic.</param>
+        /// <param name="interval">Interval to add to date.</param>
+        /// <param name="part">Unit of the interval being added to date.</param>
+        /// <returns>New date/time</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_ADD_STR")]
+        public static DateTime DateAdd(DateTime date, long interval, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+
+        /// <summary>
+        /// Returns the elapsed time between date/times as an integer whose unit is part.
+        /// </summary>
+        /// <param name="date1">Starting date/time for difference.</param>
+        /// <param name="date2">Ending date/time for difference.</param>
+        /// <param name="part">Unit of the interval to return.</param>
+        /// <returns>Difference between date1 and date2 in part units.  Result is positive if date1 is later than date2.</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_DIFF_STR")]
+        public static long DateDiff(DateTime date1, DateTime date2, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+
+        /// <summary>
+        /// Returns the date part as an integer.
+        /// </summary>
+        /// <param name="date">Date/time to extract the part of</param>
+        /// <param name="part">Part to extract.</param>
+        /// <returns>Portion of the date/time, based on part.</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_PART_STR")]
+        public static long DatePart(DateTime date, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+
+        /// <summary>
+        /// Truncates the given date/time so that the given date part is the least significant.
+        /// </summary>
+        /// <param name="date">Date/time to be truncated.</param>
+        /// <param name="part">Part to be the least significant.</param>
+        /// <returns>Truncated date/time.</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_TRUNC_STR")]
+        public static DateTime DateTrunc(DateTime date, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+    }
+}

--- a/Src/Couchbase.Linq/N1QlFunctions.Metadata.cs
+++ b/Src/Couchbase.Linq/N1QlFunctions.Metadata.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.Metadata;
+
+namespace Couchbase.Linq
+{
+    public static partial class N1QlFunctions
+    {
+        /// <summary>
+        /// Returns metadata for a document object
+        /// </summary>
+        /// <param name="document">Document to get metadata from</param>
+        /// <returns>Metadata about the document</returns>
+        /// <remarks>Should only be called against a top-level document in Couchbase</remarks>
+        public static DocumentMetadata Meta(object document)
+        {
+            // Implementation will only be called when unit testing
+            // using LINQ-to-Objects and faking a Couchbase database
+            // Any faked document object should implement IDocumentMetadataProvider
+
+            var provider = document as IDocumentMetadataProvider;
+            if (provider != null)
+            {
+                return provider.GetMetadata();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Returns the key for a document object
+        /// </summary>
+        /// <param name="document">Document to get key from</param>
+        /// <returns>Key of the document</returns>
+        /// <remarks>Should only be called against a top-level document in Couchbase</remarks>
+        public static string Key(object document)
+        {
+            // Implementation will only be called when unit testing
+            // using LINQ-to-Objects and faking a Couchbase database
+            // Any faked document object should implement IDocumentMetadataProvider
+
+            var provider = document as IDocumentMetadataProvider;
+            if (provider != null)
+            {
+                var metadata = provider.GetMetadata();
+
+                return metadata != null ? metadata.Id : null;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Src/Couchbase.Linq/N1QlFunctions.Missing.cs
+++ b/Src/Couchbase.Linq/N1QlFunctions.Missing.cs
@@ -1,62 +1,13 @@
-﻿using System.Linq.Expressions;
-using Couchbase.Linq.Metadata;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Couchbase.Linq
 {
-    /// <summary>
-    /// Implements static helper methods for N1QL queries 
-    /// </summary>
-    public static class N1QlFunctions
+    public static partial class N1QlFunctions
     {
-
-        /// <summary>
-        /// Returns metadata for a document object
-        /// </summary>
-        /// <param name="document">Document to get metadata from</param>
-        /// <returns>Metadata about the document</returns>
-        /// <remarks>Should only be called against a top-level document in Couchbase</remarks>
-        public static DocumentMetadata Meta(object document)
-        {
-            // Implementation will only be called when unit testing
-            // using LINQ-to-Objects and faking a Couchbase database
-            // Any faked document object should implement IDocumentMetadataProvider
-
-            var provider = document as IDocumentMetadataProvider;
-            if (provider != null)
-            {
-                return provider.GetMetadata();
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Returns the key for a document object
-        /// </summary>
-        /// <param name="document">Document to get key from</param>
-        /// <returns>Key of the document</returns>
-        /// <remarks>Should only be called against a top-level document in Couchbase</remarks>
-        public static string Key(object document)
-        {
-            // Implementation will only be called when unit testing
-            // using LINQ-to-Objects and faking a Couchbase database
-            // Any faked document object should implement IDocumentMetadataProvider
-
-            var provider = document as IDocumentMetadataProvider;
-            if (provider != null)
-            {
-                var metadata = provider.GetMetadata();
-
-                return metadata != null ? metadata.Id : null;
-            }
-            else
-            {
-                return null;
-            }
-        }
-
         #region IsMissing and IsNotMissing
 
         /// <summary>
@@ -210,6 +161,5 @@ namespace Couchbase.Linq
         }
 
         #endregion
-
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/N1QlFunctionMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/N1QlFunctionMethodCallTranslator.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
+{
+    /// <summary>
+    /// Translates calls to static methods decorated with <see cref="N1QlFunctionAttribute" />.
+    /// </summary>
+    internal class N1QlFunctionMethodCallTranslator : IMethodCallTranslator
+    {
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get { return new[] { MethodInfo }; }
+        }
+
+        public MethodInfo MethodInfo { get; private set; }
+        public string N1QlFunctionName { get; private set; }
+
+        /// <summary>
+        /// Creates a new N1QlFunctionMethodCallTranslator for a given method and <see cref="N1QlFunctionAttribute"/>.
+        /// </summary>
+        /// <param name="methodInfo">Method call to be translated.  Must be a static method.</param>
+        /// <param name="attribute"><see cref="N1QlFunctionAttribute"/> that defines the translation.</param>
+        public N1QlFunctionMethodCallTranslator(MethodInfo methodInfo, N1QlFunctionAttribute attribute)
+        {
+            if (methodInfo == null)
+            {
+                throw new ArgumentNullException("methodInfo");
+            }
+            if (!methodInfo.IsStatic)
+            {
+                throw new ArgumentException("Only static methods are supported", "methodInfo");
+            }
+            if (attribute == null)
+            {
+                throw new ArgumentNullException("attribute");
+            }
+
+            MethodInfo = methodInfo;
+            N1QlFunctionName = attribute.N1QlFunctionName;
+        }
+
+        /// <summary>
+        /// Translate the given method call expression.
+        /// </summary>
+        /// <param name="methodCallExpression">Method call to be translated.  Must match the method provided to the constructor.</param>
+        /// <param name="expressionTreeVisitor"><see cref="N1QlExpressionTreeVisitor"/> to use to visit parameters.</param>
+        /// <returns>Original or altered expression.</returns>
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+            if (expressionTreeVisitor == null)
+            {
+                throw new ArgumentNullException("expressionTreeVisitor");
+            }
+            if (methodCallExpression.Method != MethodInfo)
+            {
+                throw new ArgumentException("Cannot translate a method other than the one provided to the constructor.", "methodCallExpression");
+            }
+
+            expressionTreeVisitor.Expression.Append(N1QlFunctionName);
+            expressionTreeVisitor.Expression.Append('(');
+
+            for (var i = 0; i < methodCallExpression.Arguments.Count; i++)
+            {
+                if (i > 0)
+                {
+                    expressionTreeVisitor.Expression.Append(", ");
+                }
+
+                expressionTreeVisitor.Visit(methodCallExpression.Arguments[i]);
+            }
+
+            expressionTreeVisitor.Expression.Append(')');
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/docs/date-handling.md
+++ b/docs/date-handling.md
@@ -21,7 +21,31 @@ Dates on documents may be compared to each other or to constants using normal .N
 	}
 
 ##Date Functions
-At this time, date arithmetic is not supported by this library.  However, support is planned for a future release.
+A subset of N1QL date/time functions are supported for use in LINQ queries, and are provided as static methods of the N1QlFunctions class.
+
+	using (var cluster = new Cluster()) {
+		using (var bucket = cluster.OpenBucket("beer-sample")) {
+			var context = new BucketContext(bucket);
+
+			var query = from beer in context.Query<Beer>()
+						where N1QlFunctions.DateDiff(DateTime.Now, beer.Updated, N1QlDatePart.Day) > 10
+						select beer;
+
+			foreach (var doc in query) {
+				// do work
+				// query will return beers last updated more than 10 days ago
+			}
+		}
+	}
+
+| Function Name               | N1QL Equivalent |
+| --------------------------- | --------------- |
+| N1QlFunctions.DateDiff      | DATE_DIFF_STR   |
+| N1QlFunctions.DateAdd       | DATE_ADD_STR    |
+| N1QlFunctions.DatePart      | DATE_PART_STR   |
+| N1QlFunctions.DateTrunc     | DATE_TRUNC_STR  |
+
+These methods may only be used within queries.  They cannot be called directly in code.  This also means that they cannot be used in unit tests where the query source is being faked.  This may be improved in a future version.
 
 ##Time Zones
 Note that ISO 8601 date/time fields include time and time zone data.  Be sure to take this into account when working with global systems.


### PR DESCRIPTION
Motivation
----------
N1QL supports several date functions, which don't necessarily translate
directly to .Net date functions.  Supporting them will help users by
allowing filters to be applied during a query, rather than after data is
delivered to the application.

Modifications
-------------
Designed a new system for defining N1QL functions in .Net by decorating
static methods with N1QlFunctionAttribute.  It is then assumed that there
is a one-to-one mapping between the .Net parameters and the parameters of
the N1QL function.

Added additional methods to N1QlFunctions to act as the equivalent to
DATE_DIFF_STR, DATE_ADD_STR, DATE_PART_STR, and DATE_TRUNC_STR.  This
includes a new enumeration, N1QlDatePart, for the date part parameter.
The string based N1QL functions were chosen instead of the Unix
milliseconds version because they can be more easily parsed by Json.Net.

To help with code organization, split N1QlFunctions into different files
using partial classes.

Results
-------
N1QL functions for date/time addition, differences, part extraction, and
truncation are now supported.  There is a new design method which can be
used to easily add support for more N1QL functions like these in the
future.