### PR TITLE
Improved query exception handling

### DIFF
--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Clauses\UseKeysExpressionNode.cs" />
     <Compile Include="Clauses\UseKeysClause.cs" />
     <Compile Include="BucketContext.cs" />
+    <Compile Include="CouchbaseQueryException.cs" />
     <Compile Include="CouchbaseWriteException.cs" />
     <Compile Include="DocumentNotFoundException.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />

--- a/Src/Couchbase.Linq/CouchbaseQueryException.cs
+++ b/Src/Couchbase.Linq/CouchbaseQueryException.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.N1QL;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Thrown if an error occurs during the execution of a LINQ N1QL query.
+    /// </summary>
+    public class CouchbaseQueryException : ApplicationException
+    {
+        private readonly ReadOnlyCollection<Error> _errors;
+
+        /// <summary>
+        /// Errors returned by the Couchbase Server, if any.
+        /// </summary>
+        public ReadOnlyCollection<Error> Errors
+        {
+            get { return _errors; }
+        }
+
+        internal CouchbaseQueryException(string message) :
+            this(message, (Exception) null)
+        {
+        }
+
+        internal CouchbaseQueryException(string message, Exception innerException) :
+            base(message, innerException)
+        {
+            _errors = new ReadOnlyCollection<Error>(new Error[] {});
+        }
+
+        internal CouchbaseQueryException(string message, IList<Error> errors) :
+            base(message)
+        {
+            _errors = new ReadOnlyCollection<Error>(errors);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Utils/ExceptionMsgs.cs
+++ b/Src/Couchbase.Linq/Utils/ExceptionMsgs.cs
@@ -12,6 +12,14 @@ namespace Couchbase.Linq.Utils
 
         public const string KeyAttributeMissing = "No KeyAttribute could be found for the document. Please " +
                                                   "mark a key property with a KeyAttribute";
+
+        public const string QueryExecutionException = "An error occurred executing the N1QL query.  See the " +
+                                                      "inner exception for details.";
+
+        public const string QueryExecutionUnknownError = "An unknown error occurred executing the N1QL query.";
+
+        public const string QueryExecutionMultipleErrors = "Multiple errors occured executing the N1QL query. " +
+                                                           "See the Errors property for details.";
     }
 }
 #region [ License information          ]


### PR DESCRIPTION
Motivation
----------
Current exception handling during query execution can be unclear, and is
difficult to trap with filtered catch blocks.

Modifications
-------------
All errors during query execution are thrown as a CouchbaseQueryException.

If the Errors collection is present and populated, include it in the
Errors property of the CouchbaseQueryException.  If there is only one
error, its message becomes the exception message.  If there is more than
one error, a generic error message is used that refers the developer to
the Errors property.

If an Exception is returned instead, a generic error message is used and
the Exception becomes the InnerException of the CouchbaseQueryException.

If neither Errors or Exception is populated (which should not happen
unless there is a bug further up the line), the message indicates that
there was an unknown error.

Results
-------
Exceptions can be easily trapped by catching CouchbaseQueryException
specifically.  If trapped, the entire Errors collection is available in a
property, as is the Exception in the InnerException property.  The
exception message is more readable and informative.