### PR TITLE
Exposed IBucket from IBucketContext

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
@@ -380,7 +380,27 @@ namespace Couchbase.Linq.IntegrationTests
             // execute N1QL to update the beer
             var newBeerName = Guid.NewGuid().ToString();
             var n1ql = string.Format("UPDATE `beer-sample` USE KEYS '{0}' SET name = '{1}';", beer.Id, newBeerName);
-            db.Bucket.Query<int>(n1ql);
+            db.Execute(n1ql);
+
+            // get the beer back out to make sure it was updated correctly
+            var beerAgain = db.Query<Beer>().First(b => N1QlFunctions.Meta(b).Id == beer.Id);
+
+            Assert.That(beerAgain.Name, Is.EqualTo(newBeerName));
+        }
+
+        [Test]
+        public void Underlying_Bucket_can_be_used_to_execute_N1QL_query_directly_with_parameterization()
+        {
+            // setup bucket context
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+
+            // get a beer from the db
+            var beer = db.Query<Beer>().Select(b => N1QlFunctions.Meta(b)).First();
+
+            // execute N1QL to update the beer, use parameterization instead of string.Format
+            var newBeerName = Guid.NewGuid().ToString();
+            var n1ql = "UPDATE `beer-sample` USE KEYS $1 SET name = $2;";
+            db.Execute(n1ql, beer.Id, newBeerName);
 
             // get the beer back out to make sure it was updated correctly
             var beerAgain = db.Query<Beer>().First(b => N1QlFunctions.Meta(b).Id == beer.Id);

--- a/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
@@ -379,7 +379,7 @@ namespace Couchbase.Linq.IntegrationTests
 
             // execute N1QL to update the beer
             var newBeerName = Guid.NewGuid().ToString();
-            var n1ql = $"UPDATE `beer-sample` USE KEYS '{beer.Id}' SET name = '{newBeerName}';";
+            var n1ql = string.Format("UPDATE `beer-sample` USE KEYS '{0}' SET name = '{1}';", beer.Id, newBeerName);
             db.Bucket.Query<int>(n1ql);
 
             // get the beer back out to make sure it was updated correctly

--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -24,7 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>5</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -24,7 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>5</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq.Views/Couchbase.Linq.Views.csproj
+++ b/Src/Couchbase.Linq.Views/Couchbase.Linq.Views.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq.Views/Couchbase.Linq.Views.csproj
+++ b/Src/Couchbase.Linq.Views/Couchbase.Linq.Views.csproj
@@ -22,7 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>5</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -24,7 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Couchbase.Linq.xml</DocumentationFile>
-    <LangVersion>5</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Couchbase.Linq.xml</DocumentationFile>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -59,5 +59,11 @@ namespace Couchbase.Linq
         /// If true, generate change tracking proxies for documents during deserialization. Defaults to false for higher performance queries.
         /// </summary>
         bool ChangeTrackingEnabled { get; }
+
+        /// <summary>
+        /// Access to the underlying Bucket to drop down to lower-level API when necessary.
+        /// </summary>
+        IBucket Bucket { get; }
+
     }
 }

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
+using Couchbase.N1QL;
 
 namespace Couchbase.Linq
 {
@@ -61,9 +62,8 @@ namespace Couchbase.Linq
         bool ChangeTrackingEnabled { get; }
 
         /// <summary>
-        /// Access to the underlying Bucket to drop down to lower-level API when necessary.
+        /// Execute a N1QL statement
         /// </summary>
-        IBucket Bucket { get; }
-
+        void Execute(string statement, params object[] parameters);
     }
 }


### PR DESCRIPTION
I thought it might be useful to be able to get to the underlying IBucket from a BucketContext: to drop down to lower-level functionality when necessary.

I also added an integration test that uses the exposed Bucket (it just runs a raw N1QL query).

Please let me know what you think.