### PR TITLE
Support index consistency settings on LINQ queries

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/BucketQueryExecutorEmulator.cs
+++ b/Src/Couchbase.Linq.UnitTests/BucketQueryExecutorEmulator.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Linq.Execution;
 using Couchbase.Linq.QueryGeneration;
+using Couchbase.N1QL;
 using Remotion.Linq;
 
 namespace Couchbase.Linq.UnitTests
@@ -16,6 +17,9 @@ namespace Couchbase.Linq.UnitTests
     /// </summary>
     internal class BucketQueryExecutorEmulator : IBucketQueryExecutor
     {
+        public ScanConsistency? ScanConsistency { get; set; }
+        public TimeSpan? ScanWait { get; set; }
+
         private readonly N1QLTestBase _test;
         public N1QLTestBase Test
         {

--- a/Src/Couchbase.Linq/Execution/IBucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/IBucketQueryExecutor.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Linq.QueryGeneration;
+using Couchbase.N1QL;
 using Remotion.Linq;
 
 namespace Couchbase.Linq.Execution
@@ -13,6 +14,17 @@ namespace Couchbase.Linq.Execution
     /// </summary>
     internal interface IBucketQueryExecutor : IQueryExecutor
     {
+        /// <summary>
+        /// Specifies the consistency guarantee/constraint for index scanning.
+        /// </summary>
+        ScanConsistency? ScanConsistency { get; set; }
+
+        /// <summary>
+        /// Specifies the maximum time the client is willing to wait for an index to catch up to the vector timestamp in the request.
+        /// If an index has to catch up, and the time is exceed doing so, an error is returned.
+        /// </summary>
+        TimeSpan? ScanWait { get; set; }
+
         /// <summary>
         /// Asynchronously execute a <see cref="LinqQueryRequest"/>.
         /// </summary>


### PR DESCRIPTION
Motivation
----------
As an SDK consumer, I'd like to be able to specify my index consistency
requirements when using LINQ.  This extends the functionality of the LINQ
client to include functionality that already exists for handwritten
queries.

Modifications
-------------
Added IQueryable<T> extensions for setting ScanConsistency and ScanWait.
These values are passed through to BucketQueryExecutor, which then applies
them to the resulting LinqQueryRequest.

Results
-------
Users can apply index consistency settings inline as they are building the
LINQ query.

Note: ScanVector is not implemented, because dynamic types are not
supported on extension methods.  I'm also not sure that Couchbase Server
supports this parameter yet.