### PR TITLE
LINQ-17: Support for UNION statements

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -771,6 +771,52 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void SubqueryTests_Union()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var names = (from brewery in context.Query<Brewery>()
+                where brewery.Type == "brewery"
+                select new { AnyName = brewery.Name })
+                .Union(from beer in context.Query<Beer>()
+                    where beer.Type == "beer"
+                    select new { AnyName = beer.Name })
+                .OrderBy(p => p.AnyName);
+
+            var results = names.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
+            {
+                Console.WriteLine(b.AnyName);
+            }
+        }
+
+        [Test]
+        public void SubqueryTests_UnionAll()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var names = (from brewery in context.Query<Brewery>()
+                         where brewery.Type == "brewery"
+                         select new { AnyName = brewery.Name })
+                .Concat(from beer in context.Query<Beer>()
+                        where beer.Type == "beer"
+                        select new { AnyName = beer.Name })
+                .OrderBy(p => p.AnyName);
+
+            var results = names.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
+            {
+                Console.WriteLine(b.AnyName);
+            }
+        }
+
+        [Test]
         public void AggregateTests_SimpleAverage()
         {
             var bucket = ClusterHelper.GetBucket("beer-sample");

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Proxies\DocumentProxyTypeCreatorTests.cs" />
     <Compile Include="Proxies\DocumentProxyDataMapperTests.cs" />
     <Compile Include="Proxies\DocumentProxyTests.cs" />
+    <Compile Include="QueryGeneration\UnionTests.cs" />
     <Compile Include="QueryGeneration\ArrayOperatorTests.cs" />
     <Compile Include="QueryGeneration\EnumTests.cs" />
     <Compile Include="QueryGeneration\ArrayIndexTests.cs" />

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/UnionTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/UnionTests.cs
@@ -1,0 +1,259 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Couchbase.Core;
+using Couchbase.Linq.UnitTests.Documents;
+using Moq;
+using Newtonsoft.Json.Serialization;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.QueryGeneration
+{
+    [TestFixture]
+    public class UnionTests : N1QLTestBase
+    {
+        [Test]
+        public void Test_Union()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .Where(e => e.Type == "beer")
+                    .Select(e => new { e.Name })
+                    .Union(
+                        QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                            .Where(e => e.Type == "brewery")
+                            .Select(e => new { e.Name }));
+
+            const string expected =
+                "SELECT `Extent1`.`name` as `Name` FROM `default` as `Extent1` WHERE (`Extent1`.`type` = 'beer')" +
+                " UNION " +
+                "SELECT `Extent2`.`name` as `Name` FROM `default` as `Extent2` WHERE (`Extent2`.`type` = 'brewery')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_SortedUnion()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .Where(e => e.Type == "beer")
+                    .Select(e => new { e.Name })
+                    .Union(
+                        QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                            .Where(e => e.Type == "brewery")
+                            .Select(e => new { e.Name }))
+                    .OrderBy(e => e.Name);
+
+            const string expected =
+                "SELECT `Extent1`.`name` as `Name` FROM `default` as `Extent1` WHERE (`Extent1`.`type` = 'beer')" +
+                " UNION " +
+                "SELECT `Extent2`.`name` as `Name` FROM `default` as `Extent2` WHERE (`Extent2`.`type` = 'brewery')" +
+                " ORDER BY `Name` ASC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_MultiUnionType1()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .Where(e => e.Type == "beer")
+                    .Select(e => new {e.Name})
+                    .Union(
+                        QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                            .Where(e => e.Type == "brewery")
+                            .Select(e => new {e.Name})
+                            .Union(
+                                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                                    .Where(e => e.Type == "contact")
+                                    .Select(e => new { Name = e.FirstName})));
+
+            const string expected =
+                "SELECT `Extent1`.`name` as `Name` FROM `default` as `Extent1` WHERE (`Extent1`.`type` = 'beer')" +
+                " UNION " +
+                "SELECT `Extent2`.`name` as `Name` FROM `default` as `Extent2` WHERE (`Extent2`.`type` = 'brewery')" +
+                " UNION " +
+                "SELECT `Extent3`.`fname` as `Name` FROM `default` as `Extent3` WHERE (`Extent3`.`type` = 'contact')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_MultiUnionType2()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .Where(e => e.Type == "beer")
+                    .Select(e => new { e.Name })
+                    .Union(
+                        QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                            .Where(e => e.Type == "brewery")
+                            .Select(e => new { e.Name }))
+                    .Union(
+                        QueryFactory.Queryable<Contact>(mockBucket.Object)
+                            .Where(e => e.Type == "contact")
+                            .Select(e => new { Name = e.FirstName }));
+
+            const string expected =
+                "SELECT `Extent1`.`name` as `Name` FROM `default` as `Extent1` WHERE (`Extent1`.`type` = 'beer')" +
+                " UNION " +
+                "SELECT `Extent2`.`name` as `Name` FROM `default` as `Extent2` WHERE (`Extent2`.`type` = 'brewery')" +
+                " UNION " +
+                "SELECT `Extent3`.`fname` as `Name` FROM `default` as `Extent3` WHERE (`Extent3`.`type` = 'contact')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Concat()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .Where(e => e.Type == "beer")
+                    .Select(e => new { e.Name })
+                    .Concat(
+                        QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                            .Where(e => e.Type == "brewery")
+                            .Select(e => new { e.Name }));
+
+            const string expected =
+                "SELECT `Extent1`.`name` as `Name` FROM `default` as `Extent1` WHERE (`Extent1`.`type` = 'beer')" +
+                " UNION ALL " +
+                "SELECT `Extent2`.`name` as `Name` FROM `default` as `Extent2` WHERE (`Extent2`.`type` = 'brewery')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_SortedConcat()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .Where(e => e.Type == "beer")
+                    .Select(e => new { e.Name })
+                    .Concat(
+                        QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                            .Where(e => e.Type == "brewery")
+                            .Select(e => new { e.Name }))
+                    .OrderBy(e => e.Name);
+
+            const string expected =
+                "SELECT `Extent1`.`name` as `Name` FROM `default` as `Extent1` WHERE (`Extent1`.`type` = 'beer')" +
+                " UNION ALL " +
+                "SELECT `Extent2`.`name` as `Name` FROM `default` as `Extent2` WHERE (`Extent2`.`type` = 'brewery')" +
+                " ORDER BY `Name` ASC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_MultiConcatType1()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .Where(e => e.Type == "beer")
+                    .Select(e => new { e.Name })
+                    .Concat(
+                        QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                            .Where(e => e.Type == "brewery")
+                            .Select(e => new { e.Name })
+                            .Concat(
+                                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                                    .Where(e => e.Type == "contact")
+                                    .Select(e => new { Name = e.FirstName })));
+
+            const string expected =
+                "SELECT `Extent1`.`name` as `Name` FROM `default` as `Extent1` WHERE (`Extent1`.`type` = 'beer')" +
+                " UNION ALL " +
+                "SELECT `Extent2`.`name` as `Name` FROM `default` as `Extent2` WHERE (`Extent2`.`type` = 'brewery')" +
+                " UNION ALL " +
+                "SELECT `Extent3`.`fname` as `Name` FROM `default` as `Extent3` WHERE (`Extent3`.`type` = 'contact')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_MultiConcatType2()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .Where(e => e.Type == "beer")
+                    .Select(e => new { e.Name })
+                    .Concat(
+                        QueryFactory.Queryable<Brewery>(mockBucket.Object)
+                            .Where(e => e.Type == "brewery")
+                            .Select(e => new { e.Name }))
+                    .Concat(
+                        QueryFactory.Queryable<Contact>(mockBucket.Object)
+                            .Where(e => e.Type == "contact")
+                            .Select(e => new { Name = e.FirstName }));
+
+            const string expected =
+                "SELECT `Extent1`.`name` as `Name` FROM `default` as `Extent1` WHERE (`Extent1`.`type` = 'beer')" +
+                " UNION ALL " +
+                "SELECT `Extent2`.`name` as `Name` FROM `default` as `Extent2` WHERE (`Extent2`.`type` = 'brewery')" +
+                " UNION ALL " +
+                "SELECT `Extent3`.`fname` as `Name` FROM `default` as `Extent3` WHERE (`Extent3`.`type` = 'contact')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -563,8 +563,20 @@ namespace Couchbase.Linq.QueryGeneration
 
             if (_queryGenerationContext.MemberNameResolver.TryResolveMemberName(expression.Member, out memberName))
             {
-                Visit(expression.Expression);
-                _expression.AppendFormat(".{0}", N1QlHelpers.EscapeIdentifier(memberName));
+                var querySourceExpression = expression.Expression as QuerySourceReferenceExpression;
+                if ((querySourceExpression != null) &&
+                    (_queryGenerationContext.ExtentNameProvider.GetExtentName(
+                        querySourceExpression.ReferencedQuerySource) == ""))
+                {
+                    // This query source has a blank extent name, so we don't need to reference the extent to access the member
+
+                    _expression.Append(N1QlHelpers.EscapeIdentifier(memberName));
+                }
+                else
+                {
+                    Visit(expression.Expression);
+                    _expression.AppendFormat(".{0}", N1QlHelpers.EscapeIdentifier(memberName));
+                }
             }
 
             return expression;

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlExtentNameProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlExtentNameProvider.cs
@@ -100,6 +100,11 @@ namespace Couchbase.Linq.QueryGeneration
             return GetNextExtentName();
         }
 
+        public void SetBlankExtentName(IQuerySource querySource)
+        {
+            _extentDictionary[querySource] = "";
+        }
+
         /// <summary>
         /// Change the extent name of a query source to a newly generated name, replacing any previously generated name.
         /// </summary>

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
@@ -31,6 +31,24 @@ namespace Couchbase.Linq.QueryGeneration
         {
             ExtentNameProvider = new N1QlExtentNameProvider();
             ParameterAggregator = new ParameterAggregator();
-        } 
+        }
+
+        /// <summary>
+        /// Clones this N1QlQueryGenerationContext for use within a union secondary query
+        /// </summary>
+        public N1QlQueryGenerationContext CloneForUnion()
+        {
+            // In the future we may want some properties get new values when working in a union
+            // This method provides a simple point for this extension
+
+            return new N1QlQueryGenerationContext()
+            {
+                ExtentNameProvider = ExtentNameProvider,
+                MemberNameResolver = MemberNameResolver,
+                MethodCallTranslatorProvider = MethodCallTranslatorProvider,
+                ParameterAggregator = ParameterAggregator,
+                Serializer = Serializer
+            };
+        }
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -45,6 +45,10 @@ namespace Couchbase.Linq.QueryGeneration
         /// For aggregates, wraps the SelectPart with this function call
         /// </summary>
         public string AggregateFunction { get; set; }
+        /// <summary>
+        /// UNION statements appended to the end of this query
+        /// </summary>
+        public List<string> UnionParts { get; set; }
 
         /// <summary>
         /// Indicates the type of query or subquery being generated
@@ -166,6 +170,16 @@ namespace Couchbase.Linq.QueryGeneration
             WrappingFunctions.Add(function);
         }
 
+        public void AddUnionPart(string unionPart)
+        {
+            if (UnionParts == null)
+            {
+                UnionParts = new List<string>();
+            }
+
+            UnionParts.Add(unionPart);
+        }
+
         /// <summary>
         /// Builds a primary select query
         /// </summary>
@@ -262,6 +276,12 @@ namespace Couchbase.Linq.QueryGeneration
             {
                 sb.AppendFormat(" HAVING {0}", string.Join(" AND ", HavingParts));
             }
+
+            if (UnionParts != null)
+            {
+                sb.Append(string.Join("", UnionParts));
+            }
+
             if (OrderByParts.Any())
             {
                 sb.AppendFormat(" ORDER BY {0}", String.Join(", ", OrderByParts));


### PR DESCRIPTION
Motivation
----------
Currently, UNION statements between must be executed in memory, after
using the .AsEnumerator or .ToList methods.  This is much less efficient
than operating on the server in N1QL, especially since the two queries
must be run sequentially instead of concurrently.

Modifications
-------------
Added support for UnionResultOperator (UNION) and ConcatResultOperator
(UNION ALL).  Subqueries are parsed and added to the QueryPartsAggregator
in a new UnionParts collection.

Also implemented support for sorting after the UNION statement is
complete.  This required adjustments to the handling of sub queries in the
main from clause.  To reduce confusion, renamed the private GroupingStatus
enumeration to VisitStatus.

To support sorting on the union statement, adjustments were also made to
N1QlExtentNameProvider and N1QlExpressionTreeVisitor.VisitMember.  They
required support for the idea of accessing members of objects without
prefixing them with `Extent1`.

Results
-------
UNION and UNION ALL statements are now possible from LINQ.  Also supports
applying sorts after the UNION statement is complete.