### PR TITLE
Support UPDATE operator

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -1164,5 +1164,35 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         #endregion
+
+
+        [Test]
+        public void Update_Set_Unset_Execute()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var what = context.Query<Beer>().Where(beer => beer.Type == "beer" && beer.Name == "21A IPA");
+
+            Assert.AreEqual("American-Style India Pale Ale", what.First().Style);
+
+            var beers = what.Unset(x => x.Style)
+                            .Select(x => new { x.Name, x.Style })
+                            .ToArray();
+
+            Assert.AreEqual(1, beers.Length);
+            Assert.AreEqual(null, beers[0].Style);
+            Assert.AreEqual("21A IPA", beers[0].Name);
+
+            // re-execute request
+            Assert.AreEqual(null, what.First().Style);
+
+            what.Set(x => x.Style == "American-Style India Pale Ale").Execute();
+
+
+            // re-execute request
+            Assert.AreEqual("American-Style India Pale Ale", what.First().Style);
+        }
+
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -146,6 +146,7 @@
     <Compile Include="QueryGeneration\OrderByClauseTests.cs" />
     <Compile Include="QueryGeneration\SelectTests.cs" />
     <Compile Include="QueryGeneration\TakeAndSkipTests.cs" />
+    <Compile Include="QueryGeneration\UpdateClauseTests.cs" />
     <Compile Include="QueryGeneration\WhereClauseTests.cs" />
     <Compile Include="TestConfigurations.cs" />
   </ItemGroup>

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/UpdateClauseTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/UpdateClauseTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Linq;
+using Couchbase.Core;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.UnitTests.Documents;
+using Moq;
+using NUnit.Framework;
+using System.Linq.Expressions;
+
+namespace Couchbase.Linq.UnitTests.QueryGeneration
+{
+    [TestFixture]
+    public class UpdateClauseTests : N1QLTestBase
+    {
+        [Test]
+        public void Test_Update_UseKeys()
+        {
+            CreateQueryable<Contact>("default")
+                    .UseKeys(new[] { "keyname" })
+                    .Set(x => x.Age == 5)
+                    .ToArray();
+
+            const string expected =
+                "UPDATE `default` as `Extent1` USE KEYS ['keyname'] SET `Extent1`.`age` = 5 RETURNING `Extent1`.*";
+            Assert.AreEqual(expected, QueryExecutor.Query);
+        }
+
+        [Test]
+        public void Test_Update_Condition()
+        {
+            CreateQueryable<Contact>("default")
+                    .Where(e => e.Age > 10)
+                    .Set(x => x.Age == 5)
+                    .ToArray();
+
+            const string expected =
+                "UPDATE `default` as `Extent1` SET `Extent1`.`age` = 5 WHERE (`Extent1`.`age` > 10) RETURNING `Extent1`.*";
+            Assert.AreEqual(expected, QueryExecutor.Query);
+        }
+
+        [Test]
+        public void Test_Unset_Condition()
+        {
+            CreateQueryable<Contact>("default")
+                    .Where(e => e.Age > 10)
+                    .Unset(x => x.Age)
+                    .ToArray();
+
+            const string expected =
+                "UPDATE `default` as `Extent1` UNSET `Extent1`.`age` WHERE (`Extent1`.`age` > 10) RETURNING `Extent1`.*";
+            Assert.AreEqual(expected, QueryExecutor.Query);
+        }
+
+        [Test]
+        public void Test_ChainUpdate()
+        {
+            CreateQueryable<Contact>("default")
+                    .Where(e => e.Age > 10)
+                    .Set(x => x.Age == 5 && x.Email == x.FirstName && x.LastName == "lastname")
+                    .ToArray();
+
+            const string expected =
+                "UPDATE `default` as `Extent1` SET `Extent1`.`age` = 5, `Extent1`.`email` = `Extent1`.`fname`, `Extent1`.`lname` = 'lastname' WHERE (`Extent1`.`age` > 10) RETURNING `Extent1`.*";
+            Assert.AreEqual(expected, QueryExecutor.Query);
+        }
+
+        [Test]
+        public void Test_Update_SetAndUnset_WithSelectAndCondition()
+        {
+            CreateQueryable<Contact>("default")
+                    .Where(e => e.Age > 10 && e.FirstName == "Sam")
+                    .OrderBy(e => e.Age)
+                    .Set(x => x.Age == 5)
+                    .Set(x => x.Email == x.FirstName)
+                    .Unset(x=>x.Title)
+                    .Select(e => new { age = e.Age, name = e.FirstName })
+                    .ToArray();
+
+            const string expected =
+                "UPDATE `default` as `Extent1` SET `Extent1`.`age` = 5, `Extent1`.`email` = `Extent1`.`fname` UNSET `Extent1`.`title` WHERE ((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam')) RETURNING `Extent1`.`age` as `age`, `Extent1`.`fname` as `name`";
+            Assert.AreEqual(expected, QueryExecutor.Query);
+        }
+
+        [Test]
+        public void Test_Update_WithNoSelection()
+        {
+            CreateQueryable<Contact>("default")
+                    .Where(e => e.Age > 10 && e.FirstName == "Sam")
+                    .OrderBy(e => e.Age)
+                    .Set(x => x.Age == 5)
+                    .Set(x => x.Email == x.FirstName)
+                    .Unset(x => x.Title)
+                    .Execute();
+
+            const string expected =
+                "UPDATE `default` as `Extent1` SET `Extent1`.`age` = 5, `Extent1`.`email` = `Extent1`.`fname` UNSET `Extent1`.`title` WHERE ((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam'))";
+            Assert.AreEqual(expected, QueryExecutor.Query);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/ExecuteExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/ExecuteExpressionNode.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+using System.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.Linq.Clauses
+{
+    internal class ExecuteExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+        {
+            typeof (QueryExtensions).GetMethod(nameof(QueryExtensions.Execute)),
+        };
+
+
+        public ExecuteExpressionNode(MethodCallExpressionParseInfo parseInfo, LambdaExpression optionalPredicate)
+            : base (parseInfo, optionalPredicate, null)
+        {
+        }
+
+
+        public override Expression Resolve(
+            ParameterExpression inputParameter, Expression expressionToBeResolved, ClauseGenerationContext clauseGenerationContext)
+        {
+            throw CreateResolveNotSupportedException();
+        }
+
+
+        protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext)
+        {
+            return new ExecuteResultOperator();
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/ExecuteResultOperator.cs
+++ b/Src/Couchbase.Linq/Clauses/ExecuteResultOperator.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq.Expressions;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Clauses
+{
+    internal class ExecuteResultOperator : Remotion.Linq.Clauses.ResultOperatorBase
+    {
+        public override ResultOperatorBase Clone(CloneContext cloneContext)
+        {
+            return new ExecuteResultOperator();
+        }
+
+        public override IStreamedData ExecuteInMemory(IStreamedData input)
+        {
+            return new StreamedValue(null, new StreamedSingleValueInfo(typeof(void), true));
+        }
+
+        public override IStreamedDataInfo GetOutputDataInfo(IStreamedDataInfo inputInfo)
+        {
+            return new StreamedScalarValueInfo(typeof(void));
+        }
+
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/UpdateClause.cs
+++ b/Src/Couchbase.Linq/Clauses/UpdateClause.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq.Expressions;
+using Remotion.Linq.Clauses;
+using Remotion.Linq;
+using Couchbase.Linq.QueryGeneration;
+using System.Collections.Generic;
+using System;
+
+namespace Couchbase.Linq.Clauses
+{
+    internal class UpdateClause : IBodyClause
+    {
+        public List<Expression> Setters { get; private set; } = new List<Expression>();
+        public List<Expression> Unsetters { get; private set; } = new List<Expression>();
+        
+        public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
+        {
+            var visotorx = visitor as IN1QlQueryModelVisitor;
+            if (visotorx != null)
+                visotorx.VisitUpdateClause(this, queryModel, index);
+        }
+        
+        public void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+            throw new NotSupportedException("Update does not support transformations");
+        }
+
+        IBodyClause IBodyClause.Clone(CloneContext cloneContext)
+        {
+            return Clone(cloneContext);
+        }
+
+
+        public virtual UpdateClause Clone(CloneContext cloneContext)
+        {
+            var clone = new UpdateClause
+            {
+                Setters = new List<Expression>(Setters),
+                Unsetters = new List<Expression>(Unsetters),
+            };
+            return clone;
+        }
+
+        public override string ToString()
+        {
+            return String.Format("set {0} unset {1}", string.Join(", ",Setters), string.Join(", ",Unsetters));
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/UpdateExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/UpdateExpressionNode.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+using System.Linq;
+
+namespace Couchbase.Linq.Clauses
+{
+    internal class UpdateExpressionNode : MethodCallExpressionNodeBase
+    {
+        // see reference source https://github.com/re-motion/Relinq/blob/fe7061590f2204cbe12477529df723d52de9047b/Core/Parsing/Structure/IntermediateModel/WhereExpressionNode.cs
+
+        public static readonly MethodInfo[] SupportedMethods =
+        {
+            typeof (QueryExtensions).GetMethod(nameof(QueryExtensions.Set)),
+            typeof (QueryExtensions).GetMethod(nameof(QueryExtensions.Unset)),
+        };
+
+        private readonly ResolvedExpressionCache<Expression> _cachedPredicate;
+        bool unset;
+
+        public UpdateExpressionNode(MethodCallExpressionParseInfo parseInfo, LambdaExpression predicate)
+            : base(parseInfo)
+        {
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+            unset = parseInfo.ParsedExpression.Method.Name == nameof(QueryExtensions.Unset);
+            _predicate = predicate;
+            _cachedPredicate = new ResolvedExpressionCache<Expression>(this);
+        }
+
+        public LambdaExpression _predicate { get; private set; }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        public Expression GetResolvedPredicate(ClauseGenerationContext clauseGenerationContext)
+        {
+            return _cachedPredicate.GetOrCreate(r => r.GetResolvedExpression(_predicate.Body, _predicate.Parameters[0], clauseGenerationContext));
+        }
+
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            var upd = new UpdateClause();
+            if (unset)
+                upd.Unsetters.Add(GetResolvedPredicate(clauseGenerationContext));
+            else
+                upd.Setters.Add(GetResolvedPredicate(clauseGenerationContext));
+
+            queryModel.BodyClauses.Add(upd);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -89,6 +89,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Clauses\ExecuteResultOperator.cs" />
+    <Compile Include="Clauses\UpdateClause.cs" />
+    <Compile Include="Clauses\ExecuteExpressionNode.cs" />
+    <Compile Include="Clauses\UpdateExpressionNode.cs" />
     <Compile Include="Clauses\UseKeysExpressionNode.cs" />
     <Compile Include="Clauses\UseKeysClause.cs" />
     <Compile Include="BucketContext.cs" />

--- a/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
@@ -15,6 +15,7 @@ using Couchbase.N1QL;
 using Newtonsoft.Json;
 using Remotion.Linq;
 using Remotion.Linq.Clauses.ResultOperators;
+using Couchbase.Linq.Clauses;
 
 namespace Couchbase.Linq.Execution
 {
@@ -202,7 +203,7 @@ namespace Couchbase.Linq.Execution
 
         public T ExecuteScalar<T>(QueryModel queryModel)
         {
-            return ExecuteSingle<T>(queryModel, false);
+            return ExecuteSingle<T>(queryModel, queryModel.ResultOperators.OfType<ExecuteResultOperator>().Any());
         }
 
         public T ExecuteSingle<T>(QueryModel queryModel, bool returnDefaultWhenEmpty)

--- a/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
@@ -14,5 +14,7 @@ namespace Couchbase.Linq.QueryGeneration
         void VisitNestClause(NestClause clause, QueryModel queryModel, int index);
 
         void VisitUseKeysClause(UseKeysClause clause, QueryModel queryModel, int index);
+
+        void VisitUpdateClause(UpdateClause clause, QueryModel queryModel, int index);
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryType.cs
@@ -53,6 +53,11 @@
         /// <summary>
         /// Represents a simple aggregate against a group.  Query returned will be the aggregate function call only.
         /// </summary>
-        Aggregate
+        Aggregate,
+
+        /// <summary>
+        /// Represents an UPDATE query.
+        /// </summary>
+        Update,
     }
 }

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -31,6 +31,14 @@ namespace Couchbase.Linq
             customNodeTypeRegistry.Register(ToQueryRequestExpressionNode.SupportedMethods,
                 typeof(ToQueryRequestExpressionNode));
 
+            //register the "Set" and "Unset" expression node parser
+            customNodeTypeRegistry.Register(UpdateExpressionNode.SupportedMethods,
+                typeof(UpdateExpressionNode));
+
+            //register the "Execute" expression node parser
+            customNodeTypeRegistry.Register(ExecuteExpressionNode.SupportedMethods,
+                typeof(ExecuteExpressionNode));
+
             //This creates all the default node types
             var nodeTypeProvider = ExpressionTreeParser.CreateDefaultNodeTypeProvider();
 


### PR DESCRIPTION
## Motivation

There is currently no support for the N1QL "UPDATE"  operator.
## Modifications

Adds 3 extension methods to IQueryable<T>:  Set, Unset and Execute.
## Results

User can now use update operator. Usage examples:

```
var newCustomers = query<User>()
      .Where(x=> x.Age > 20)
      .Set( x => x.CanHaveBeers == true )
      .Unset(x => x.WeirdVoice )
      .Select(x=>x.Name)
     .ToArray();
```

which will translate to N1QL:

```
 UPDATE default x SET x.canHaveBeers=true UNSET x.weirdVoice WHERE x.age > 20 RETURNING x.name
```

[see update reference](http://developer.couchbase.com/documentation/server/4.0/n1ql/n1ql-language-reference/update.html)

**nb1:** You may have noticed that i'm using "==" operator in expressions. That's just a trick because unfortunately, C# does not support assignations in expressions. (unless built manually with Expression.Assign)

**nb2:** You could also use .Execute() to not return user names, which saves bandwidth.
