### PR TITLE
Issue #129: Ensure N1QL numbers use period as decimal separator

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/ConstantExpressionTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/ConstantExpressionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -174,6 +175,53 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
             Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Decimal()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                .Where(e => e.Abv == 0.5M);
+
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`abv` = 0.5)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_DecimalInCommaCulture()
+        {
+            var currentCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("da-DK");
+            try
+            {
+                Assert.AreEqual(",", System.Threading.Thread.CurrentThread.CurrentCulture.NumberFormat.NumberDecimalSeparator);
+
+                var mockBucket = new Mock<IBucket>();
+                mockBucket.SetupGet(e => e.Name).Returns("default");
+
+                var query =
+                    QueryFactory.Queryable<Beer>(mockBucket.Object)
+                        .Where(e => e.Abv == 0.5M);
+
+                const string expected =
+                    "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`abv` = 0.5)";
+
+                var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+                Assert.AreEqual(expected, n1QlQuery);
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = currentCulture;
+            }
         }
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -516,7 +516,8 @@ namespace Couchbase.Linq.QueryGeneration
             }
             else
             {
-                _expression.AppendFormat("{0}", namedParameter.Value);
+                // Use the invariant culture so that decimal handling is correct
+                _expression.Append(Convert.ToString(namedParameter.Value, System.Globalization.CultureInfo.InvariantCulture));
             }
 
             return expression;


### PR DESCRIPTION
Motivation
----------
In cultures with a comma decimal separator, including a constant in your
query that has decimal precision will cause an invalid N1QL query.  N1QL
expects numbers to always use a period decimal separator.

Modifications
-------------
When serializing numeric constants to a N1QL query, always convert them to
a string using the Invariant culture.

Created a unit test to prevent future regressions.

Results
-------
N1QL queries with decimal constants will now work with any culture
setting, without requiring special workarounds by consumers.