### PR TITLE
LINQ-19: Add change-tracking to BucketContext

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/App.config
+++ b/Src/Couchbase.Linq.IntegrationTests/App.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <configuration>
   <configSections>
     <sectionGroup name="common">
@@ -7,11 +6,12 @@
     </sectionGroup>
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
     <sectionGroup name="couchbaseClients">
-      <section name="couchbase" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+      <section name="couchbase"
+               type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
     </sectionGroup>
   </configSections>
   <couchbaseClients>
-  <couchbase enableConfigHeartBeat="false">
+    <couchbase enableConfigHeartBeat="false">
       <servers>
         <!-- changes in appSettings section should also be reflected here -->
         <add uri="http://localhost:8091"></add>
@@ -34,45 +34,25 @@
       </factoryAdapter>
     </logging>
   </common>
-
   <runtime>
-
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-
       <dependentAssembly>
-
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
-
       </dependentAssembly>
-
       <dependentAssembly>
-
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-1.2.11.0" newVersion="1.2.11.0" />
-
       </dependentAssembly>
-
       <dependentAssembly>
-
         <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
-
       </dependentAssembly>
-
       <dependentAssembly>
-
         <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
-
       </dependentAssembly>
-
     </assemblyBinding>
-
   </runtime>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />

--- a/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
@@ -19,10 +19,8 @@ namespace Couchbase.Linq.IntegrationTests
                 where x.Type == "beer"
                 select x;
 
-            foreach (var beer in query.Take(1))
-            {
-                Console.WriteLine(beer.Name);
-            }
+            var beer = query.FirstOrDefault();
+            Assert.IsNotNull(beer);
         }
 
         [Test]
@@ -32,10 +30,8 @@ namespace Couchbase.Linq.IntegrationTests
             var beers = from b in db.Beers
                 select b;
 
-            foreach (var beer in beers.Take(1))
-            {
-                Console.WriteLine(beer.Name);
-            }
+            var beer = beers.Take(1);
+            Assert.IsNotNull(beer);
         }
 
         [Test]
@@ -58,10 +54,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Query_EnableProxyGeneration_ReturnsProxyBeer()
         {
-            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"))
-            {
-                EnableChangeTracking = true
-            };
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            db.BeginChangeTracking();
 
             var query = from x in db.Query<Beer>()
                         where x.Type == "beer"
@@ -79,10 +74,8 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Query_EnableProxyGeneration_ReturnsProxyBeerWithId()
         {
-            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"))
-            {
-                EnableChangeTracking = true
-            };
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+            db.BeginChangeTracking();
 
             const string documentId = "21st_amendment_brewery_cafe-21a_ipa";
 
@@ -102,10 +95,8 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Query_EnableProxyGeneration_ReturnsProxyBeerWithCas()
         {
-            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"))
-            {
-                EnableChangeTracking = true
-            };
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+            db.BeginChangeTracking();
 
             const string documentId = "21st_amendment_brewery_cafe-21a_ipa";
 
@@ -123,12 +114,30 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void Query_DisableProxyGeneration_ReturnsNoProxy()
+        {
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            const string documentId = "21st_amendment_brewery_cafe-21a_ipa";
+
+            var query = from x in db.Query<Beer>().UseKeys(new[] { documentId })
+                        where x.Type == "beer"
+                        select x;
+
+            var beer = query.First();
+
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            var status = beer as ITrackedDocumentNode;
+
+            Assert.Null(status);
+        }
+
+        [Test]
         public void Query_EnableProxyGenerationChanges_FlagAsDirty()
         {
-            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"))
-            {
-                EnableChangeTracking = true
-            };
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            db.BeginChangeTracking();
 
             var query = from x in db.Query<Beer>()
                         where x.Type == "beer"
@@ -150,10 +159,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Query_EnableProxyGenerationChangesInSubDocuments_FlagAsDirty()
         {
-            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"))
-            {
-                EnableChangeTracking = true
-            };
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            db.BeginChangeTracking();
 
             var query = from x in db.Query<Brewery>()
                         where x.Type == "brewery" && N1QlFunctions.IsValued(x.Geo)
@@ -175,10 +183,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Query_EnableProxyGeneration_ReturnsProxyBreweryAddressCollection()
         {
-            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"))
-            {
-                EnableChangeTracking = true
-            };
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            db.BeginChangeTracking();
 
             var query = from x in db.Query<Brewery>()
                         where x.Type == "brewery"
@@ -197,10 +204,10 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Query_EnableProxyGenerationClearAddresses_FlagAsDirty()
         {
-            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"))
-            {
-                EnableChangeTracking = true
-            };
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            db.BeginChangeTracking();
+
 
             var query = from x in db.Query<Brewery>()
                         where x.Type == "brewery" && x.Address.Any()
@@ -221,10 +228,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Query_EnableProxyGenerationAddAddress_FlagAsDirty()
         {
-            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"))
-            {
-                EnableChangeTracking = true
-            };
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            db.BeginChangeTracking();
 
             var query = from x in db.Query<Brewery>()
                         where x.Type == "brewery" && x.Address.Any()
@@ -245,10 +251,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Query_EnableProxyGenerationRemoveAddress_FlagAsDirty()
         {
-            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"))
-            {
-                EnableChangeTracking = true
-            };
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            db.BeginChangeTracking();
 
             var query = from x in db.Query<Brewery>()
                         where x.Type == "brewery" && x.Address.Any()
@@ -269,10 +274,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Query_EnableProxyGenerationSetAddress_FlagAsDirty()
         {
-            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"))
-            {
-                EnableChangeTracking = true
-            };
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            db.BeginChangeTracking();
 
             var query = from x in db.Query<Brewery>()
                         where x.Type == "brewery" && x.Address.Any()
@@ -292,6 +296,77 @@ namespace Couchbase.Linq.IntegrationTests
 
         #endregion
 
+        [Test]
+        public void BeginChangeTracking_DoesNotClear_Modified_List()
+        {
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            db.BeginChangeTracking();
+
+            var query = from x in db.Query<Beer>()
+                        where x.Type == "beer"
+                        select x;
+
+            db.BeginChangeTracking();
+
+            var context = db as IChangeTrackableContext;
+
+            Assert.AreEqual(0, context.ModifiedCount);
+
+            var brewery = query.First();
+            brewery.Abv = 10;
+
+            Assert.AreEqual(1, context.ModifiedCount);
+
+            db.BeginChangeTracking();
+
+            Assert.AreEqual(1, context.ModifiedCount);
+        }
+
+
+        [Test]
+        public void SubmitChanges_WhenDocsAreModified_DocumentIsMutated()
+        {
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            var query = from x in db.Query<Beer>()
+                        where x.Type == "beer"
+                        select x;
+
+            db.BeginChangeTracking();
+
+            var beer = query.First();
+
+            beer.Abv = beer.Abv+1;
+
+            db.SubmitChanges();
+
+            var doc = ClusterHelper.GetBucket("beer-sample").GetDocument<Beer>(((ITrackedDocumentNode) beer).Metadata.Id);
+            Assert.AreEqual(beer.Abv, doc.Content.Abv);
+        }
+
+        [Test]
+        public void SubmitChanges_WhenDocsAreModifiedAndEndChangeTracking_DocumentIsNotMutated()
+        {
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            var query = from x in db.Query<Beer>()
+                        where x.Type == "beer"
+                        select x;
+
+            db.BeginChangeTracking();
+
+            var beer = query.First();
+
+            beer.Abv = beer.Abv + 1;
+
+            db.EndChangeTracking();
+
+            db.SubmitChanges();
+
+            var doc = ClusterHelper.GetBucket("beer-sample").GetDocument<Beer>(((ITrackedDocumentNode)beer).Metadata.Id);
+            Assert.AreNotEqual(beer.Abv, doc.Content.Abv);
+        }
     }
 }
 

--- a/Src/Couchbase.Linq.IntegrationTests/Documents/Beer.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/Documents/Beer.cs
@@ -6,7 +6,6 @@ namespace Couchbase.Linq.IntegrationTests.Documents
 {
     public class Beer
     {
-        [Key]
         [JsonProperty("name")]
         public virtual string Name { get; set; }
 

--- a/Src/Couchbase.Linq.UnitTests/App.config
+++ b/Src/Couchbase.Linq.UnitTests/App.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <configuration>
   <configSections>
     <sectionGroup name="common">
@@ -7,11 +6,12 @@
     </sectionGroup>
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
     <sectionGroup name="couchbaseClients">
-      <section name="couchbase" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+      <section name="couchbase"
+               type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
     </sectionGroup>
   </configSections>
   <couchbaseClients>
-  <couchbase enableConfigHeartBeat="false">
+    <couchbase enableConfigHeartBeat="false">
       <servers>
         <!-- changes in appSettings section should also be reflected here -->
         <add uri="http://localhost:8091"></add>
@@ -34,45 +34,25 @@
       </factoryAdapter>
     </logging>
   </common>
-
   <runtime>
-
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-
       <dependentAssembly>
-
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
-
       </dependentAssembly>
-
       <dependentAssembly>
-
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-1.2.11.0" newVersion="1.2.11.0" />
-
       </dependentAssembly>
-
       <dependentAssembly>
-
         <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
-
       </dependentAssembly>
-
       <dependentAssembly>
-
         <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
-
         <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
-
       </dependentAssembly>
-
     </assemblyBinding>
-
   </runtime>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />

--- a/Src/Couchbase.Linq.UnitTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/BucketContextTests.cs
@@ -1,5 +1,8 @@
-﻿using Couchbase.Core;
+﻿using System.Linq;
+using Couchbase.Configuration.Client;
+using Couchbase.Core;
 using Couchbase.IO;
+using Couchbase.Linq.Proxies;
 using Couchbase.Linq.UnitTests.Documents;
 using Moq;
 using NUnit.Framework;
@@ -12,95 +15,369 @@ namespace Couchbase.Linq.UnitTests
         [Test]
         public void GetDocumentId_When_Id_Field_DoesNotExist_Throw_KeyAttributeMissingException()
         {
+            //arrange
             var route = new Route();
             var bucket = new Mock<IBucket>();
             var ctx = new BucketContext(bucket.Object);
-            Assert.Throws<KeyAttributeMissingException>(()=>ctx.GetDocumentId(route));
+
+            //act-assert
+            Assert.Throws<KeyAttributeMissingException>(() => ctx.GetDocumentId(route));
         }
 
         [Test]
         public void GetDocumentId_When_DocId_Exists_Use_It()
         {
+            //arrange
             var beer = new Beer {Name = "beer1"};
             var bucket = new Mock<IBucket>();
             var ctx = new BucketContext(bucket.Object);
+
+            //act
             var id = ctx.GetDocumentId(beer);
+
+            //assert
             Assert.AreEqual("beer1", id);
         }
 
-       [Test]
+        [Test]
         public void Save_When_Write_Is_Succesful_Return_Success()
         {
+            //arrange
             var beer = new Beer();
             var bucket = new Mock<IBucket>();
-            var result = new Mock<IOperationResult<Beer>> ();
+            var result = new Mock<IOperationResult<Beer>>();
             result.Setup(x => x.Status).Returns(ResponseStatus.Success);
             result.Setup(x => x.Success).Returns(true);
             bucket.Setup(x => x.Upsert(It.IsAny<string>(), It.IsAny<Beer>())).Returns(result.Object);
             var ctx = new BucketContext(bucket.Object);
+
+            //act
             ctx.Save(beer);
+
+            //assert - does not throw exception
         }
 
-       [Test]
-       public void Save_When_Write_Is_Not_Succesful_Throw_CouchbaseWriteException()
-       {
-           var beer = new Beer();
-           var bucket = new Mock<IBucket>();
-           var result = new Mock<IOperationResult<Beer>>();
-           result.Setup(x => x.Success).Returns(false);
-           bucket.Setup(x => x.Upsert(It.IsAny<string>(), It.IsAny<Beer>())).Returns(result.Object);
-           var ctx = new BucketContext(bucket.Object);
-           Assert.Throws<CouchbaseWriteException>(()=>ctx.Save(beer));
-       }
+        [Test]
+        public void Save_When_Write_Is_Not_Succesful_Throw_CouchbaseWriteException()
+        {
+            //arrange
+            var beer = new Beer();
+            var bucket = new Mock<IBucket>();
+            var result = new Mock<IOperationResult<Beer>>();
+            result.Setup(x => x.Success).Returns(false);
+            bucket.Setup(x => x.Upsert(It.IsAny<string>(), It.IsAny<Beer>())).Returns(result.Object);
+            var ctx = new BucketContext(bucket.Object);
 
-       [Test]
-       public void Remove_When_Write_Is_Not_Succesful_Throw_CouchbaseWriteException()
-       {
-           var beer = new Beer();
-           var bucket = new Mock<IBucket>();
-           var result = new Mock<IOperationResult<Beer>>();
-           result.Setup(x => x.Success).Returns(false);
-           bucket.Setup(x => x.Remove(It.IsAny<string>())).Returns(result.Object);
-           var ctx = new BucketContext(bucket.Object);
-           Assert.Throws<CouchbaseWriteException>(() => ctx.Remove(beer));
-       }
+            //act
+            Assert.Throws<CouchbaseWriteException>(() => ctx.Save(beer));
+        }
 
-       [Test]
-       public void Save_When_KeyAttribute_Is_Not_Defined_Throw_DocumentIdMissingException()
-       {
-           var brewery = new Brewery();
-           var bucket = new Mock<IBucket>();
-           var result = new Mock<IOperationResult<Brewery>>();
-           result.Setup(x => x.Status).Returns(ResponseStatus.Success);
-           bucket.Setup(x => x.Upsert(It.IsAny<string>(), It.IsAny<Brewery>())).Returns(result.Object);
-           var ctx = new BucketContext(bucket.Object);
-           Assert.Throws<KeyAttributeMissingException>(()=>ctx.Save(brewery));
-       }
+        [Test]
+        public void Remove_When_Write_Is_Not_Succesful_Throw_CouchbaseWriteException()
+        {
+            //arrange
+            var beer = new Beer();
+            var bucket = new Mock<IBucket>();
+            var result = new Mock<IOperationResult<Beer>>();
+            result.Setup(x => x.Success).Returns(false);
+            bucket.Setup(x => x.Remove(It.IsAny<string>())).Returns(result.Object);
+            var ctx = new BucketContext(bucket.Object);
 
-       [Test]
-       public void Remove_When_Write_Is_Succesful_Return_Success()
-       {
-           var beer = new Beer();
-           var bucket = new Mock<IBucket>();
-           var result = new Mock<IOperationResult<Beer>>();
-           result.Setup(x => x.Status).Returns(ResponseStatus.Success);
-           result.Setup(x => x.Success).Returns(true);
-           bucket.Setup(x => x.Remove(It.IsAny<string>())).Returns(result.Object);
-           var ctx = new BucketContext(bucket.Object);
-           ctx.Remove(beer);
-       }
+            //act-assert
+            Assert.Throws<CouchbaseWriteException>(() => ctx.Remove(beer));
+        }
 
-       [Test]
-       public void Remove_When_DocId_Is_Not_Defined_Throw_DocumentIdMissingException()
-       {
-           var brewery = new Brewery();
-           var bucket = new Mock<IBucket>();
-           var result = new Mock<IOperationResult<Brewery>>();
-           result.Setup(x => x.Status).Returns(ResponseStatus.Success);
-           bucket.Setup(x => x.Upsert(It.IsAny<string>(), It.IsAny<Brewery>())).Returns(result.Object);
-           var ctx = new BucketContext(bucket.Object);
-           Assert.Throws<KeyAttributeMissingException>(() => ctx.Remove(brewery));
-       }
+        [Test]
+        public void Save_When_KeyAttribute_Is_Not_Defined_Throw_DocumentIdMissingException()
+        {
+            //arrange
+            var brewery = new Brewery();
+            var bucket = new Mock<IBucket>();
+            var result = new Mock<IOperationResult<Brewery>>();
+            result.Setup(x => x.Status).Returns(ResponseStatus.Success);
+            bucket.Setup(x => x.Upsert(It.IsAny<string>(), It.IsAny<Brewery>())).Returns(result.Object);
+            var ctx = new BucketContext(bucket.Object);
+
+            //act-assert
+            Assert.Throws<KeyAttributeMissingException>(() => ctx.Save(brewery));
+        }
+
+        [Test]
+        public void Remove_When_Write_Is_Succesful_Return_Success()
+        {
+            //arrange
+            var beer = new Beer();
+            var bucket = new Mock<IBucket>();
+            var result = new Mock<IOperationResult<Beer>>();
+            result.Setup(x => x.Status).Returns(ResponseStatus.Success);
+            result.Setup(x => x.Success).Returns(true);
+            bucket.Setup(x => x.Remove(It.IsAny<string>())).Returns(result.Object);
+            var ctx = new BucketContext(bucket.Object);
+
+            //act-assert
+            ctx.Remove(beer);
+        }
+
+        [Test]
+        public void Remove_When_DocId_Is_Not_Defined_Throw_DocumentIdMissingException()
+        {
+            //arrange
+            var brewery = new Brewery();
+            var bucket = new Mock<IBucket>();
+            var ctx = new BucketContext(bucket.Object);
+
+            //act-assert
+            Assert.Throws<KeyAttributeMissingException>(() => ctx.Remove(brewery));
+        }
+
+        [Test]
+        public void BeginChangeTracking_ChangeTrackingEnabled_Is_True()
+        {
+            //arrange
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+            var ctx = new BucketContext(bucket.Object);
+
+            //act
+            ctx.BeginChangeTracking();
+
+            //assert
+            Assert.IsTrue(ctx.ChangeTrackingEnabled);
+        }
+
+        [Test]
+        public void EndChangeTracking_ChangeTrackingEnabled_Is_False()
+        {
+            //arrange
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+
+            var ctx = new BucketContext(bucket.Object);
+            ctx.BeginChangeTracking();
+
+            //act
+            ctx.EndChangeTracking();
+
+            //assert
+            Assert.IsFalse(ctx.ChangeTrackingEnabled);
+        }
+
+        [Test]
+        public void BeginChangeTracking_CalledTwiceThenEndChangeTracking_ChangTrackingEnabledIsTrue()
+        {
+            //arrange
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+
+            var ctx = new BucketContext(bucket.Object);
+
+            //act
+            ctx.BeginChangeTracking();
+            ctx.BeginChangeTracking();
+            ctx.EndChangeTracking();
+
+            //assert
+            Assert.IsTrue(ctx.ChangeTrackingEnabled);
+        }
+
+        [Test]
+        public void BeginChangeTracking_CalledTwiceThenEndChangeTrackingTwice_ChangTrackingEnabledIsFalse()
+        {
+            //arrange
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+
+            var ctx = new BucketContext(bucket.Object);
+
+            //act
+            ctx.BeginChangeTracking();
+            ctx.BeginChangeTracking();
+            ctx.EndChangeTracking();
+            ctx.EndChangeTracking();
+
+            //assert
+            Assert.IsFalse(ctx.ChangeTrackingEnabled);
+        }
+
+
+        [Test]
+        public void Save_Adds_New_Document_To_Modified_List()
+        {
+            //arrange
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+
+            var ctx = new BucketContext(bucket.Object);
+            ctx.BeginChangeTracking();
+
+            var beer = new Beer
+            {
+                Name = "doc1" //key field
+            };
+
+            //act
+            ctx.Save(beer);
+
+            //assert
+            Assert.AreEqual(1, ctx.ModifiedCount);
+        }
+
+        [Test]
+        public void Save_Updates_Duplicate_Document_In_Modified_List()
+        {
+            //arrange
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+
+            var ctx = new BucketContext(bucket.Object);
+            ctx.BeginChangeTracking();
+
+            var beer = new Beer
+            {
+                Name = "doc1" //key field
+            };
+
+            //act
+            ctx.Save(beer);
+            ctx.Save(beer);
+
+            //assert
+            Assert.AreEqual(1, ctx.ModifiedCount);
+        }
+
+        [Test]
+        public void SubmitChanges_Removes_Document_From_Modified_List()
+        {
+            //arrange
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+
+            var ctx = new BucketContext(bucket.Object);
+            ctx.BeginChangeTracking();
+
+            var beer = new Beer
+            {
+                Name = "doc1" //key field
+            };
+
+            ctx.Save(beer);
+
+            //act
+            ctx.SubmitChanges();
+
+            //assert
+            Assert.AreEqual(0, ctx.ModifiedCount);
+        }
+
+        [Test]
+        public void SubmitChanges_WhenCalled_DoesNotClearTrackedList()
+        {
+            //arrange
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+
+            var ctx = new BucketContext(bucket.Object);
+            ctx.BeginChangeTracking();
+
+            var beer = new Beer
+            {
+                Name = "doc1" //key field
+            };
+
+            ctx.Save(beer);
+
+            //act
+            ctx.SubmitChanges();
+
+            //assert
+            Assert.AreEqual(1, ctx.TrackedCount);
+        }
+
+        [Test]
+        public void EndChangeTracking_WhenCalled_ClearsTrackedList()
+        {
+            //arrange
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+
+            var ctx = new BucketContext(bucket.Object);
+            ctx.BeginChangeTracking();
+
+            var beer = new Beer
+            {
+                Name = "doc1" //key field
+            };
+
+            ctx.Save(beer);
+
+            //act
+            ctx.EndChangeTracking();
+
+            //assert
+            Assert.AreEqual(0, ctx.TrackedCount);
+        }
+
+        [Test]
+        public void Save_WhenChangeTrackingEnabled_AddsToTrackedList()
+        {
+            //arrange
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+
+            var ctx = new BucketContext(bucket.Object);
+            ctx.BeginChangeTracking();
+
+            var beer = new Beer
+            {
+                Name = "doc1" //key field
+            };
+
+            ctx.Save(beer);
+
+            Assert.AreEqual(1, ctx.TrackedCount);
+        }
+
+        [Test]
+        public void GetDocumentId_WhenChangeTrackingEnabled_ProxyUses__idFieldForKey()
+        {
+            var document = (Beer)DocumentProxyManager.Default.CreateProxy(typeof(Beer));
+
+            ((ITrackedDocumentNode) document).Metadata.Id = "thekey";
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+
+            var ctx = new BucketContext(bucket.Object);
+            ctx.BeginChangeTracking();
+
+            var key = ctx.GetDocumentId(document);
+
+            Assert.AreEqual("thekey", key);
+        }
+
+        [Test]
+        public void EndChangeTracking_WhenCalled_ModifiedList()
+        {
+            //arrange
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+
+            var ctx = new BucketContext(bucket.Object);
+            ctx.BeginChangeTracking();
+
+            var beer = new Beer
+            {
+                Name = "doc1" //key field
+            };
+
+            ctx.Save(beer);
+
+            //act
+            ctx.EndChangeTracking();
+
+            //assert
+            Assert.AreEqual(0, ctx.ModifiedCount);
+        }
     }
 }
 

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -170,7 +170,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Src/Couchbase.Linq.UnitTests/Proxies/DocumentCollectionTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Proxies/DocumentCollectionTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Linq.Proxies;
+using Moq;
 using NUnit.Framework;
 
 namespace Couchbase.Linq.UnitTests.Proxies
@@ -34,7 +35,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var collection = new DocumentCollection<SubDocument>
+            var collection = new DocumentCollection<SubDocument>()
             {
                 new SubDocument()
             };
@@ -56,7 +57,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var collection = new DocumentCollection<SubDocument>
+            var collection = new DocumentCollection<SubDocument>()
             {
                 IsDeserializing = true
             };
@@ -82,7 +83,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var collection = new DocumentCollection<SubDocument>
+            var collection = new DocumentCollection<SubDocument>()
             {
                 new SubDocument()
             };
@@ -101,7 +102,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var collection = new DocumentCollection<SubDocument>
+            var collection = new DocumentCollection<SubDocument>()
             {
                 new SubDocument()
             };
@@ -124,7 +125,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var collection = new DocumentCollection<SubDocument>
+            var collection = new DocumentCollection<SubDocument>()
             {
                 new SubDocument()
             };
@@ -147,7 +148,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var collection = new DocumentCollection<SubDocument>
+            var collection = new DocumentCollection<SubDocument>()
             {
                 new SubDocument()
             };
@@ -174,7 +175,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var collection = new DocumentCollection<SubDocument>
+            var collection = new DocumentCollection<SubDocument>()
             {
                 (SubDocument)DocumentProxyManager.Default.CreateProxy(typeof (SubDocument))
             };
@@ -199,7 +200,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
 
             var originalDocument = (SubDocument) DocumentProxyManager.Default.CreateProxy(typeof (SubDocument));
 
-            var collection = new DocumentCollection<SubDocument>
+            var collection = new DocumentCollection<SubDocument>()
             {
                 originalDocument
             };
@@ -225,7 +226,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var collection = new DocumentCollection<SubDocument>
+            var collection = new DocumentCollection<SubDocument>()
             {
                 (SubDocument)DocumentProxyManager.Default.CreateProxy(typeof (SubDocument))
             };
@@ -249,7 +250,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var collection = new DocumentCollection<SubDocument>
+            var collection = new DocumentCollection<SubDocument>()
             {
                 (SubDocument)DocumentProxyManager.Default.CreateProxy(typeof (SubDocument))
             };

--- a/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyDataMapperTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyDataMapperTests.cs
@@ -31,7 +31,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
             // Act/Assert
 
             // ReSharper disable once ObjectCreationAsStatement
-            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper(configuration));
+            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper(configuration, new Mock<IChangeTrackableContext>().Object));
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
             // Act/Assert
 
             // ReSharper disable once ObjectCreationAsStatement
-            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper(configuration));
+            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper(configuration, new Mock<IChangeTrackableContext>().Object));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
                 Serializer = () => new FakeSerializer()
             };
 
-            var dataMapper = new DocumentProxyDataMapper(configuration);
+            var dataMapper = new DocumentProxyDataMapper(configuration, new Mock<IChangeTrackableContext>().Object);
 
             // Act
 
@@ -88,7 +88,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
                 Serializer = () => new FakeSerializer()
             };
 
-            var dataMapper = new DocumentProxyDataMapper(configuration);
+            var dataMapper = new DocumentProxyDataMapper(configuration, new Mock<IChangeTrackableContext>().Object);
 
             // Act
 

--- a/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Configuration.Client;
 using Couchbase.Linq.Proxies;
+using Moq;
 using NUnit.Framework;
 
 // ReSharper disable SuspiciousTypeConversion.Global
@@ -48,7 +49,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
             // Arrange
 
             var configuration = new ClientConfiguration();
-            var dataMapper = new DocumentProxyDataMapper(configuration);
+            var dataMapper = new DocumentProxyDataMapper(configuration, null);
 
             DocumentRoot proxy;
             using (var stream = new System.IO.MemoryStream(Encoding.UTF8.GetBytes("{\"stringProperty\":\"value\",\"__metadata\":{\"id\":\"test\"}}")))

--- a/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyTypeCreatorTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyTypeCreatorTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Linq.Proxies;
+using Moq;
 using NUnit.Framework;
 
 namespace Couchbase.Linq.UnitTests.Proxies

--- a/Src/Couchbase.Linq/BucketQueryable.cs
+++ b/Src/Couchbase.Linq/BucketQueryable.cs
@@ -17,6 +17,7 @@ namespace Couchbase.Linq
     {
         private readonly IBucket _bucket;
         private readonly IBucketQueryExecutor _bucketQueryExecutor;
+        private readonly IBucketContext _bucketContext;
 
         /// <summary>
         /// Bucket query is run against
@@ -71,11 +72,11 @@ namespace Couchbase.Linq
         /// </summary>
         /// <param name="bucket">The bucket.</param>
         /// <param name="configuration">The configuration.</param>
-        /// <param name="enableProxyGeneration">If true, generate change tracking proxies for documents during deserialization.</param>
+        /// <param name="bucketContext">The context object for tracking and managing changes to documents.</param>
         /// <exception cref="System.ArgumentNullException">bucket</exception>
         /// <exception cref="ArgumentNullException"><paramref name="bucket" /> is <see langword="null" />.</exception>
-        public BucketQueryable(IBucket bucket, ClientConfiguration configuration, bool enableProxyGeneration)
-            : base(QueryParserHelper.CreateQueryParser(), new BucketQueryExecutor(bucket, configuration, enableProxyGeneration))
+        public BucketQueryable(IBucket bucket, ClientConfiguration configuration, IBucketContext bucketContext)
+            : base(QueryParserHelper.CreateQueryParser(), new BucketQueryExecutor(bucket, configuration, bucketContext))
         {
             if (bucket == null)
             {
@@ -84,6 +85,7 @@ namespace Couchbase.Linq
 
             _bucket = bucket;
             _bucketQueryExecutor = (IBucketQueryExecutor) ((DefaultQueryProvider) Provider).Executor;
+            _bucketContext = bucketContext;
         }
     }
 }

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -89,6 +89,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IChangeTrackableContext.cs" />
     <Compile Include="Clauses\UseKeysExpressionNode.cs" />
     <Compile Include="Clauses\UseKeysClause.cs" />
     <Compile Include="BucketContext.cs" />
@@ -119,6 +120,7 @@
     <Compile Include="Proxies\DocumentProxyManager.cs" />
     <Compile Include="Proxies\ITrackedDocumentNode.cs" />
     <Compile Include="Proxies\ITrackedDocumentNodeCallback.cs" />
+    <Compile Include="Proxies\NewDocumentWrapper.cs" />
     <Compile Include="QueryGeneration\Expressions\StringComparisonExpression.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\DateTimeComparisonExpressionTransformer.cs" />
     <Compile Include="QueryGeneration\ExpressionTransformers\StringComparisonExpressionTransformer.cs" />

--- a/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
@@ -23,7 +23,7 @@ namespace Couchbase.Linq.Execution
         private static readonly ILog Log = LogManager.GetLogger<BucketQueryExecutor>();
         private readonly IBucket _bucket;
         private readonly ClientConfiguration _configuration;
-        private readonly bool _enableProxyGeneration;
+        private readonly IBucketContext _bucketContext;
 
         public string BucketName
         {
@@ -35,7 +35,7 @@ namespace Couchbase.Linq.Execution
         /// </summary>
         public bool EnableProxyGeneration
         {
-            get { return _enableProxyGeneration; }
+            get { return _bucketContext.ChangeTrackingEnabled; }
         }
 
         /// <summary>
@@ -54,12 +54,12 @@ namespace Couchbase.Linq.Execution
         /// </summary>
         /// <param name="bucket"><see cref="IBucket"/> to query.</param>
         /// <param name="configuration"><see cref="ClientConfiguration"/> used during the query.</param>
-        /// <param name="enableProxyGeneration">If true, generate change tracking proxies for documents during deserialization.</param>
-        public BucketQueryExecutor(IBucket bucket, ClientConfiguration configuration, bool enableProxyGeneration)
+        /// <param name="bucketContext">The context object for tracking and managing changes to documents.</param>
+        public BucketQueryExecutor(IBucket bucket, ClientConfiguration configuration, IBucketContext bucketContext)
         {
             _bucket = bucket;
             _configuration = configuration;
-            _enableProxyGeneration = enableProxyGeneration;
+            _bucketContext = bucketContext;
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace Couchbase.Linq.Execution
             if (generateProxies)
             {
                 // Proxy generation was requested, and the
-                queryRequest.DataMapper = new Proxies.DocumentProxyDataMapper(_configuration);
+                queryRequest.DataMapper = new Proxies.DocumentProxyDataMapper(_configuration, (IChangeTrackableContext)_bucketContext);
             }
 
             if (queryModel.ResultOperators.Any(p => p is ToQueryRequestResultOperator))

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -19,25 +19,19 @@ namespace Couchbase.Linq
         ClientConfiguration Configuration { get; }
 
         /// <summary>
-        /// If true, generate change tracking proxies for documents during deserialization. Defaults to false for higher performance queries.
-        /// </summary>
-        bool EnableChangeTracking { get; set; }
-
-        /// <summary>
-        /// Begins change tracking for the current request. To complete and save the changes call <see cref="SubmitChanges"/>. Note that
-        /// <see cref="EnableChangeTracking"/> must be set to true for change tracking to be enabled.
+        /// Begins change tracking for the current request. To complete and save the changes call <see cref="SubmitChanges"/>.
         /// </summary>
         void BeginChangeTracking();
+
+        /// <summary>
+        /// Ends change tracking on the current context.
+        /// </summary>
+        void EndChangeTracking();
 
         /// <summary>
         /// Submits the changes.
         /// </summary>
         void SubmitChanges();
-
-        /// <summary>
-        /// Flushes the changes.
-        /// </summary>
-        void FlushChanges();
 
         /// <summary>
         /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
@@ -60,5 +54,10 @@ namespace Couchbase.Linq
         /// <typeparam name="T"></typeparam>
         /// <param name="document">The document.</param>
         void Remove<T>(T document);
+
+        /// <summary>
+        /// If true, generate change tracking proxies for documents during deserialization. Defaults to false for higher performance queries.
+        /// </summary>
+        bool ChangeTrackingEnabled { get; }
     }
 }

--- a/Src/Couchbase.Linq/IChangeTrackableContext.cs
+++ b/Src/Couchbase.Linq/IChangeTrackableContext.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Couchbase.Linq.Proxies;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Provides an interface for supporting persistence of documents via proxies when change tracking is enabled.
+    /// </summary>
+    internal interface IChangeTrackableContext : ITrackedDocumentNodeCallback
+    {
+        /// <summary>
+        /// Adds a document to the list of tracked documents if change tracking is enabled.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> of the document to track.</typeparam>
+        /// <param name="document">The object representing the document.</param>
+        void Track<T>(T document);
+
+        /// <summary>
+        /// Removes a document from the list if tracked documents.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="document"></param>
+        void Untrack<T>(T document);
+
+        /// <summary>
+        /// Adds a document to the list of modified documents if it is has been mutated and is being tracked.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="document"></param>
+        void Modified<T>(T document);
+
+        /// <summary>
+        /// The count of documents that have been modified if change tracking is enabled.
+        /// </summary>
+        int ModifiedCount { get; }
+
+        /// <summary>
+        /// The count of all documents currently being tracked.
+        /// </summary>
+        int TrackedCount { get; }
+    }
+}

--- a/Src/Couchbase.Linq/Proxies/DocumentCollection.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentCollection.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Dynamic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Linq.Metadata;
@@ -20,6 +22,8 @@ namespace Couchbase.Linq.Proxies
         #region ITrackedDocumentNode
 
         // Redirect all ITrackedDocumentNode calls to the DocumentNode
+
+        public bool IsDeleted { get; set; }
 
         public bool IsDeserializing
         {
@@ -63,7 +67,7 @@ namespace Couchbase.Linq.Proxies
                 base.ClearItems();
 
                 _documentNode.RemoveAllChildren();
-                _documentNode.DocumentModified();
+                _documentNode.DocumentModified(this);
             }
         }
 
@@ -77,7 +81,7 @@ namespace Couchbase.Linq.Proxies
                 _documentNode.AddChild(status);
             }
 
-            _documentNode.DocumentModified();
+            _documentNode.DocumentModified(this);
         }
 
         protected override void RemoveItem(int index)
@@ -90,7 +94,7 @@ namespace Couchbase.Linq.Proxies
 
             base.RemoveItem(index);
 
-            _documentNode.DocumentModified();
+            _documentNode.DocumentModified(this);
         }
 
         protected override void SetItem(int index, T item)
@@ -111,7 +115,7 @@ namespace Couchbase.Linq.Proxies
                 _documentNode.AddChild(status);
             }
 
-            _documentNode.DocumentModified();
+            _documentNode.DocumentModified(this);
         }
     }
 }

--- a/Src/Couchbase.Linq/Proxies/DocumentProxyDataMapper.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentProxyDataMapper.cs
@@ -21,9 +21,11 @@ namespace Couchbase.Linq.Proxies
     internal class DocumentProxyDataMapper : IDataMapper
     {
         private readonly IExtendedTypeSerializer _serializer;
+        private readonly IChangeTrackableContext _context;
 
-        public DocumentProxyDataMapper(ClientConfiguration configuration)
+        public DocumentProxyDataMapper(ClientConfiguration configuration, IChangeTrackableContext context)
         {
+
             if (configuration == null)
             {
                 throw new ArgumentNullException("configuration");
@@ -40,6 +42,8 @@ namespace Couchbase.Linq.Proxies
                 throw new NotSupportedException("Change tracking is not supported without an IExtendedTypeSerializer which supports CustomObjectCreator.");
             }
 
+            _context = context;
+
             _serializer.DeserializationOptions = new DeserializationOptions
             {
                 CustomObjectCreator = new DocumentProxyTypeCreator()
@@ -54,7 +58,7 @@ namespace Couchbase.Linq.Proxies
         /// <returns>An object deserialized to it's T type.</returns>
         public T Map<T>(Stream stream)
         {
-            var document = _serializer.Deserialize<T>(stream);
+            var queryResults = _serializer.Deserialize<T>(stream);
 
             // The use of reflection here isn't terribly efficient.  However, for a N1QL query this method will
             // only be called once for a single IQueryResult<T>, so the performance penalty is very negligible.
@@ -70,16 +74,16 @@ namespace Couchbase.Linq.Proxies
                     ClearStatusOnQueryRequestRowsMethodInfo.MakeGenericMethod(
                         queryResultInterface.GenericTypeArguments[0]);
 
-                methodInfo.Invoke(this, new object[] {document});
+                methodInfo.Invoke(this, new object[] {queryResults, _context});
             }
 
-            return document;
+            return queryResults;
         }
 
         private static readonly MethodInfo ClearStatusOnQueryRequestRowsMethodInfo =
             typeof (DocumentProxyDataMapper).GetMethod("ClearStatusOnQueryRequestRows");
 
-        public static void ClearStatusOnQueryRequestRows<T>(IQueryResult<T> result)
+        public static void ClearStatusOnQueryRequestRows<T>(IQueryResult<T> result, IChangeTrackableContext context)
         {
             if (result.Rows != null)
             {
@@ -88,8 +92,13 @@ namespace Couchbase.Linq.Proxies
                     var status = row as ITrackedDocumentNode;
                     if (status != null)
                     {
-                        // Clear the deserialization flags to start change tracking
+                        // Track the document
+                        context.Track(row);
 
+                        // Register the context so that it can handled the changed document
+                        status.RegisterChangeTracking(context);
+
+                        // Clear the deserialization flags to start change tracking
                         status.ClearStatus();
                     }
                 }

--- a/Src/Couchbase.Linq/Proxies/DocumentProxyGenerationHook.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentProxyGenerationHook.cs
@@ -51,7 +51,7 @@ namespace Couchbase.Linq.Proxies
             // Only proxy getters and setters for properties on the document
             // We must proxy getters or serializing the document back to Couchbase has problems
 
-            return methodInfo.IsSpecialName;
+            return methodInfo.IsSpecialName && (methodInfo.Name.StartsWith("set_") || methodInfo.Name.StartsWith("get_"));
         }
     }
 }

--- a/Src/Couchbase.Linq/Proxies/DocumentProxyInterceptor.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentProxyInterceptor.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 using Castle.DynamicProxy;
 using Couchbase.Linq.Metadata;
 
@@ -80,7 +74,7 @@ namespace Couchbase.Linq.Proxies
                     _documentNode.AddChild(status);
                 }
 
-                _documentNode.DocumentModified();
+                _documentNode.DocumentModified(status);
             }
         }
     }

--- a/Src/Couchbase.Linq/Proxies/DocumentProxyTypeCreator.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentProxyTypeCreator.cs
@@ -35,10 +35,18 @@ namespace Couchbase.Linq.Proxies
                 return false;
             }
 
-            if (type.GetInterfaces().Any(p => p.IsGenericType && (p.GetGenericTypeDefinition() == typeof(IQueryResult<>))))
+            var interfaces = type.GetInterfaces();
+
+            if (interfaces.Any(p => p.IsGenericType && (p.GetGenericTypeDefinition() == typeof(IQueryResult<>))))
             {
                 // Don't proxy the QueryResult<T> object
 
+                return false;
+            }
+
+            if (interfaces.Any(p => p.UnderlyingSystemType == typeof (IBucketContext)))
+            {
+                //don't proxy the context
                 return false;
             }
 

--- a/Src/Couchbase.Linq/Proxies/ITrackedDocumentNode.cs
+++ b/Src/Couchbase.Linq/Proxies/ITrackedDocumentNode.cs
@@ -12,7 +12,11 @@ namespace Couchbase.Linq.Proxies
     internal interface ITrackedDocumentNode
     {
         [IgnoreDataMember]
+        bool IsDeleted { get; set; }
+
+        [IgnoreDataMember]
         bool IsDeserializing { get; set; }
+
         [IgnoreDataMember]
         bool IsDirty { get; set; }
 
@@ -23,6 +27,7 @@ namespace Couchbase.Linq.Proxies
         DocumentMetadata Metadata { get; set; }
 
         void RegisterChangeTracking(ITrackedDocumentNodeCallback callback);
+
         void UnregisterChangeTracking(ITrackedDocumentNodeCallback callback);
 
         /// <summary>

--- a/Src/Couchbase.Linq/Proxies/ITrackedDocumentNodeCallback.cs
+++ b/Src/Couchbase.Linq/Proxies/ITrackedDocumentNodeCallback.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace Couchbase.Linq.Proxies
 {
     internal interface ITrackedDocumentNodeCallback
     {
-        void DocumentModified();
+        void DocumentModified(ITrackedDocumentNode mutatedDocument);
     }
 }

--- a/Src/Couchbase.Linq/Proxies/NewDocumentWrapper.cs
+++ b/Src/Couchbase.Linq/Proxies/NewDocumentWrapper.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.Proxies
+{
+    internal class NewDocumentWrapper : DocumentNode
+    {
+        public object Value { get; set; }
+    }
+}

--- a/Src/Couchbase.Linq/QueryFactory.cs
+++ b/Src/Couchbase.Linq/QueryFactory.cs
@@ -9,7 +9,7 @@ namespace Couchbase.Linq
         public static IQueryable<T> Queryable<T>(IBucket bucket)
         {
             //TODO refactor so ClientConfiguration is injectable
-            return new BucketQueryable<T>(bucket, new ClientConfiguration(), false);
+            return new BucketQueryable<T>(bucket, new ClientConfiguration(), new BucketContext(bucket));
         }
     }
 }


### PR DESCRIPTION
Motivation
----------
This commit introduces experimental support for change tracking of
entities/POCOs loaded from documents stored in Couchbase server. By enabling
change tracking through a call to the BeginChangeTracking method on
BucketContext, each POCO or entity that corresponds to a document returned
by a query will be intercepted and proxied. The proxy contains logic for
detecting any modifications to a document and adding the corresponding
object to a mutated list. When SubmitChanges is called, the changed
documents will be added, updated or deleted on Couchbase Server. Change
tracking be disabled by calling the EndChangeTracking method; which will
remove any modified documents from the mutated list and subsequent queries
will not be intercepted and proxied.

Modifications
-------------
The BucketContext is now a subcriber for all proxy modifications when
change tracking is enabled; any changes to an object which is proxied will
be bubbled up to the BucketContext and stored in a mutated list. If a new
document is added that was not proxied it will be wrapped in a
NewDocumentWrapper class and treated as if it was proxied. Various other
methods of BucketContext were also modified to support the cases where
chnage tracking is enabled and when it is not enabled. In general, any
delete, add or mutation persistence will be deferred until SubmitChanges
is called.

Results
-------
When BegingChangeTracking is enabled all documents returned by a query
will be proxied. If a document is modified, the BucketContext will be
notified. When SubmitChanges it called, the documents that have been
changed or added will be persisted to Couchbase.