### PR TITLE
Issue #107: Support for subquerys against constant lists

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -708,6 +708,27 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void SubqueryTests_StaticArraySubqueryContains()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweryNames = new[] { "21st Amendment Brewery Cafe", "357" };
+            var breweries = from brewery in context.Query<Brewery>()
+                            where brewery.Type == "brewery" && breweryNames.Contains(brewery.Name)
+                            orderby brewery.Name
+                            select new { name = brewery.Name, addresses = brewery.Address };
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
+            {
+                Console.WriteLine("Brewery {0} has address {1}", b.name, string.Join(", ", b.addresses));
+            }
+        }
+
+        [Test]
         public void SubqueryTests_ArraySubquerySelectNewObject()
         {
             var bucket = ClusterHelper.GetBucket("beer-sample");

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -477,7 +477,7 @@ namespace Couchbase.Linq.QueryGeneration
 
                 _expression.Append(Encoding.UTF8.GetString(serializedDateTime));
             }
-            else if (namedParameter.Value is Array)
+            else if (namedParameter.Value is System.Collections.IEnumerable)
             {
                 _expression.Append('[');
 

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -185,6 +185,18 @@ namespace Couchbase.Linq.QueryGeneration
                 // Ensure that we use the same extent name as the grouping
                 _queryGenerationContext.ExtentNameProvider.LinkExtents(_queryGenerationContext.GroupingQuerySource.ReferencedQuerySource, fromClause);
             }
+            else if (fromClause.FromExpression is ConstantExpression)
+            {
+                // From clause for this subquery is a constant array
+
+                _queryPartsAggregator.QueryType = N1QlQueryType.Array;
+
+                _queryPartsAggregator.AddFromPart(new N1QlFromQueryPart()
+                {
+                    Source = GetN1QlExpression(fromClause.FromExpression),
+                    ItemName = GetExtentName(fromClause)
+                });
+            }
 
             base.VisitMainFromClause(fromClause, queryModel);
         }
@@ -418,7 +430,7 @@ namespace Couchbase.Linq.QueryGeneration
             {
                 if (_queryPartsAggregator.QueryType != N1QlQueryType.Array)
                 {
-                    throw new NotSupportedException("Contains is only supported in N1QL against nested arrays.");
+                    throw new NotSupportedException("Contains is only supported in N1QL against nested or constant arrays.");
                 }
 
                 var containsResultOperator = (ContainsResultOperator) resultOperator;


### PR DESCRIPTION
Motivation
----------
A desirable use case is to use the .Contains function against a static
list to test if a document attribute matches at least one item in the
list.  This can be implemented with the N1QL IN keyword.

Modifications
-------------
Relinq treats this is a subquery, with a constant value implementing
IEnumerable as the expression on the from clause.  Detect this case, and
render a static array to N1QL when it is encountered.  We can treat this
like any other array-type subquery, which includes support for the
.Contains method.

Results
-------
array.Contains(x) can now be used within a query, where array is constant
in relation to the query.  Note that array can be dynamically built before
the query, it is simply constant within the query's execution plan and
does not vary based on data returned within the query.

Also, due to the implementation approach, it also supports more advanced
subqueries against constant arrays.  For example, it is possible to filter
or perform select projections against the constant array before the
.Contains statement.  In the future, it might be worthwhile to optimize
these cases by performing filtering and projections before writing the
array to the N1QL query.  However, it is functional now.