### PR TITLE
Handle GUIDs correctly in expression tree.

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Documents\Beer.cs" />
     <Compile Include="Documents\Brewery.cs" />
     <Compile Include="Documents\BreweryFilter.cs" />
+    <Compile Include="Documents\Car.cs" />
     <Compile Include="Documents\ChildWithContract.cs" />
     <Compile Include="Documents\Child.cs" />
     <Compile Include="Documents\Contact.cs" />

--- a/Src/Couchbase.Linq.UnitTests/Documents/Car.cs
+++ b/Src/Couchbase.Linq.UnitTests/Documents/Car.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Couchbase.Linq.UnitTests.Documents
+{
+    class Car
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/WhereClauseTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/WhereClauseTests.cs
@@ -231,5 +231,26 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             Assert.AreEqual(expected, n1QlQuery);
         }
+
+        [Test]
+        public void Test_Where_With_Guid()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var guid = Guid.NewGuid();
+            var query =
+                QueryFactory.Queryable<Car>(mockBucket.Object)
+                    .Where(e => e.Id == guid)
+                    .Select(e => new { id = e.Id, name = e.Name });
+
+            string expected =
+                "SELECT `Extent1`.`Id` as `id`, `Extent1`.`Name` as `name` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`Id` = '" + guid.ToString() + "')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -510,6 +510,10 @@ namespace Couchbase.Linq.QueryGeneration
 
                 return Visit(System.Linq.Expressions.Expression.Constant(jsonValue));
             }
+            else if (namedParameter.Value is Guid)
+            {
+                _expression.AppendFormat("'{0}'", namedParameter.Value.ToString());
+            }
             else
             {
                 _expression.AppendFormat("{0}", namedParameter.Value);


### PR DESCRIPTION
This fixes the issue with using a Guid comparison in a where clause.  I went ahead and added a test and an additional test document class (Car) that has a Guid.  Didn't want to mess with any existing documents since I'm not familiar with the library.  