### PR TITLE
XML documentation and warning cleanup

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/N1QLTestBase.cs
@@ -32,8 +32,10 @@ namespace Couchbase.Linq.IntegrationTests
             }
 
             var config = TestConfigurations.DefaultConfig();
+#pragma warning disable CS0618 // Type or member is obsolete
             config.DeserializationSettings.ContractResolver = _contractResolver;
             config.SerializationSettings.ContractResolver = _contractResolver;
+#pragma warning restore CS0618 // Type or member is obsolete
             ClusterHelper.Initialize(config);
         }
 
@@ -42,8 +44,10 @@ namespace Couchbase.Linq.IntegrationTests
             _contractResolver = contractResolver;
 
             var cluster = ClusterHelper.Get();
+#pragma warning disable CS0618 // Type or member is obsolete
             cluster.Configuration.DeserializationSettings.ContractResolver = contractResolver;
             cluster.Configuration.SerializationSettings.ContractResolver = contractResolver;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/Src/Couchbase.Linq/BucketContext.cs
+++ b/Src/Couchbase.Linq/BucketContext.cs
@@ -17,14 +17,18 @@ namespace Couchbase.Linq
     public class BucketContext : IBucketContext
     {
         private readonly IBucket _bucket;
-        protected BucketConfiguration BucketConfig;
-        private Dictionary<Type, PropertyInfo>_cachedKeyProperties = new Dictionary<Type, PropertyInfo>();
+
+        private readonly Dictionary<Type, PropertyInfo>_cachedKeyProperties = new Dictionary<Type, PropertyInfo>();
 
         /// <summary>
         /// If true, generate change tracking proxies for documents during deserialization.  Defaults to false for higher performance queries.
         /// </summary>
         public virtual bool EnableChangeTracking { get; set; }
 
+        /// <summary>
+        /// Creates a new BucketContext for a given Couchbase bucket.
+        /// </summary>
+        /// <param name="bucket">Bucket referenced by the new BucketContext.</param>
         public BucketContext(IBucket bucket)
         {
             _bucket = bucket;
@@ -42,11 +46,11 @@ namespace Couchbase.Linq
         }
 
         /// <summary>
-        /// Queries the current <see cref="IBucket" /> for entities of type <see cref="T" />. This is the target of
-        /// the Linq query requires that the associated JSON document have a type property that is the same as <see cref="T" />.
+        /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
+        /// a LINQ query and requires that the associated JSON document have a type property that is the same as T.
         /// </summary>
         /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
-        /// <returns></returns>
+        /// <returns><see cref="IQueryable{T}" /> which can be used to query the bucket.</returns>
         public IQueryable<T> Query<T>()
         {
             return DocumentFilterManager.ApplyFilters(new BucketQueryable<T>(_bucket, Configuration, EnableChangeTracking));

--- a/Src/Couchbase.Linq/BucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/BucketQueryExecutor.cs
@@ -162,9 +162,12 @@ namespace Couchbase.Linq
             // Note that DefaultSerializer implements IExtendedTypeSerializer, but has the same logic as JsonNetMemberNameResolver
 
             var serializer = _configuration.Serializer.Invoke() as IExtendedTypeSerializer;
+
+#pragma warning disable CS0618 // Type or member is obsolete
             var memberNameResolver = serializer != null ?
                 (IMemberNameResolver)new ExtendedTypeSerializerMemberNameResolver(serializer) :
                 (IMemberNameResolver)new JsonNetMemberNameResolver(_configuration.SerializationSettings.ContractResolver);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var methodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider();
 

--- a/Src/Couchbase.Linq/Clauses/NestClause.cs
+++ b/Src/Couchbase.Linq/Clauses/NestClause.cs
@@ -15,6 +15,7 @@ namespace Couchbase.Linq.Clauses
         /// <param name="itemType">Type of the item returned by the nest clause</param>
         /// <param name="inner">The inner sequence being nested</param>
         /// <param name="keySelector">Expression used to get the keys from each item in the outer sequence</param>
+        /// <param name="isLeftOuterNest">If true, indicates this is a LEFT OUTER NEST.  If false, this is an INNER NEST.</param>
         public NestClause(string itemName, Type itemType, Expression inner, Expression keySelector, bool isLeftOuterNest)
         {
             ItemName = itemName;

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Couchbase.Linq.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Couchbase.Linq.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'RepackedRelease|AnyCPU'">
     <DebugType>pdbonly</DebugType>
@@ -40,6 +42,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ILRepack>true</ILRepack>
+    <DocumentationFile>bin\RepackedRelease\Couchbase.Linq.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>

--- a/Src/Couchbase.Linq/DocumentNotFoundException.cs
+++ b/Src/Couchbase.Linq/DocumentNotFoundException.cs
@@ -7,6 +7,10 @@ namespace Couchbase.Linq
     /// </summary>
     public class DocumentNotFoundException : Exception
     {
+        /// <summary>
+        /// Creates a new DocumentNotFoundException.
+        /// </summary>
+        /// <param name="message">Exception message.</param>
         public DocumentNotFoundException(string message)
             : base(message)
         {

--- a/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
@@ -9,6 +9,10 @@ using Couchbase.Linq.Metadata;
 
 namespace Couchbase.Linq.Extensions
 {
+    /// <summary>
+    /// Extensions to <see cref="IEnumerable{T}"/> which emulate query extensions in <see cref="QueryExtensions"/>.
+    /// This helps to provide support for unit tests against a fake <see cref="BucketContext"/>.
+    /// </summary>
     public static class EnumerableExtensions
     {
 

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
@@ -9,6 +9,9 @@ using Remotion.Linq.Parsing.ExpressionVisitors;
 
 namespace Couchbase.Linq.Extensions
 {
+    /// <summary>
+    /// Extentions to <see cref="IQueryable{T}" /> for use in queries against a <see cref="BucketContext"/>.
+    /// </summary>
     public static class QueryExtensions
     {
         #region Nest
@@ -166,7 +169,7 @@ namespace Couchbase.Linq.Extensions
         /// <summary>
         ///     Filters documents based on a list of keys
         /// </summary>
-        /// <typeparam name="items">Type of the items being filtered<typeparam>
+        /// <typeparam name="T">Type of the items being filtered</typeparam>
         /// <param name="items">Items being filtered</param>
         /// <param name="keys">Keys to be selected</param>
         /// <returns>Modified IQueryable</returns>

--- a/Src/Couchbase.Linq/Filters/DocumentFilterAttribute.cs
+++ b/Src/Couchbase.Linq/Filters/DocumentFilterAttribute.cs
@@ -13,7 +13,12 @@ namespace Couchbase.Linq.Filters
         /// </summary>
         public int Priority { get; set; }
 
-        public abstract IDocumentFilter<T> GetFilter<T>(); 
+        /// <summary>
+        /// Returns the <see cref="IDocumentFilter{T}"/> to be applied by this attribute.
+        /// </summary>
+        /// <typeparam name="T">Type of the document being filtered.</typeparam>
+        /// <returns>The <see cref="IDocumentFilter{T}"/> to be applied by this attribute.</returns>
+        public abstract IDocumentFilter<T> GetFilter<T>();
 
     }
 }

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -40,11 +40,11 @@ namespace Couchbase.Linq
         void FlushChanges();
 
         /// <summary>
-        /// Queries the current <see cref="IBucket"/> for entities of type <see cref="T"/>. This is the target of
-        /// the Linq query requires that the associated JSON document have a type property that is the same as <see cref="T"/>.
+        /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
+        /// a LINQ query and requires that the associated JSON document have a type property that is the same as T.
         /// </summary>
         /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
-        /// <returns></returns>
+        /// <returns><see cref="IQueryable{T}" /> which can be used to query the bucket.</returns>
         IQueryable<T> Query<T>();
 
         /// <summary>

--- a/Src/Couchbase.Linq/KeyAttributeMissingException.cs
+++ b/Src/Couchbase.Linq/KeyAttributeMissingException.cs
@@ -8,6 +8,10 @@ namespace Couchbase.Linq
     /// </summary>
     public class KeyAttributeMissingException : Exception
     {
+        /// <summary>
+        /// Creates a new KeyAttributeMissingException.
+        /// </summary>
+        /// <param name="message">Exception message.</param>
         public KeyAttributeMissingException(string message)
             : base(message)
         {

--- a/Src/Couchbase.Linq/Metadata/DocumentMetadata.cs
+++ b/Src/Couchbase.Linq/Metadata/DocumentMetadata.cs
@@ -7,23 +7,39 @@ namespace Couchbase.Linq.Metadata
     /// </summary>
     public class DocumentMetadata
     {
-
+        /// <summary>
+        /// "Compare and swap" value.  This value changes each time the document is mutated.
+        /// This can be used to ensure that the document has not been modified
+        /// during a mutation, which enforces optimistic concurrency.
+        /// </summary>
         [JsonProperty("cas")]
         public double Cas { get; set; }
 
+        /// <summary>
+        /// SDK specific flags.
+        /// </summary>
         [JsonProperty("flags")]
         public int Flags { get; set; }
 
+        /// <summary>
+        /// Document's unique ID.  Also referred to as the document key.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <summary>
+        /// Information about the type of the document.
+        /// </summary>
         [JsonProperty("type")]
         public string Type { get; set; }
 
+        /// <summary>
+        /// Returns the JSON string representation of this object.
+        /// </summary>
+        /// <returns>JSON string representation of this object.</returns>
         public override string ToString()
         {
             return JsonConvert.SerializeObject(this);
         }
-
     }
 }

--- a/Src/Couchbase.Linq/N1QlDatePart.cs
+++ b/Src/Couchbase.Linq/N1QlDatePart.cs
@@ -19,63 +19,123 @@ namespace Couchbase.Linq
     [JsonConverter(typeof(StringEnumConverter))]
     public enum N1QlDatePart
     {
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "millennium")]
         Millennium,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "century")]
         Century,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "decade")]
         Decade,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "year")]
         Year,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "quarter")]
         Quarter,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "month")]
         Month,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "week")]
         Week,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "day")]
         Day,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "hour")]
         Hour,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "minute")]
         Minute,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "second")]
         Second,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "millisecond")]
         Millisecond,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "doy")]
         DayOfYear,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "dow")]
         DayOfWeek,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "iso_week")]
         IsoWeek,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "iso_year")]
         IsoYear,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "iso_dow")]
         IsoDayOfWeek,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "timezone")]
         TimeZone,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "timezone_hour")]
         TimeZoneOffsetHour,
 
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
         [EnumMember(Value = "timezone_minute")]
         TimeZoneOffsetMinute
     }

--- a/Src/Couchbase.Linq/N1QlFunctions.Missing.cs
+++ b/Src/Couchbase.Linq/N1QlFunctions.Missing.cs
@@ -32,7 +32,7 @@ namespace Couchbase.Linq
         /// <param name="document">Document being tested</param>
         /// <param name="propertyName">Property name to test</param>
         /// <returns>True if the property is missing from the document</returns>
-        /// <remarks><see cref="propertyName">propertyName</see> must be a constant when used in a LINQ expression</remarks>
+        /// <remarks>propertyName must be a constant when used in a LINQ expression</remarks>
         public static bool IsMissing<T>(T document, string propertyName)
         {
             // Implementation will only be called when unit testing
@@ -63,7 +63,7 @@ namespace Couchbase.Linq
         /// <param name="document">Document being tested</param>
         /// <param name="propertyName">Property name to test</param>
         /// <returns>True if the property is present on the document</returns>
-        /// <remarks><see cref="propertyName">propertyName</see> must be a constant when used in a LINQ expression</remarks>
+        /// <remarks>propertyName must be a constant when used in a LINQ expression</remarks>
         public static bool IsNotMissing<T>(T document, string propertyName)
         {
             // Implementation will only be called when unit testing
@@ -98,7 +98,7 @@ namespace Couchbase.Linq
         /// <param name="document">Document being tested</param>
         /// <param name="propertyName">Property name to test</param>
         /// <returns>True if the property is present on the document and not null</returns>
-        /// <remarks><see cref="propertyName">propertyName</see> must be a constant when used in a LINQ expression</remarks>
+        /// <remarks>propertyName must be a constant when used in a LINQ expression</remarks>
         public static bool IsValued<T>(T document, string propertyName)
         {
             // Implementation will only be called when unit testing
@@ -140,7 +140,7 @@ namespace Couchbase.Linq
         /// <param name="document">Document being tested</param>
         /// <param name="propertyName">Property name to test</param>
         /// <returns>True if the property is missing from the document or null</returns>
-        /// <remarks><see cref="propertyName">propertyName</see> must be a constant when used in a LINQ expression</remarks>
+        /// <remarks>propertyName must be a constant when used in a LINQ expression</remarks>
         public static bool IsNotValued<T>(T document, string propertyName)
         {
             // Implementation will only be called when unit testing

--- a/Src/Couchbase.Linq/QueryGeneration/Expressions/StringComparisonExpression.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/Expressions/StringComparisonExpression.cs
@@ -23,8 +23,6 @@ namespace Couchbase.Linq.QueryGeneration.Expressions
             ExpressionType.GreaterThanOrEqual
         };
 
-        private Type _type;
-
         public ExpressionType Operation { get; private set; }
         public Expression Left { get; private set; }
         public Expression Right { get; private set; }

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
@@ -57,7 +57,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                     expressionTreeVisitor.Visit(Expression.Constant(chars[0], typeof(char)));
                 }
             }
-            catch (NotSupportedException ex)
+            catch (NotSupportedException)
             {
                 throw;
             }

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
@@ -58,7 +58,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                         expressionTreeVisitor.Visit(Expression.Constant(new String(chars), typeof (string)));
                     }
                 }
-                catch (NotSupportedException ex)
+                catch (NotSupportedException)
                 {
                     throw;
                 }

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -9,7 +9,7 @@ namespace Couchbase.Linq.QueryGeneration
 {
     internal class QueryPartsAggregator
     {
-        private static readonly ILog Log = LogManager.GetCurrentClassLogger();
+        private static readonly ILog Log = LogManager.GetLogger<QueryPartsAggregator>();
 
         public QueryPartsAggregator()
         {

--- a/Src/Couchbase.Linq/Utils/ExceptionMsgs.cs
+++ b/Src/Couchbase.Linq/Utils/ExceptionMsgs.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Couchbase.Linq.Utils
 {
-    public class ExceptionMsgs
+    internal class ExceptionMsgs
     {
         public const string DocumentNotFound = "Document not found for Id: ";
 


### PR DESCRIPTION
Motivation
----------
Generate XML documentation for inclusion in the Nuget package, while also
preparing it for Sandcastle documentation generation (LINQ-5).  Also
reduce compiler warnings.

Modifications
-------------
Updated project definition to generate XML documentation files.  Cleaned
up various issues in the XML documentation, including errors and public
members which were missing documentation.

Also, fixed several compiler warnings.  Used pragmas to disable some
obsolete warnings on the Couchbase SDK.

Results
-------
Valid XML documentation is now generated for inclusion in the Nuget
package and for later use with Sandcastle to generate HTML documentation.
There are no more compiler warnings issued.