### PR TITLE
Don't serializer __interceptors field on proxies

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyTests.cs
@@ -28,6 +28,19 @@ namespace Couchbase.Linq.UnitTests.Proxies
         }
 
         [Test]
+        public void InterceptorsAreNotSerialized()
+        {
+            // Act
+
+            var result = Newtonsoft.Json.JsonConvert.SerializeObject(DocumentProxyManager.Default.CreateProxy(typeof(DocumentRoot)));
+
+            // Assert
+
+            Assert.NotNull(result);
+            Assert.False(result.Contains("__interceptors"));
+        }
+
+        [Test]
         public void NoAction_IsNotDirty()
         {
             // Arrange

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -103,6 +103,8 @@
     <Compile Include="N1QlFunctions.Metadata.cs" />
     <Compile Include="Proxies\DocumentCollection.cs" />
     <Compile Include="Proxies\DocumentNode.cs" />
+    <Compile Include="Proxies\DocumentProxyBuilder.cs" />
+    <Compile Include="Proxies\DocumentProxyGenerator.cs" />
     <Compile Include="Proxies\DocumentProxyTypeCreator.cs" />
     <Compile Include="Proxies\DocumentProxyDataMapper.cs" />
     <Compile Include="Proxies\DocumentProxyGenerationHook.cs" />

--- a/Src/Couchbase.Linq/Proxies/DocumentProxyBuilder.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentProxyBuilder.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Castle.Core.Logging;
+using Castle.DynamicProxy;
+using Castle.DynamicProxy.Generators;
+
+namespace Couchbase.Linq.Proxies
+{
+    /// <summary>
+    /// Overrides <see cref="CreateClassProxyType"/> for an existing <see cref="IProxyBuilder"/> so that it uses
+    /// <see cref="DocumentProxyGenerator"/> instead of the default <see cref="ClassProxyGenerator"/>.
+    /// </summary>
+    class DocumentProxyBuilder : IProxyBuilder
+    {
+        private readonly IProxyBuilder _baseProxyBuilder;
+
+        public ILogger Logger
+        {
+            get { return _baseProxyBuilder.Logger; }
+            set { _baseProxyBuilder.Logger = value; }
+        }
+
+        public ModuleScope ModuleScope
+        {
+            get { return _baseProxyBuilder.ModuleScope; }
+        }
+
+        /// <summary>
+        /// Creates a DocumentProxyBuilder instance.
+        /// </summary>
+        public DocumentProxyBuilder() : this(new DefaultProxyBuilder())
+        {
+        }
+
+        /// <summary>
+        /// Creates a DocumentProxyBuilder instance.
+        /// </summary>
+        /// <param name="scope"><see cref="ModuleScope"/> to use for <see cref="DefaultProxyBuilder"/>.</param>
+        public DocumentProxyBuilder(ModuleScope scope) : this(new DefaultProxyBuilder(scope))
+        {
+        }
+
+        /// <summary>
+        /// Creates a DocumentProxyBuilder instance.
+        /// </summary>
+        /// <param name="baseProxyBuilder">Base <see cref="IProxyBuilder"/> to use for all calls other than <see cref="CreateClassProxyType"/>.</param>
+        public DocumentProxyBuilder(IProxyBuilder baseProxyBuilder)
+        {
+            if (baseProxyBuilder == null)
+            {
+                throw new ArgumentNullException("baseProxyBuilder");
+            }
+
+            _baseProxyBuilder = baseProxyBuilder;
+        }
+
+        public Type CreateClassProxyType(Type classToProxy, Type[] additionalInterfacesToProxy, ProxyGenerationOptions options)
+        {
+            var generator = new DocumentProxyGenerator(ModuleScope, classToProxy)
+            {
+                Logger = Logger
+            };
+
+            return generator.GenerateCode(additionalInterfacesToProxy, options);
+        }
+
+        public Type CreateClassProxyTypeWithTarget(Type classToProxy, Type[] additionalInterfacesToProxy,
+            ProxyGenerationOptions options)
+        {
+            return _baseProxyBuilder.CreateClassProxyTypeWithTarget(classToProxy, additionalInterfacesToProxy, options);
+        }
+
+        public Type CreateInterfaceProxyTypeWithTarget(Type interfaceToProxy, Type[] additionalInterfacesToProxy, Type targetType,
+            ProxyGenerationOptions options)
+        {
+            return _baseProxyBuilder.CreateInterfaceProxyTypeWithTarget(interfaceToProxy, additionalInterfacesToProxy, targetType, options);
+        }
+
+        public Type CreateInterfaceProxyTypeWithTargetInterface(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
+            ProxyGenerationOptions options)
+        {
+            return _baseProxyBuilder.CreateInterfaceProxyTypeWithTargetInterface(interfaceToProxy, additionalInterfacesToProxy, options);
+        }
+
+        public Type CreateInterfaceProxyTypeWithoutTarget(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
+            ProxyGenerationOptions options)
+        {
+            return _baseProxyBuilder.CreateInterfaceProxyTypeWithoutTarget(interfaceToProxy, additionalInterfacesToProxy, options);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Proxies/DocumentProxyGenerator.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentProxyGenerator.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using Castle.DynamicProxy;
+using Castle.DynamicProxy.Generators;
+using Castle.DynamicProxy.Generators.Emitters;
+
+namespace Couchbase.Linq.Proxies
+{
+    /// <summary>
+    /// Inherited from <see cref="DocumentProxyGenerator"/>, this generator applies <see cref="IgnoreDataMemberAttribute"/>
+    /// to the emitted "__interceptors" field.  This prevents it from  being serialized by JSON serializers.
+    /// </summary>
+    internal class DocumentProxyGenerator : ClassProxyGenerator
+    {
+        private const string InterceptorsFieldName = "__interceptors";
+
+        public DocumentProxyGenerator(ModuleScope scope, Type targetType) : base(scope, targetType)
+        {
+        }
+
+        protected override void CreateFields(ClassEmitter emitter)
+        {
+            base.CreateFields(emitter);
+
+            var interceptorsField = emitter.GetField(InterceptorsFieldName);
+            if (interceptorsField != null)
+            {
+                emitter.DefineCustomAttributeFor<IgnoreDataMemberAttribute>(interceptorsField);
+            }
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Proxies/DocumentProxyManager.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentProxyManager.cs
@@ -54,7 +54,7 @@ namespace Couchbase.Linq.Proxies
         /// <summary>
         /// Creates a new DocumentProxyManager with a default <see cref="Castle.DynamicProxy.ProxyGenerator"/>.
         /// </summary>
-        public DocumentProxyManager() : this(new ProxyGenerator())
+        public DocumentProxyManager() : this(new ProxyGenerator(new DocumentProxyBuilder()))
         {
         }
 


### PR DESCRIPTION
Motivation
----------
When document proxy generation is enabled, the proxied documents gain an
extra __interceptors attribute when they are serialized back to JSON.

Modifications
-------------
Created DocumentProxyGenerator which overrides the behavior of the default
ClassProxyGenerator so that IgnoreDataMemberAttribute is applied to the
emitted __interceptors field.

Created DocumentProxyBuilder which overrides DefaultProxyBuilder to use
DocumentProxyGenerator instead of ClassProxyGenerator, and inject it into
the default DocumentProxyManager.

Created a unit test that ensures that "__interceptors" is not found in the
output JSON for a test proxy document.

Results
-------
__interceptors attribute is no longer serialized when document proxies are
written back to Couchbase.