### PR TITLE
Issue #122: N1QlFunctions.Key in select and where clauses

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -193,6 +193,27 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void Map2PocoTests_Simple_Projections_Key()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = (from b in context.Query<Beer>()
+                         where b.Type == "beer"
+                         select new { name = b.Name, key = N1QlFunctions.Key(b) }).
+                Take(1);
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
+            {
+                Assert.NotNull(b.key);
+                Console.WriteLine("{0} has key {1}", b.name, b.key);
+            }
+        }
+
+        [Test]
         public void Map2PocoTests_Explain()
         {
             var bucket = ClusterHelper.GetBucket("beer-sample");

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Proxies\DocumentProxyDataMapperTests.cs" />
     <Compile Include="Proxies\DocumentProxyTests.cs" />
     <Compile Include="QueryGeneration\LinqQueryRequestTests.cs" />
+    <Compile Include="QueryGeneration\MethodCallTranslators\KeyMethodCallTranslatorTests.cs" />
     <Compile Include="QueryGeneration\SelectDocumentIdTests.cs" />
     <Compile Include="QueryGeneration\UnionTests.cs" />
     <Compile Include="QueryGeneration\ArrayOperatorTests.cs" />

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslatorTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslatorTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.QueryGeneration;
+using Couchbase.Linq.QueryGeneration.MethodCallTranslators;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.QueryGeneration.MethodCallTranslators
+{
+    class KeyMethodCallTranslatorTests
+    {
+        #region Translate
+
+        [Test]
+        public void Translate_NoMethod_ThrowsArgumentNullException()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var transformer = new KeyMethodCallTranslator();
+
+            // Act/Assert
+
+            var result = Assert.Throws<ArgumentNullException>(() => transformer.Translate(null, visitor.Object));
+
+            Assert.AreEqual("methodCallExpression", result.ParamName);
+        }
+
+        [Test]
+        public void Translate_NoVisitor_ThrowsArgumentNullException()
+        {
+            // Arrange
+
+            var method = typeof(N1QlFunctions).GetMethod("Key");
+            var expression = Expression.Call(method,
+                Expression.Constant("arg1"));
+
+            var transformer = new KeyMethodCallTranslator();
+
+            // Act/Assert
+
+            var result = Assert.Throws<ArgumentNullException>(() => transformer.Translate(expression, null));
+
+            Assert.AreEqual("expressionTreeVisitor", result.ParamName);
+        }
+
+        [Test]
+        public void Translate_OneParameter_RendersCorrectly()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var method = typeof(N1QlFunctions).GetMethod("Key");
+            var expression = Expression.Call(method,
+                Expression.Constant("arg1"));
+
+            var transformer = new KeyMethodCallTranslator();
+
+            // Act
+
+            transformer.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            Assert.AreEqual("META('arg1').id", result);
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
@@ -28,12 +28,16 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             {
                 throw new ArgumentNullException("methodCallExpression");
             }
+            if (expressionTreeVisitor == null)
+            {
+                throw new ArgumentNullException("expressionTreeVisitor");
+            }
 
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("META(");
             expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
-            expression.Append(").Id");
+            expression.Append(").id");
 
             return methodCallExpression;
         }


### PR DESCRIPTION
Motivation
----------
While N1QlFunctions.Key is interpreted correctly in join and nest type
clauses, it is always returning null when used in where clauses and select
projections.  This is because it is incorrectly using the capitalized
property "Id" instead of "id".

Modifications
-------------
Corrected capitalization of the output N1QL query.  Added unit and
integration tests to prevent future regressions.

Results
-------
N1QlFunctions.Key can now be used in any clause where it is supported by
N1QL.