### PR TITLE
Load document ids into proxies automatically

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Couchbase.Linq.Extensions;
 using Couchbase.Linq.IntegrationTests.Documents;
 using Couchbase.Linq.Proxies;
 using NUnit.Framework;
@@ -73,6 +74,29 @@ namespace Couchbase.Linq.IntegrationTests
 
             Assert.NotNull(status);
             Assert.IsFalse(status.IsDirty);
+        }
+
+        [Test]
+        public void Query_EnableProxyGeneration_ReturnsProxyBeerWithId()
+        {
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"))
+            {
+                EnableChangeTracking = true
+            };
+
+            const string documentId = "21st_amendment_brewery_cafe-21a_ipa";
+
+            var query = from x in db.Query<Beer>().UseKeys(new[] { documentId })
+                        where x.Type == "beer"
+                        select x;
+
+            var beer = query.First();
+
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            var status = beer as ITrackedDocumentNode;
+
+            Assert.NotNull(status);
+            Assert.AreEqual(documentId, status.__id);
         }
 
         [Test]

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Proxies\DocumentProxyTypeCreatorTests.cs" />
     <Compile Include="Proxies\DocumentProxyDataMapperTests.cs" />
     <Compile Include="Proxies\DocumentProxyTests.cs" />
+    <Compile Include="QueryGeneration\SelectDocumentIdTests.cs" />
     <Compile Include="QueryGeneration\UnionTests.cs" />
     <Compile Include="QueryGeneration\ArrayOperatorTests.cs" />
     <Compile Include="QueryGeneration\EnumTests.cs" />

--- a/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
@@ -36,13 +36,19 @@ namespace Couchbase.Linq.UnitTests
 
         protected string CreateN1QlQuery(IBucket bucket, Expression expression)
         {
+            return CreateN1QlQuery(bucket, expression, false);
+        }
+
+        protected string CreateN1QlQuery(IBucket bucket, Expression expression, bool selectDocumentId)
+        {
             var queryModel = QueryParserHelper.CreateQueryParser().GetParsedQuery(expression);
 
             var queryGenerationContext = new N1QlQueryGenerationContext()
             {
                 MemberNameResolver = MemberNameResolver,
                 MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider(),
-                Serializer = new Core.Serialization.DefaultSerializer()
+                Serializer = new Core.Serialization.DefaultSerializer(),
+                SelectDocumentId = selectDocumentId
             };
 
             var visitor = new N1QlQueryModelVisitor(queryGenerationContext);

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectDocumentIdTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectDocumentIdTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Couchbase.Core;
+using Couchbase.Linq.UnitTests.Documents;
+using Moq;
+using Newtonsoft.Json.Serialization;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.QueryGeneration
+{
+    [TestFixture]
+    public class SelectDocumentIdTests : N1QLTestBase
+    {
+        [Test]
+        public void Test_SelectDocumentId_Basic()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object);
+
+            const string expected = "SELECT `Extent1`.*, META(`Extent1`).id as `__id` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression, true);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_SelectDocumentId_WithPlainSelectProjection()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .Select(p => p);
+
+            const string expected = "SELECT `Extent1`.*, META(`Extent1`).id as `__id` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression, true);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Proxies/DocumentCollection.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentCollection.cs
@@ -32,6 +32,12 @@ namespace Couchbase.Linq.Proxies
             set { _documentNode.IsDirty = value; }
         }
 
+        public string __id
+        {
+            get { return _documentNode.__id; }
+            set { _documentNode.__id = value; }
+        }
+
         public void RegisterChangeTracking(ITrackedDocumentNodeCallback callback)
         {
             _documentNode.RegisterChangeTracking(callback);

--- a/Src/Couchbase.Linq/Proxies/DocumentNode.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentNode.cs
@@ -15,6 +15,7 @@ namespace Couchbase.Linq.Proxies
     {
         public bool IsDeserializing { get; set; }
         public bool IsDirty { get; set; }
+        public string __id { get; set; }
 
         #region Child Document Tracking
 

--- a/Src/Couchbase.Linq/Proxies/ITrackedDocumentNode.cs
+++ b/Src/Couchbase.Linq/Proxies/ITrackedDocumentNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Couchbase.Linq.Proxies
 {
@@ -10,6 +11,16 @@ namespace Couchbase.Linq.Proxies
     {
         bool IsDeserializing { get; set; }
         bool IsDirty { get; set; }
+
+        /// <summary>
+        /// If this is the root node in a document tree, this should contain the document ID.  Otherwise null.
+        /// </summary>
+        /// <remarks>
+        /// The property name __id is important for compatibility with other JSON deserializers, since we can't rely
+        /// on JsonProperty attributes for Newtonsoft.Json.
+        /// </remarks>
+        // ReSharper disable once InconsistentNaming
+        string __id { get; set; }
 
         void RegisterChangeTracking(ITrackedDocumentNodeCallback callback);
         void UnregisterChangeTracking(ITrackedDocumentNodeCallback callback);

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
@@ -27,6 +27,11 @@ namespace Couchbase.Linq.QueryGeneration
         /// </summary>
         public QuerySourceReferenceExpression GroupingQuerySource { get; set; }
 
+        /// <summary>
+        /// If true, indicates that the document ID should also be included in the select projection as "__id"
+        /// </summary>
+        public bool SelectDocumentId { get; set; }
+
         public N1QlQueryGenerationContext()
         {
             ExtentNameProvider = new N1QlExtentNameProvider();


### PR DESCRIPTION
Motivation
----------
For change tracking, it is important to know the document ID of a document
read from the database.  This ensures that changes saved back to the
database are saved back to the same ID.  Any approach that doesn't read
the document IDs at load time is relying on a key generation system that
is always 100% consistent.

Modifications
-------------
If proxy generation is enabled, and if the query being run will generate
proxies, then append an extra element to the select projection. This
element should return the document ID in the __id property.

Add __id as a property to the proxy objects via ITrackedDocumentNode, and
store it in the DocumentNode object.  This value can then be used by the
change tracking engine.

Note that "__id" as the property name doesn't really follow normal naming
conventions.  However, using the JsonProperty attribute would only work
with Newtonsoft.Json based deserialization.  Naming the property to match
the name in the N1QL query increases the likelihood of compatibility with
other deserialization engines.  Also, naming the property "__id" decreases
the likelihood of a naming conflict with the document attributes.

Results
-------
Document IDs are automatically read for any document being proxied for
change tracking, and made available to the change tracking system.