### PR TITLE
Refactor integration tests for issue#94

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
@@ -10,12 +10,6 @@ namespace Couchbase.Linq.IntegrationTests
     // ReSharper disable once InconsistentNaming
     public class BucketContextTests
     {
-        [TestFixtureSetUp]
-        public void TestFixtureSetUp()
-        {
-            ClusterHelper.Initialize(TestConfigurations.DefaultConfig());
-        }
-
         [Test]
         public void Test_Basic_Query()
         {
@@ -24,7 +18,7 @@ namespace Couchbase.Linq.IntegrationTests
                 where x.Type == "beer"
                 select x;
 
-            foreach (var beer in query)
+            foreach (var beer in query.Take(1))
             {
                 Console.WriteLine(beer.Name);
             }
@@ -37,7 +31,7 @@ namespace Couchbase.Linq.IntegrationTests
             var beers = from b in db.Beers
                 select b;
 
-            foreach (var beer in beers)
+            foreach (var beer in beers.Take(1))
             {
                 Console.WriteLine(beer.Name);
             }
@@ -52,7 +46,7 @@ namespace Couchbase.Linq.IntegrationTests
                         on beer.BreweryId equals N1QlFunctions.Key(brewery)
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 
-            foreach (var beer in query)
+            foreach (var beer in query.Take(1))
             {
                 Console.WriteLine(beer.Name);
             }

--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Documents\Geo.cs" />
     <Compile Include="N1QLTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestSetup.cs" />
     <Compile Include="TestConfigurations.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 namespace Couchbase.Linq.IntegrationTests
 {
     [TestFixture]
-    public class QueryTests : N1QLTestBase
+    public class QueryTests
     {
         [SetUp]
         public void TestSetUp()
@@ -22,489 +22,412 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests()
         {
-            using (var cluster = new Cluster(
-                TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from b in context.Query<Beer>()
+                select b;
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var beer in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from b in context.Query<Beer>()
-                        select b;
-
-                    foreach (var beer in beers)
-                    {
-                        Console.WriteLine(beer.Name);
-                    }
-                }
+                Console.WriteLine(beer.Name);
             }
         }
 
         [Test]
         public void Map2PocoTests_Simple_Projections()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from b in context.Query<Beer>()
+                select new {name = b.Name, abv = b.Abv};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from b in context.Query<Beer>()
-                        select new {name = b.Name, abv = b.Abv};
-
-                    foreach (var b in beers)
-                    {
-                        Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
-                    }
-                }
+                Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
             }
         }
 
         [Test]
         public void Map2PocoTests_StronglyTyped_Projections()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from b in context.Query<Beer>()
+                select new Beer {Name = b.Name, Abv = b.Abv};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from b in context.Query<Beer>()
-                                select new Beer() { Name = b.Name, Abv = b.Abv };
-
-                    foreach (var b in beers.Take(10))
-                    {
-                        Console.WriteLine("{0} has {1} ABV", b.Name, b.Abv);
-                    }
-                }
+                Console.WriteLine("{0} has {1} ABV", b.Name, b.Abv);
             }
         }
 
         [Test]
         public void Map2PocoTests_Simple_Projections_Where()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from b in context.Query<Beer>()
+                where b.Type == "beer"
+                select new {name = b.Name, abv = b.Abv};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from b in context.Query<Beer>()
-                        where b.Type == "beer"
-                        select new {name = b.Name, abv = b.Abv};
-
-                    foreach (var b in beers)
-                    {
-                        Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
-                    }
-                }
+                Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
             }
         }
 
         [Test]
         public void Map2PocoTests_Simple_Projections_WhereNot()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from b in context.Query<Beer>()
+                where b.Type == "beer" && !(b.Abv < 4)
+                select new {name = b.Name, abv = b.Abv};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from b in context.Query<Beer>()
-                        where b.Type == "beer" && !(b.Abv < 4)
-                        select new {name = b.Name, abv = b.Abv};
-
-                    foreach (var b in beers)
-                    {
-                        Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
-                    }
-                }
+                Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
             }
         }
 
         [Test]
         public void Map2PocoTests_Simple_Projections_WhereDateTime()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from b in context.Query<Beer>()
+                where (b.Type == "beer") && (b.Updated >= new DateTime(2010, 1, 1))
+                select new {name = b.Name, updated = b.Updated};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from b in context.Query<Beer>()
-                                where (b.Type == "beer") && (b.Updated >= new DateTime(2010, 1, 1))
-                                select new { name = b.Name, updated = b.Updated };
-
-                    foreach (var b in beers.Take(20))
-                    {
-                        Console.WriteLine("{0} last updated {1:g}", b.name, b.updated);
-                    }
-                }
+                Console.WriteLine("{0} last updated {1:g}", b.name, b.updated);
             }
         }
 
         [Test]
         public void Map2PocoTests_Simple_Projections_WhereEnum()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = (from b in context.Query<BeerWithEnum>()
+                where (b.Type == "beer") && (b.Style == BeerStyle.OatmealStout)
+                select new {name = b.Name, style = b.Style})
+                .Take(1).ToList();
+
+            Assert.IsNotEmpty(beers);
+
+            foreach (var b in beers)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+                Assert.AreEqual(BeerStyle.OatmealStout, b.style);
 
-                    var beers = (from b in context.Query<BeerWithEnum>()
-                                 where (b.Type == "beer") && (b.Style == BeerStyle.OatmealStout)
-                                 select new { name = b.Name, style = b.Style })
-                                .Take(10).ToList();
-
-                    Assert.IsNotEmpty(beers);
-
-                    foreach (var b in beers)
-                    {
-                        Assert.AreEqual(BeerStyle.OatmealStout, b.style);
-
-                        Console.WriteLine("{0} has style {1}", b.name, b.style);
-                    }
-                }
+                Console.WriteLine("{0} has style {1}", b.name, b.style);
             }
         }
 
         [Test]
         public void Map2PocoTests_Simple_Projections_Limit()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = (from b in context.Query<Beer>()
+                where b.Type == "beer"
+                select new {name = b.Name, abv = b.Abv}).
+                Take(1).
+                Skip(5);
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = (from b in context.Query<Beer>()
-                        where b.Type == "beer"
-                        select new {name = b.Name, abv = b.Abv}).
-                        Take(10).
-                        Skip(5);
-
-                    foreach (var b in beers)
-                    {
-                        Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
-                    }
-                }
+                Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
             }
         }
 
         [Test]
         public void Map2PocoTests_Simple_Projections_Meta()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = (from b in context.Query<Beer>()
+                where b.Type == "beer"
+                select new {name = b.Name, meta = N1QlFunctions.Meta(b)}).
+                Take(1);
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = (from b in context.Query<Beer>()
-                        where b.Type == "beer"
-                        select new {name = b.Name, meta = N1QlFunctions.Meta(b)}).
-                        Take(10);
-
-                    foreach (var b in beers)
-                    {
-                        Console.WriteLine("{0} has metadata {1}", b.name, b.meta);
-                    }
-                }
+                Console.WriteLine("{0} has metadata {1}", b.name, b.meta);
             }
         }
 
         [Test]
         public void Map2PocoTests_Explain()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var explanation = (from b in context.Query<Beer>()
-                        where b.Type == "beer"
-                        select b).
-                        Explain();
+            var explanation = (from b in context.Query<Beer>()
+                where b.Type == "beer"
+                select b).
+                Explain();
 
-                    Console.WriteLine(explanation);
-                }
-            }
+            Console.WriteLine(explanation);
         }
 
         [Test]
         public void Map2PocoTests_Explain_QueryWithPropertyExtraction()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var explanation = (from b in context.Query<Beer>()
-                                       where b.Type == "beer"
-                                       select b.Abv).
-                        Explain();
+            var explanation = (from b in context.Query<Beer>()
+                where b.Type == "beer"
+                select b.Abv).
+                Explain();
 
-                    Console.WriteLine(explanation);
-                }
-            }
+            Console.WriteLine(explanation);
         }
 
         [Test]
         public void Map2PocoTests_NewObjectsInArray()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var query = from brewery in context.Query<Brewery>()
-                        where brewery.Type == "brewery"
-                        select
-                            new
-                            {
-                                name = brewery.Name,
-                                list =
-                                    new[]
-                                    {new {part = brewery.City}, new {part = brewery.State}, new {part = brewery.Code}}
-                            };
-
-                    foreach (var brewery in query.Take(10))
+            var query = from brewery in context.Query<Brewery>()
+                where brewery.Type == "brewery"
+                select
+                    new
                     {
-                        Console.WriteLine("Brewery {0} has address parts {1}", brewery.name,
-                            String.Join(", ", brewery.list.Select(p => p.part)));
-                    }
-                }
+                        name = brewery.Name,
+                        list =
+                            new[]
+                            {new {part = brewery.City}, new {part = brewery.State}, new {part = brewery.Code}}
+                    };
+
+            var results = query.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var brewery in results)
+            {
+                Console.WriteLine("Brewery {0} has address parts {1}", brewery.name,
+                    string.Join(", ", brewery.list.Select(p => p.part)));
             }
         }
 
         [Test]
         public void NoProjection_Meta()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = (from b in context.Query<Beer>()
+                where b.Type == "beer"
+                select N1QlFunctions.Meta(b)).
+                Take(1);
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = (from b in context.Query<Beer>()
-                                 where b.Type == "beer"
-                                 select N1QlFunctions.Meta(b)).
-                        Take(10);
-
-                    foreach (var b in beers)
-                    {
-                        Console.WriteLine(b);
-                    }
-                }
+                Console.WriteLine(b);
             }
         }
 
         [Test]
         public void NoProjection_Number()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = (from b in context.Query<Beer>()
+                where b.Type == "beer"
+                select b.Abv).
+                Take(1);
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = (from b in context.Query<Beer>()
-                                 where b.Type == "beer"
-                                 select b.Abv).
-                        Take(10);
-
-                    foreach (var b in beers)
-                    {
-                        Console.WriteLine(b);
-                    }
-                }
+                Console.WriteLine(b);
             }
         }
 
         [Test]
         public void UseKeys_SelectDocuments()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var query =
+                from brewery in
+                    context.Query<Brewery>().UseKeys(new[] {"21st_amendment_brewery_cafe", "357"})
+                select new {name = brewery.Name};
+
+            var results = query.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var brewery in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var query =
-                        from brewery in
-                            context.Query<Brewery>().UseKeys(new[] {"21st_amendment_brewery_cafe", "357"})
-                        select new {name = brewery.Name};
-
-                    foreach (var brewery in query)
-                    {
-                        Console.WriteLine("Brewery {0}", brewery.name);
-                    }
-                }
+                Console.WriteLine("Brewery {0}", brewery.name);
             }
         }
 
         [Test]
         public void AnyAllTests_AnyNestedArrayWithFilter()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var breweries = (from b in context.Query<Brewery>()
-                        where b.Type == "brewery" && b.Address.Any(p => p == "563 Second Street")
-                        select new {name = b.Name, address = b.Address}).
-                        ToList();
+            var breweries = (from b in context.Query<Brewery>()
+                where b.Type == "brewery" && b.Address.Any(p => p == "563 Second Street")
+                select new {name = b.Name, address = b.Address}).
+                Take(1).
+                ToList();
 
-                    Assert.IsNotEmpty(breweries);
-                    Assert.True(breweries.All(p => p.address.Contains("563 Second Street")));
-
-                }
-            }
+            Assert.IsNotEmpty(breweries);
+            Assert.True(breweries.All(p => p.address.Contains("563 Second Street")));
         }
 
         [Test]
         public void AnyAllTests_AnyOnMainDocument_ReturnsTrue()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var hasBreweries = (from b in context.Query<Brewery>()
-                        where b.Type == "brewery"
-                        select new {name = b.Name, address = b.Address}).
-                        Any();
+            var hasBreweries = (from b in context.Query<Brewery>()
+                where b.Type == "brewery"
+                select new {name = b.Name, address = b.Address}).Take(1).
+                Any();
 
-                    Assert.True(hasBreweries);
-                }
-            }
+            Assert.True(hasBreweries);
         }
 
         [Test]
         public void AnyAllTests_AnyOnMainDocument_ReturnsFalse()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var hasFaketype = (from b in context.Query<Brewery>()
-                        where b.Type == "faketype"
-                        select new {name = b.Name, address = b.Address}).
-                        Any();
+            var hasFaketype = (from b in context.Query<Brewery>()
+                where b.Type == "faketype"
+                select new {name = b.Name, address = b.Address}).
+                Take(1).
+                Any();
 
-                    Assert.False(hasFaketype);
-                }
-            }
+            Assert.False(hasFaketype);
         }
 
         [Test]
         public void AnyAllTests_AllNestedArray()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var breweries = (from b in context.Query<Brewery>()
-                        where b.Type == "brewery" && b.Address.All(p => p == "563 Second Street")
-                        select new {name = b.Name, address = b.Address}).
-                        ToList();
+            var breweries = (from b in context.Query<Brewery>()
+                where b.Type == "brewery" && b.Address.All(p => p == "563 Second Street")
+                select new {name = b.Name, address = b.Address}).
+                Take(1).
+                ToList();
 
-                    Assert.IsNotEmpty(breweries);
-                    Assert.True(breweries.SelectMany(p => p.address).All(p => p == "563 Second Street"));
-                }
-            }
+            Assert.IsNotEmpty(breweries);
+            Assert.True(breweries.SelectMany(p => p.address).All(p => p == "563 Second Street"));
         }
 
         [Test]
         public void AnyAllTests_AllNestedArrayPrefiltered()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    // Note: This query isn't very useful in the real world
-                    // However, it does demonstrate how to prefilter the collection before all is run
-                    // Which is behaviorly different then adding the Where predicate inside the All predicate
-                    // In this example, all breweries which have NO address 563 Second Street will be returned
+            // Note: This query isn't very useful in the real world
+            // However, it does demonstrate how to prefilter the collection before all is run
+            // Which is behaviorly different then adding the Where predicate inside the All predicate
+            // In this example, all breweries which have NO address 563 Second Street will be returned
 
-                    var breweries = (from b in context.Query<Brewery>()
-                        where
-                            b.Type == "brewery" &&
-                            b.Address.Where(p => p == "563 Second Street").All(p => p == "101 Fake Street")
-                        orderby b.Name
-                        select new {name = b.Name, address = b.Address}).
-                        ToList();
+            var breweries = (from b in context.Query<Brewery>()
+                where
+                    b.Type == "brewery" &&
+                    b.Address.Where(p => p == "563 Second Street").All(p => p == "101 Fake Street")
+                orderby b.Name
+                select new {name = b.Name, address = b.Address}).
+                Take(1).
+                ToList();
 
-                    Assert.IsNotEmpty(breweries);
-                    Assert.False(breweries.SelectMany(p => p.address).Any(p => p == "563 Second Street"));
-                }
-            }
+            Assert.IsNotEmpty(breweries);
+            Assert.False(breweries.SelectMany(p => p.address).Any(p => p == "563 Second Street"));
         }
 
         [Test]
         public void AnyAllTests_AllOnMainDocument_ReturnsFalse()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var isAllBreweries = context.Query<Brewery>().All(p => p.Type == "brewery");
+            var isAllBreweries = context.Query<Brewery>().All(p => p.Type == "brewery");
 
-                    Assert.False(isAllBreweries);
-                }
-            }
+            Assert.False(isAllBreweries);
         }
 
         [Test]
         public void AnyAllTests_AllOnMainDocument_ReturnsTrue()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var allBreweriesHaveAddress = (from b in context.Query<Brewery>()
-                        where b.Type == "brewery"
-                        select new {b.Name})
-                        .All(p => p.Name != "");
+            var allBreweriesHaveAddress = (from b in context.Query<Brewery>()
+                where b.Type == "brewery"
+                select new {b.Name})
+                .All(p => p.Name != "");
 
-                    Assert.True(allBreweriesHaveAddress);
-                }
-            }
+            Assert.True(allBreweriesHaveAddress);
         }
 
         [Test]
         public void Map2PocoTests_Simple_Projections_TypeFilterAttribute()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var beers = (from b in context.Query<BeerFiltered>()
-                        select new {type = b.Type}).
-                        AsEnumerable();
+            var beers = (from b in context.Query<BeerFiltered>()
+                select new {type = b.Type}).
+                AsEnumerable();
 
-                    Assert.True(beers.All(p => p.type == "beer"));
-                }
-            }
+            Assert.True(beers.All(p => p.type == "beer"));
         }
 
         [Test]
@@ -512,776 +435,664 @@ namespace Couchbase.Linq.IntegrationTests
         {
             DocumentFilterManager.SetFilter(new BreweryFilter());
 
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var breweries = (from b in context.Query<Brewery>()
-                        select new {type = b.Type})
-                        .AsEnumerable();
+            var breweries = (from b in context.Query<Brewery>()
+                select new {type = b.Type})
+                .AsEnumerable();
 
-                    Assert.True(breweries.All(p => p.type == "brewery"));
-                }
-            }
+            Assert.True(breweries.All(p => p.type == "brewery"));
         }
 
         public void Map2PocoTests_Simple_Projections_MetaWhere()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = (from b in context.Query<Beer>()
+                where b.Type == "beer" && N1QlFunctions.Meta(b).Type == "json"
+                select new {name = b.Name}).
+                Take(1);
+
+            var results = beers.Take(1);
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = (from b in context.Query<Beer>()
-                        where b.Type == "beer" && N1QlFunctions.Meta(b).Type == "json"
-                        select new {name = b.Name}).
-                        Take(10);
-
-                    foreach (var b in beers)
-                    {
-                        Console.WriteLine("{0} is a JSON document", b.name);
-                    }
-                }
+                Console.WriteLine("{0} is a JSON document", b.name);
             }
         }
 
         public void Map2PocoTests_Simple_Projections_MetaId()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = (from b in context.Query<Beer>()
+                where b.Type == "beer"
+                select new {name = b.Name, id = N1QlFunctions.Meta(b).Id}).
+                Take(1);
+
+            var results = beers.Take(1);
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = (from b in context.Query<Beer>()
-                        where b.Type == "beer"
-                        select new {name = b.Name, id = N1QlFunctions.Meta(b).Id}).
-                        Take(10);
-
-                    foreach (var b in beers)
-                    {
-                        Console.WriteLine("{0} has id {1}", b.name, b.id);
-                    }
-                }
+                Console.WriteLine("{0} has id {1}", b.name, b.id);
             }
         }
 
         public void AnyAllTests_AnyNestedArray()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var breweries = (from b in context.Query<Brewery>()
-                        where b.Type == "brewery" && b.Address.Any()
-                        select new {name = b.Name, address = b.Address}).
-                        ToList();
+            var breweries = (from b in context.Query<Brewery>()
+                where b.Type == "brewery" && b.Address.Any()
+                select new {name = b.Name, address = b.Address}).
+                ToList();
 
-                    Assert.IsNotEmpty(breweries);
-                    Assert.True(breweries.All(p => p.address.Any()));
-                }
-            }
+            Assert.IsNotEmpty(breweries);
+            Assert.True(breweries.All(p => p.address.Any()));
         }
 
         [Test]
         public void JoinTests_InnerJoin_Simple()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                join brewery in context.Query<Brewery>()
+                    on beer.BreweryId equals N1QlFunctions.Key(brewery)
+                select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                        join brewery in context.Query<Brewery>()
-                            on beer.BreweryId equals N1QlFunctions.Key(brewery)
-                        select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
-
-                    foreach (var b in beers.Take(10))
-                    {
-                        Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
-                    }
-                }
+                Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
             }
         }
 
         [Test]
         public void JoinTests_InnerJoin_SortAndFilter()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                join brewery in context.Query<Brewery>()
+                    on beer.BreweryId equals N1QlFunctions.Key(brewery)
+                where brewery.Geo.Longitude > -80
+                orderby beer.Name
+                select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                        join brewery in context.Query<Brewery>()
-                            on beer.BreweryId equals N1QlFunctions.Key(brewery)
-                        where brewery.Geo.Longitude > -80
-                        orderby beer.Name
-                        select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
-
-                    foreach (var b in beers.Take(10))
-                    {
-                        Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
-                    }
-                }
+                Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
             }
         }
 
         [Test]
         public void JoinTests_InnerJoin_Prefiltered()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>().Where(p => p.Type == "beer")
+                join brewery in context.Query<Brewery>().Where(p => p.Type == "brewery")
+                    on beer.BreweryId equals N1QlFunctions.Key(brewery)
+                where brewery.Geo.Longitude > -80
+                orderby beer.Name
+                select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>().Where(p => p.Type == "beer")
-                        join brewery in context.Query<Brewery>().Where(p => p.Type == "brewery")
-                            on beer.BreweryId equals N1QlFunctions.Key(brewery)
-                        where brewery.Geo.Longitude > -80
-                        orderby beer.Name
-                        select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
-
-                    foreach (var b in beers.Take(10))
-                    {
-                        Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
-                    }
-                }
+                Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
             }
         }
 
         [Test]
         public void JoinTests_LeftJoin_Simple()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                join breweryGroup in context.Query<Brewery>()
+                    on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
+                from brewery in bg.DefaultIfEmpty()
+                select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                        join breweryGroup in context.Query<Brewery>()
-                            on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
-                        from brewery in bg.DefaultIfEmpty()
-                        select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
-
-                    foreach (var b in beers.Take(10))
-                    {
-                        Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
-                    }
-                }
+                Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
             }
         }
 
         [Test]
         public void JoinTests_LeftJoin_SortAndFilter()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                join breweryGroup in context.Query<Brewery>()
+                    on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
+                from brewery in bg.DefaultIfEmpty()
+                where beer.Abv > 4
+                orderby brewery.Name, beer.Name
+                select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                        join breweryGroup in context.Query<Brewery>()
-                            on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
-                        from brewery in bg.DefaultIfEmpty()
-                        where beer.Abv > 4
-                        orderby brewery.Name, beer.Name
-                        select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
-
-                    foreach (var b in beers.Take(10))
-                    {
-                        Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
-                    }
-                }
+                Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
             }
         }
 
         [Test]
         public void JoinTests_LeftJoin_Prefiltered()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>().Where(p => p.Type == "beer")
+                join breweryGroup in context.Query<Brewery>().Where(p => p.Type == "brewery")
+                    on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
+                from brewery in bg.DefaultIfEmpty()
+                where beer.Abv > 4
+                orderby brewery.Name, beer.Name
+                select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>().Where(p => p.Type == "beer")
-                        join breweryGroup in context.Query<Brewery>().Where(p => p.Type == "brewery")
-                            on beer.BreweryId equals N1QlFunctions.Key(breweryGroup) into bg
-                        from brewery in bg.DefaultIfEmpty()
-                        where beer.Abv > 4
-                        orderby brewery.Name, beer.Name
-                        select new {beer.Name, beer.Abv, BreweryName = brewery.Name};
-
-                    foreach (var b in beers.Take(10))
-                    {
-                        Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
-                    }
-                }
+                Console.WriteLine("Beer {0} with ABV {1} is from {2}", b.Name, b.Abv, b.BreweryName);
             }
         }
 
         [Test]
         public void NestTests_Unnest_Simple()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries = from brewery in context.Query<Brewery>()
+                from address in brewery.Address
+                select new {name = brewery.Name, address};
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var breweries = from brewery in context.Query<Brewery>()
-                        from address in brewery.Address
-                        select new {name = brewery.Name, address};
-
-                    foreach (var b in breweries.Take(10))
-                    {
-                        Console.WriteLine("Brewery {0} has address line {1}", b.name, b.address);
-                    }
-                }
+                Console.WriteLine("Brewery {0} has address line {1}", b.name, b.address);
             }
         }
 
         [Test]
         public void NestTests_Unnest_Sort()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries = from brewery in context.Query<Brewery>()
+                from address in brewery.Address
+                orderby address
+                select new {name = brewery.Name, address};
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var breweries = from brewery in context.Query<Brewery>()
-                        from address in brewery.Address
-                        orderby address
-                        select new {name = brewery.Name, address};
-
-                    foreach (var b in breweries.Take(10))
-                    {
-                        Console.WriteLine("Brewery {0} has address line {1}", b.name, b.address);
-                    }
-                }
+                Console.WriteLine("Brewery {0} has address line {1}", b.name, b.address);
             }
         }
 
-        [Test()]
+        [Test]
         public void SubqueryTests_ArraySubqueryWithFilter()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries = from brewery in context.Query<Brewery>()
+                where brewery.Type == "brewery"
+                orderby brewery.Name
+                select new {name = brewery.Name, addresses = brewery.Address.Where(p => p.Length > 3)};
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var breweries = from brewery in context.Query<Brewery>()
-                        where brewery.Type == "brewery"
-                        orderby brewery.Name
-                        select new {name = brewery.Name, addresses = brewery.Address.Where(p => p.Length > 3)};
-
-                    foreach (var b in breweries.Take(10))
-                    {
-                        Console.WriteLine("Brewery {0} has address {1}", b.name, string.Join(", ", b.addresses));
-                    }
-                }
+                Console.WriteLine("Brewery {0} has address {1}", b.name, string.Join(", ", b.addresses));
             }
         }
 
-        [Test()]
+        [Test]
         public void SubqueryTests_ArraySubqueryContains()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries = from brewery in context.Query<Brewery>()
+                where brewery.Type == "brewery" && brewery.Address.Contains("563 Second Street")
+                orderby brewery.Name
+                select new {name = brewery.Name, addresses = brewery.Address};
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var breweries = from brewery in context.Query<Brewery>()
-                                    where brewery.Type == "brewery" && brewery.Address.Contains("563 Second Street")
-                                    orderby brewery.Name
-                                    select new { name = brewery.Name, addresses = brewery.Address };
-
-                    foreach (var b in breweries.Take(10))
-                    {
-                        Console.WriteLine("Brewery {0} has address {1}", b.name, string.Join(", ", b.addresses));
-                    }
-                }
+                Console.WriteLine("Brewery {0} has address {1}", b.name, string.Join(", ", b.addresses));
             }
         }
 
-        [Test()]
+        [Test]
         public void SubqueryTests_ArraySubquerySelectNewObject()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries = from brewery in context.Query<Brewery>()
+                where brewery.Type == "brewery"
+                orderby brewery.Name
+                select new {name = brewery.Name, addresses = brewery.Address.Select(p => new {address = p})};
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var breweries = from brewery in context.Query<Brewery>()
-                        where brewery.Type == "brewery"
-                        orderby brewery.Name
-                        select new {name = brewery.Name, addresses = brewery.Address.Select(p => new {address = p})};
-
-                    foreach (var b in breweries.Take(10))
-                    {
-                        Console.WriteLine("Brewery {0} has address {1}", b.name,
-                            string.Join(", ", b.addresses.Select(p => p.address)));
-                    }
-                }
+                Console.WriteLine("Brewery {0} has address {1}", b.name,
+                    string.Join(", ", b.addresses.Select(p => p.address)));
             }
         }
 
-        [Test()]
+        [Test]
         public void SubqueryTests_ArraySubquerySorted()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries = from brewery in context.Query<Brewery>()
+                where brewery.Type == "brewery"
+                orderby brewery.Name
+                select
+                    new {name = brewery.Name, addresses = brewery.Address.OrderByDescending(p => p).ToArray()};
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var breweries = from brewery in context.Query<Brewery>()
-                        where brewery.Type == "brewery"
-                        orderby brewery.Name
-                        select
-                            new {name = brewery.Name, addresses = brewery.Address.OrderByDescending(p => p).ToArray()};
-
-                    foreach (var b in breweries.Take(10))
-                    {
-                        Console.WriteLine("Brewery {0} has address {1}", b.name, string.Join(", ", b.addresses));
-                    }
-                }
+                Console.WriteLine("Brewery {0} has address {1}", b.name, string.Join(", ", b.addresses));
             }
         }
 
-        [Test()]
+        [Test]
         public void AggregateTests_SimpleAverage()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var avg = context.Query<Beer>().Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv)).Average(p => p.Abv);
-
-                    Console.WriteLine("Average ABV of all beers is {0}", avg);
-                }
-            }
+            var avg =
+                context.Query<Beer>().Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv)).Average(p => p.Abv);
+            Assert.Greater(avg, 0);
+            Console.WriteLine("Average ABV of all beers is {0}", avg);
         }
 
-        [Test()]
+        [Test]
         public void AggregateTests_SimpleCount()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var count = context.Query<Beer>().Count(p => p.Type == "beer");
-
-                    Console.WriteLine("Number of beers is {0}", count);
-                }
-            }
+            var count = context.Query<Beer>().Count(p => p.Type == "beer");
+            Assert.Greater(count, 0);
+            Console.WriteLine("Number of beers is {0}", count);
         }
 
-        [Test()]
+        [Test]
         public void AggregateTests_GroupBy()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries =
+                from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                group beer by beer.BreweryId
+                into g
+                orderby g.Key
+                select new {breweryid = g.Key, count = g.Count(), avgAbv = g.Average(p => p.Abv)};
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+
+            foreach (var brewery in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var breweries =
-                        from beer in context.Query<Beer>()
-                        where beer.Type == "beer"
-                        group beer by beer.BreweryId
-                        into g
-                        orderby g.Key
-                        select new { breweryid = g.Key, count = g.Count(), avgAbv = g.Average(p => p.Abv)};
-
-                    foreach (var brewery in breweries)
-                    {
-                        Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryid, brewery.count, brewery.avgAbv);
-                    }
-                }
+                Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryid, brewery.count,
+                    brewery.avgAbv);
             }
         }
 
-        [Test()]
+        [Test]
         public void AggregateTests_Having()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries =
+                from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                group beer by beer.BreweryId
+                into g
+                where g.Count() >= 5
+                orderby g.Key
+                select new {breweryid = g.Key, count = g.Count(), avgAbv = g.Average(p => p.Abv)};
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+
+            foreach (var brewery in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var breweries =
-                        from beer in context.Query<Beer>()
-                        where beer.Type == "beer"
-                        group beer by beer.BreweryId
-                        into g
-                        where g.Count() >= 5
-                        orderby g.Key
-                        select new { breweryid = g.Key, count = g.Count(), avgAbv = g.Average(p => p.Abv) };
-
-                    foreach (var brewery in breweries)
-                    {
-                        Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryid, brewery.count, brewery.avgAbv);
-                    }
-                }
+                Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryid, brewery.count,
+                    brewery.avgAbv);
             }
         }
 
-        [Test()]
+        [Test]
         public void AggregateTests_OrderByAggregate()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries =
+                from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                group beer by beer.BreweryId
+                into g
+                orderby g.Count() descending
+                select new {breweryid = g.Key, count = g.Count(), avgAbv = g.Average(p => p.Abv)};
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+
+            foreach (var brewery in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var breweries =
-                        from beer in context.Query<Beer>()
-                        where beer.Type == "beer"
-                        group beer by beer.BreweryId
-                        into g
-                        orderby g.Count() descending
-                        select new { breweryid = g.Key, count = g.Count(), avgAbv = g.Average(p => p.Abv) };
-
-                    foreach (var brewery in breweries)
-                    {
-                        Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryid, brewery.count, brewery.avgAbv);
-                    }
-                }
+                Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryid, brewery.count,
+                    brewery.avgAbv);
             }
         }
 
-        [Test()]
+        [Test]
         public void AggregateTests_JoinBeforeGroupByAndMultipartKey()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries =
+                from beer in context.Query<Beer>()
+                join brewery in context.Query<Brewery>() on beer.BreweryId equals N1QlFunctions.Key(brewery)
+                where beer.Type == "beer"
+                group beer by new {breweryid = beer.BreweryId, breweryName = brewery.Name}
+                into g
+                select new {g.Key.breweryName, count = g.Count(), avgAbv = g.Average(p => p.Abv)};
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+
+            foreach (var brewery in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var breweries =
-                        from beer in context.Query<Beer>()
-                        join brewery in context.Query<Brewery>() on beer.BreweryId equals N1QlFunctions.Key(brewery)
-                        where beer.Type == "beer"
-                        group beer by new { breweryid = beer.BreweryId, breweryName = brewery.Name }
-                        into g
-                        select new { g.Key.breweryName, count = g.Count(), avgAbv = g.Average(p => p.Abv) };
-
-                    foreach (var brewery in breweries)
-                    {
-                        Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryName, brewery.count, brewery.avgAbv);
-                    }
-                }
+                Console.WriteLine("Brewery {0} has {1} beers with {2:f2} average ABV", brewery.breweryName,
+                    brewery.count, brewery.avgAbv);
             }
         }
 
-        [Test()]
+        [Test]
         public void First_Empty()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "abcdefg"
+                select new {beer.Name};
+
+            Assert.Throws<InvalidOperationException>(() =>
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                        where beer.Type == "abcdefg"
-                        select new { beer.Name };
-
-                    Assert.Throws<InvalidOperationException>(() =>
-                    {
-                        // ReSharper disable once UnusedVariable
-                        var temp = beers.First();
-                    });
-                }
-            }
+                // ReSharper disable once UnusedVariable
+                var temp = beers.First();
+            });
         }
 
-        [Test()]
+        [Test]
         public void First_HasResult()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var beers = from beer in context.Query<Beer>()
-                                where beer.Type == "beer"
-                                select new { beer.Name };
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
 
-                    Console.WriteLine(beers.First().Name);
-                }
-            }
+            Console.WriteLine(beers.First().Name);
         }
 
-        [Test()]
+        [Test]
         public void FirstOrDefault_Empty()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var beers = from beer in context.Query<Beer>()
-                                where beer.Type == "abcdefg"
-                                select new { beer.Name };
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "abcdefg"
+                select new {beer.Name};
 
-                    var aBeer = beers.FirstOrDefault();
-                    Assert.IsNull(aBeer);
-                }
-            }
+            var aBeer = beers.FirstOrDefault();
+            Assert.IsNull(aBeer);
         }
 
-        [Test()]
+        [Test]
         public void FirstOrDefault_HasResult()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var beers = from beer in context.Query<Beer>()
-                                where beer.Type == "beer"
-                                select new { beer.Name };
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
 
-                    var aBeer = beers.FirstOrDefault();
-                    Assert.IsNotNull(aBeer);
-                    Console.WriteLine(aBeer.Name);
-                }
-            }
+            var aBeer = beers.FirstOrDefault();
+            Assert.IsNotNull(aBeer);
+            Console.WriteLine(aBeer.Name);
         }
 
-        [Test()]
+        [Test]
         public void Single_Empty()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "abcdefg"
+                select new {beer.Name};
+
+            Assert.Throws<InvalidOperationException>(() =>
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                                where beer.Type == "abcdefg"
-                                select new { beer.Name };
-
-                    Assert.Throws<InvalidOperationException>(() =>
-                    {
-                        // ReSharper disable once UnusedVariable
-                        var temp = beers.Single();
-                    });
-                }
-            }
+                // ReSharper disable once UnusedVariable
+                var temp = beers.Single();
+            });
         }
 
-        [Test()]
+        [Test]
         public void Single_HasResult()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var beers = from beer in context.Query<Beer>()
-                                where beer.Name == "21A IPA"
-                                select new { beer.Name };
+            var beers = from beer in context.Query<Beer>()
+                where beer.Name == "21A IPA"
+                select new {beer.Name};
 
-                    Console.WriteLine(beers.Single().Name);
-                }
-            }
+            Console.WriteLine(beers.Single().Name);
         }
 
-        [Test()]
+        [Test]
         public void Single_HasManyResults()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            Assert.Throws<InvalidOperationException>(() =>
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                                where beer.Type == "beer"
-                                select new { beer.Name };
-
-                    Assert.Throws<InvalidOperationException>(() =>
-                    {
-                        // ReSharper disable once UnusedVariable
-                        var temp = beers.Single();
-                    });
-                }
-            }
+                // ReSharper disable once UnusedVariable
+                var temp = beers.Single();
+            });
         }
 
-        [Test()]
+        [Test]
         public void SingleOrDefault_Empty()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var beers = from beer in context.Query<Beer>()
-                                where beer.Type == "abcdefg"
-                                select new { beer.Name };
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "abcdefg"
+                select new {beer.Name};
 
-                    var aBeer = beers.SingleOrDefault();
-                    Assert.IsNull(aBeer);
-                }
-            }
+            var aBeer = beers.SingleOrDefault();
+            Assert.IsNull(aBeer);
         }
 
-        [Test()]
+        [Test]
         public void SingleOrDefault_HasResult()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
-            {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
 
-                    var beers = from beer in context.Query<Beer>()
-                                where beer.Name == "21A IPA"
-                                select new { beer.Name };
+            var beers = from beer in context.Query<Beer>()
+                where beer.Name == "21A IPA"
+                select new {beer.Name};
 
-                    var aBeer = beers.SingleOrDefault();
-                    Assert.IsNotNull(aBeer);
-                    Console.WriteLine(aBeer.Name);
-                }
-            }
+            var aBeer = beers.SingleOrDefault();
+            Assert.IsNotNull(aBeer);
+            Console.WriteLine(aBeer.Name);
         }
 
-        [Test()]
+        [Test]
         public void SingleOrDefault_HasManyResults()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            Assert.Throws<InvalidOperationException>(() =>
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                                where beer.Type == "beer"
-                                select new { beer.Name };
-
-                    Assert.Throws<InvalidOperationException>(() =>
-                    {
-                        // ReSharper disable once UnusedVariable
-                        var temp = beers.SingleOrDefault();
-                    });
-                }
-            }
+                // ReSharper disable once UnusedVariable
+                var temp = beers.SingleOrDefault();
+            });
         }
 
         #region "Date/time functions"
 
-        [Test()]
+        [Test]
         public void DateTime_DateAdd()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name, Updated = N1QlFunctions.DateAdd(beer.Updated, -10, N1QlDatePart.Day)};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                                where (beer.Type == "beer")
-                                select new { beer.Name, Updated = N1QlFunctions.DateAdd(beer.Updated, -10, N1QlDatePart.Day) };
-
-                    foreach (var b in beers.Take(10))
-                    {
-                        Console.WriteLine("Beer {0} was updated 10 days after {1:g}", b.Name, b.Updated);
-                    }
-                }
+                Console.WriteLine("Beer {0} was updated 10 days after {1:g}", b.Name, b.Updated);
             }
         }
 
-        [Test()]
+        [Test]
         public void DateTime_DateDiff()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name, DaysOld = N1QlFunctions.DateDiff(DateTime.Now, beer.Updated, N1QlDatePart.Day)};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                                where (beer.Type == "beer")
-                                select new { beer.Name, DaysOld = N1QlFunctions.DateDiff(DateTime.Now, beer.Updated, N1QlDatePart.Day) };
-
-                    foreach (var b in beers.Take(10))
-                    {
-                        Console.WriteLine("Beer {0} is {1} days old", b.Name, b.DaysOld);
-                    }
-                }
+                Console.WriteLine("Beer {0} is {1} days old", b.Name, b.DaysOld);
             }
         }
 
-        [Test()]
+        [Test]
         public void DateTime_DatePart()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name, Year = N1QlFunctions.DatePart(beer.Updated, N1QlDatePart.Year)};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                                where (beer.Type == "beer")
-                                select new { beer.Name, Year = N1QlFunctions.DatePart(beer.Updated, N1QlDatePart.Year) };
-
-                    foreach (var b in beers.Take(10))
-                    {
-                        Console.WriteLine("Beer {0} was updated in {1:0000}", b.Name, b.Year);
-                    }
-                }
+                Console.WriteLine("Beer {0} was updated in {1:0000}", b.Name, b.Year);
             }
         }
 
-        [Test()]
+        [Test]
         public void DateTime_DateTrunc()
         {
-            using (var cluster = new Cluster(TestConfigurations.DefaultConfig()))
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name, Updated = N1QlFunctions.DateTrunc(beer.Updated, N1QlDatePart.Month)};
+
+            foreach (var b in beers.Take(1))
             {
-                using (var bucket = cluster.OpenBucket("beer-sample"))
-                {
-                    var context = new BucketContext(bucket);
-
-                    var beers = from beer in context.Query<Beer>()
-                                where (beer.Type == "beer")
-                                select new { beer.Name, Updated = N1QlFunctions.DateTrunc(beer.Updated, N1QlDatePart.Month) };
-
-                    foreach (var b in beers.Take(10))
-                    {
-                        Console.WriteLine("Beer {0} is in {1:MMMM yyyy}", b.Name, b.Updated);
-                    }
-                }
+                Console.WriteLine("Beer {0} is in {1:MMMM yyyy}", b.Name, b.Updated);
             }
         }
 

--- a/Src/Couchbase.Linq.IntegrationTests/TestSetup.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/TestSetup.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.IntegrationTests
+{
+    [SetUpFixture]
+    public class TestSetup
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            ClusterHelper.Initialize(TestConfigurations.DefaultConfig());
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
While somewhat expected, the integration tests run extremely slow. This
commit addresses a number of issues effecting the slowness and speeds up
the tests significantly.

Modifications
-------------
Made all queries limit the result set to one. Added additional assertions
to ensure only one item is returned. Refactored the ClusterHelper
initialization to a global TestSetup.cs class that will run first before
any other tests. Made all QueryTests.cs tests reuse the bucket and cluster
via ClusterHelper. QueryTests no longer derives from N1QLTestBase.

Results
-------
On my machine using a vagrants VM cluster, the integration tests went from
over 5 minutes to run to around 1.5 mins.