### PR TITLE
Support for IN operator on nested arrays via Contains

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -797,6 +797,28 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test()]
+        public void SubqueryTests_ArraySubqueryContains()
+        {
+            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            {
+                using (var bucket = cluster.OpenBucket("beer-sample"))
+                {
+                    var context = new BucketContext(bucket);
+
+                    var breweries = from brewery in context.Query<Brewery>()
+                                    where brewery.Type == "brewery" && brewery.Address.Contains("563 Second Street")
+                                    orderby brewery.Name
+                                    select new { name = brewery.Name, addresses = brewery.Address };
+
+                    foreach (var b in breweries.Take(10))
+                    {
+                        Console.WriteLine("Brewery {0} has address {1}", b.name, string.Join(", ", b.addresses));
+                    }
+                }
+            }
+        }
+
+        [Test()]
         public void SubqueryTests_ArraySubquerySelectNewObject()
         {
             using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Proxies\DocumentProxyTypeCreatorTests.cs" />
     <Compile Include="Proxies\DocumentProxyDataMapperTests.cs" />
     <Compile Include="Proxies\DocumentProxyTests.cs" />
+    <Compile Include="QueryGeneration\ArrayOperatorTests.cs" />
     <Compile Include="QueryGeneration\EnumTests.cs" />
     <Compile Include="QueryGeneration\ArrayIndexTests.cs" />
     <Compile Include="QueryGeneration\AggregateTests.cs" />

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/ArrayOperatorTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/ArrayOperatorTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Couchbase.Core;
+using Moq;
+using Newtonsoft.Json.Serialization;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.QueryGeneration
+{
+    [TestFixture]
+    public class ArrayOperatorTests : N1QLTestBase
+    {
+        [Test]
+        public void Test_ArrayContains()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<DocumentWithArray>(mockBucket.Object)
+                    .Where(e => e.Array.Contains("abc"));
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE 'abc' IN (`Extent1`.`Array`)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_ListContains()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<DocumentWithIList>(mockBucket.Object)
+                    .Where(e => e.List.Contains("abc"));
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE 'abc' IN (`Extent1`.`List`)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #region Helper Classes
+
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class DocumentWithArray
+        {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public string[] Array { get; set; }
+        }
+
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class DocumentWithIList
+        {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public IList<string> List { get; set; }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Motivation
----------
N1QL supports testing nested arrays for values using the IN operator.
Contains is an equivalent LINQ function which can be supported.

Modifications
-------------
Implement ContainsResultOperator for nested array subqueries, mapping to
the IN statement in N1QL.

Throw an exception if an unsupported result operator is used for a query.
The current handling was to fail transparently without an exception,
ignoring the result operator.

Results
-------
The LINQ Contains method may be used against nested arrays within
Couchbase documents.