### PR TITLE
Internalize Castle.Core and Remotion.Linq assemblies

### DIFF
--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <ILRepackPath>$(SolutionDir)\packages\ILRepack.2.0.10\tools\ILRepack.exe</ILRepackPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,6 +31,15 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'RepackedRelease|AnyCPU'">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\RepackedRelease\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ILRepack>true</ILRepack>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
@@ -181,6 +191,35 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <PropertyGroup>
+    <BuildDependsOn>ILRepackPrebuild;$(BuildDependsOn);ILRepackPostbuild</BuildDependsOn>
+  </PropertyGroup>
+  <Target Name="ILRepackPrebuild" Condition="'$(ILRepack)' == 'true'">
+    <!-- Save the modified timestamp from the output assembly before build starts -->
+    <PropertyGroup>
+      <ILRepackCompileTimestamp>%(IntermediateAssembly.ModifiedTime)</ILRepackCompileTimestamp>
+    </PropertyGroup>
+  </Target>
+  <Target Name="ILRepackPostbuild" Condition="'$(ILRepack)' == 'true'">
+    <!-- If the output assembly was modified, then start the repack -->
+    <CallTarget Condition="'$(ILRepackCompileTimestamp)' != '%(IntermediateAssembly.ModifiedTime)'" Targets="ILRepack" />
+    <!-- Remove repacked files from the output directory -->
+    <ItemGroup>
+      <ToBeDeleted Include="$(OutputPath)Remotion.Linq.*" />
+      <ToBeDeleted Include="$(OutputPath)Castle.Core.*" />
+    </ItemGroup>
+    <Delete Files="@(ToBeDeleted)" />
+  </Target>
+  <Target Name="ILRepack" Condition="'$(ILRepack)' == 'true'">
+    <!-- This will be triggered by ILRepackPostbuild only if the output assembly was modified by the build -->
+    <!-- Ensure that ILRepack.exe exists -->
+    <PropertyGroup>
+      <ErrorText>Cannot find ILRepack executable: {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(ILRepackPath)')" Text="$([System.String]::Format('$(ErrorText)', '$(ILRepackPath)'))" />
+    <!-- Perform repack -->
+    <Exec WorkingDirectory="$(OutputPath)" Command="&quot;$(ILRepackPath)&quot; /internalize /parallel /out:Couchbase.Linq.dll Couchbase.Linq.dll Remotion.Linq.dll Castle.Core.dll" Outputs="$(OutputPath)Couchbase.Linq.dll" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Src/Couchbase.Linq/packages.config
+++ b/Src/Couchbase.Linq/packages.config
@@ -4,6 +4,7 @@
   <package id="Common.Logging" version="3.3.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.0" targetFramework="net45" />
   <package id="CouchbaseNetClient" version="2.2.2" targetFramework="net45" />
+  <package id="ILRepack" version="2.0.10" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.0.1" targetFramework="net45" />
 </packages>

--- a/Src/couchbase-net-linq.sln
+++ b/Src/couchbase-net-linq.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Couchbase.Linq", "Couchbase.Linq\Couchbase.Linq.csproj", "{C0254649-0162-47A4-B3D3-354E0B3FF7D0}"
 EndProject
@@ -22,24 +22,30 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		RepackedRelease|Any CPU = RepackedRelease|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.RepackedRelease|Any CPU.ActiveCfg = RepackedRelease|Any CPU
+		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.RepackedRelease|Any CPU.Build.0 = RepackedRelease|Any CPU
 		{8B5F339F-6E52-4E03-9FFA-12C1C025E591}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8B5F339F-6E52-4E03-9FFA-12C1C025E591}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8B5F339F-6E52-4E03-9FFA-12C1C025E591}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8B5F339F-6E52-4E03-9FFA-12C1C025E591}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B5F339F-6E52-4E03-9FFA-12C1C025E591}.RepackedRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{6F80608B-2EB5-4EF1-9D77-A2033ADC84AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6F80608B-2EB5-4EF1-9D77-A2033ADC84AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6F80608B-2EB5-4EF1-9D77-A2033ADC84AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F80608B-2EB5-4EF1-9D77-A2033ADC84AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F80608B-2EB5-4EF1-9D77-A2033ADC84AB}.RepackedRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{AEA6FE33-62F1-4F1A-B955-6CD5AAF8AC7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AEA6FE33-62F1-4F1A-B955-6CD5AAF8AC7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AEA6FE33-62F1-4F1A-B955-6CD5AAF8AC7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AEA6FE33-62F1-4F1A-B955-6CD5AAF8AC7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AEA6FE33-62F1-4F1A-B955-6CD5AAF8AC7F}.RepackedRelease|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Motivation
----------
Reduce the number of dependencies required for the Couchbase.Linq
Nuget package.  Also, improve side-by-side compatibility with other
libraries which may use different versions of these assemblies that
aren't compatible.

Modifications
-------------
Added a Nuget dependency on ILRepack, which downloads the executable
before building.  Created a new solution configuration named
"RepackedRelease", which triggers the ILRepack process after the normal
build steps are complete.  The final assembly can be found in the
Src/Couchbase.Linq/bin/RepackedRelease folder.

The RepackedRelease build mode does not build the test assemblies.  This
is because they don't function cleanly, because they already access
internal classes in Couchbase.Linq and make use of Remotion.Linq and
Castle.Core classes.  Once repacked, the references then disagree with
each other.

Results
-------
The Couchbase.Linq assembly has both Castle.Core and Remotion.Linq
assemblies embedded within it.  When embedded, the assemblies are marked
as internal so they are not a part of the exposed API.

This means that internally the full functionality of both assemblies are
available for use.  But dependencies on these libraries don't need to be
added to the Nuget package definition, and they don't need to be installed
by the consuming project.  It also means that consumers can choose to use
other packages, such as Entity Framework, which may have dependencies on
different versions of these packages that are not compatible.

Notes
-----
Unfortunately, there wasn't a good way to run the unit and integration
tests against the repacked version of the assembly.  Therefore, for
testing purposes I used another project and consumed the repacked assembly
successfully.