### PR TITLE
Support for Couchbase 4.5 index joins

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestSetup.cs" />
     <Compile Include="TestConfigurations.cs" />
+    <Compile Include="Versioning\DefaultVersionProviderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Couchbase.Linq\Couchbase.Linq.csproj">

--- a/Src/Couchbase.Linq.IntegrationTests/Versioning/DefaultVersionProviderTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/Versioning/DefaultVersionProviderTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Linq.Versioning;
+using NUnit.Framework;
+using Moq;
+
+namespace Couchbase.Linq.IntegrationTests.Versioning
+{
+    [TestFixture]
+    class DefaultVersionProviderTests
+    {
+        [Test]
+        public void GetVersionNumber_ReturnsVersion()
+        {
+            // Arrange
+
+            var provider = new DefaultVersionProvider();
+
+            // Act
+
+            var version = provider.GetVersion(ClusterHelper.GetBucket("beer-sample"));
+
+            // Assert
+
+            Assert.NotNull(version);
+        }
+
+        [Test]
+        public void GetVersionNumber_NoDeadlock()
+        {
+            // Using an asynchronous HttpClient request within an MVC Web API action may cause
+            // a deadlock when we wait for the result synchronously.
+
+            var context = new Mock<SynchronizationContext>
+            {
+                CallBase = true
+            };
+
+            SynchronizationContext.SetSynchronizationContext(context.Object);
+            try
+            {
+                var provider = new DefaultVersionProvider();
+
+                provider.GetVersion(ClusterHelper.GetBucket("beer-sample"));
+
+                // If view queries are incorrectly awaiting on the current SynchronizationContext
+                // We will see calls to Post or Send on the mock
+
+                context.Verify(m => m.Post(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()), Times.Never);
+                context.Verify(m => m.Send(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()), Times.Never);
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+            }
+        }
+    }
+}

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -149,6 +149,7 @@
     <Compile Include="QueryGeneration\TakeAndSkipTests.cs" />
     <Compile Include="QueryGeneration\WhereClauseTests.cs" />
     <Compile Include="TestConfigurations.cs" />
+    <Compile Include="Versioning\DefaultVersionProviderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Couchbase.Linq\Couchbase.Linq.csproj">

--- a/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
@@ -39,7 +39,17 @@ namespace Couchbase.Linq.UnitTests
             return CreateN1QlQuery(bucket, expression, false);
         }
 
+        protected string CreateN1QlQuery(IBucket bucket, Expression expression, Version clusterVersion)
+        {
+            return CreateN1QlQuery(bucket, expression, clusterVersion, false);
+        }
+
         protected string CreateN1QlQuery(IBucket bucket, Expression expression, bool selectDocumentMetadata)
+        {
+            return CreateN1QlQuery(bucket, expression, new Version(4, 0, 0), selectDocumentMetadata);
+        }
+
+        protected string CreateN1QlQuery(IBucket bucket, Expression expression, Version clusterVersion, bool selectDocumentMetadata)
         {
             var queryModel = QueryParserHelper.CreateQueryParser().GetParsedQuery(expression);
 
@@ -48,7 +58,8 @@ namespace Couchbase.Linq.UnitTests
                 MemberNameResolver = MemberNameResolver,
                 MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider(),
                 Serializer = new Core.Serialization.DefaultSerializer(),
-                SelectDocumentMetadata = selectDocumentMetadata
+                SelectDocumentMetadata = selectDocumentMetadata,
+                ClusterVersion = clusterVersion
             };
 
             var visitor = new N1QlQueryModelVisitor(queryGenerationContext);

--- a/Src/Couchbase.Linq.UnitTests/Versioning/DefaultVersionProviderTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Versioning/DefaultVersionProviderTests.cs
@@ -1,0 +1,540 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Configuration.Client;
+using Couchbase.Core;
+using Couchbase.Linq.Versioning;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.Versioning
+{
+    [TestFixture]
+    public class DefaultVersionProviderTests
+    {
+        private static readonly Version Version40 = new Version(4, 0, 0);
+        private static readonly Version Version45 = new Version(4, 5, 0);
+
+        private static readonly Uri Uri1 = new Uri("http://abc.def");
+        private static readonly Uri Uri2 = new Uri("http://def.abc");
+
+        #region GetVersion
+
+        [Test]
+        public void GetVersion_Succeeds_ReturnsVersion()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket
+                .SetupGet(m => m.Configuration)
+                .Returns(new BucketConfiguration()
+                {
+                    PoolConfiguration = new PoolConfiguration()
+                    {
+                        ClientConfiguration = new ClientConfiguration()
+                        {
+                            Servers = new List<Uri>
+                            {
+                                Uri1
+                            }
+                        }
+                    }
+                });
+
+            var provider = new Mock<DefaultVersionProvider>()
+            {
+                CallBase = true
+            };
+
+            provider
+                .Setup(m => m.DownloadConfig(It.IsAny<Uri>()))
+                .ReturnsAsync(new DefaultVersionProvider.Bootstrap()
+                {
+                    ImplementationVersion = "4.5.0"
+                });
+
+            // Act
+
+            var result = provider.Object.GetVersion(bucket.Object);
+
+            // Assert
+
+            Assert.AreEqual(Version45, result);
+        }
+
+        [Test]
+        public void GetVersion_Succeeds_CachesResult()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket
+                .SetupGet(m => m.Configuration)
+                .Returns(new BucketConfiguration()
+                {
+                    PoolConfiguration = new PoolConfiguration()
+                    {
+                        ClientConfiguration = new ClientConfiguration()
+                        {
+                            Servers = new List<Uri>
+                            {
+                                Uri1,
+                                Uri2
+                            }
+                        }
+                    }
+                });
+
+            var provider = new Mock<DefaultVersionProvider>()
+            {
+                CallBase = true
+            };
+
+            provider
+                .Setup(m => m.DownloadConfig(It.IsAny<Uri>()))
+                .ReturnsAsync(new DefaultVersionProvider.Bootstrap()
+                {
+                    ImplementationVersion = "4.5.0"
+                });
+
+            // Act
+
+            provider.Object.GetVersion(bucket.Object);
+
+            // Assert
+
+            provider
+                .Verify(
+                    m => m.CacheStore(It.Is<List<Uri>>(p => p.Contains(Uri1) && p.Contains(Uri2)), Version45),
+                    Times.Once);
+        }
+
+        [Test]
+        public void GetVersion_Fails_Returns4()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket
+                .SetupGet(m => m.Configuration)
+                .Returns(new BucketConfiguration()
+                {
+                    PoolConfiguration = new PoolConfiguration()
+                    {
+                        ClientConfiguration = new ClientConfiguration()
+                        {
+                            Servers = new List<Uri>
+                            {
+                                Uri1
+                            }
+                        }
+                    }
+                });
+
+            var provider = new Mock<DefaultVersionProvider>()
+            {
+                CallBase = true
+            };
+
+            provider
+                .Setup(m => m.DownloadConfig(It.IsAny<Uri>()))
+                .ReturnsAsync(null);
+
+            // Act
+
+            var result = provider.Object.GetVersion(bucket.Object);
+
+            // Assert
+
+            Assert.AreEqual(Version40, result);
+        }
+
+        [Test]
+        public void GetVersion_DownloadThrowsException_Returns4()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket
+                .SetupGet(m => m.Configuration)
+                .Returns(new BucketConfiguration()
+                {
+                    PoolConfiguration = new PoolConfiguration()
+                    {
+                        ClientConfiguration = new ClientConfiguration()
+                        {
+                            Servers = new List<Uri>
+                            {
+                                Uri1
+                            }
+                        }
+                    }
+                });
+
+            var provider = new Mock<DefaultVersionProvider>()
+            {
+                CallBase = true
+            };
+
+            provider
+                .Setup(m => m.DownloadConfig(It.IsAny<Uri>()))
+                .ThrowsAsync(new ApplicationException());
+
+            // Act
+
+            var result = provider.Object.GetVersion(bucket.Object);
+
+            // Assert
+
+            Assert.AreEqual(Version40, result);
+        }
+
+        [Test]
+        public void GetVersion_Fails_CachesResult()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket
+                .SetupGet(m => m.Configuration)
+                .Returns(new BucketConfiguration()
+                {
+                    PoolConfiguration = new PoolConfiguration()
+                    {
+                        ClientConfiguration = new ClientConfiguration()
+                        {
+                            Servers = new List<Uri>
+                            {
+                                Uri1,
+                                Uri2
+                            }
+                        }
+                    }
+                });
+
+            var provider = new Mock<DefaultVersionProvider>()
+            {
+                CallBase = true
+            };
+
+            provider
+                .Setup(m => m.DownloadConfig(It.IsAny<Uri>()))
+                .ReturnsAsync(null);
+
+            // Act
+
+            provider.Object.GetVersion(bucket.Object);
+
+            // Assert
+
+            provider
+                .Verify(
+                    m => m.CacheStore(It.Is<List<Uri>>(p => p.Contains(Uri1) && p.Contains(Uri2)), Version40),
+                    Times.Once);
+        }
+
+        [Test]
+        public void GetVersion_FirstDownloadFails_ReturnsSecond()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket
+                .SetupGet(m => m.Configuration)
+                .Returns(new BucketConfiguration()
+                {
+                    PoolConfiguration = new PoolConfiguration()
+                    {
+                        ClientConfiguration = new ClientConfiguration()
+                        {
+                            Servers = new List<Uri>
+                            {
+                                Uri1,
+                                Uri2
+                            }
+                        }
+                    }
+                });
+
+            var provider = new Mock<DefaultVersionProvider>()
+            {
+                CallBase = true
+            };
+
+            provider
+                .Setup(m => m.Shuffle(It.IsAny<List<Uri>>()))
+                .Returns((List<Uri> p1) => p1);
+            provider
+                .Setup(m => m.DownloadConfig(Uri1))
+                .ReturnsAsync(null);
+            provider
+                .Setup(m => m.DownloadConfig(Uri2))
+                .ReturnsAsync(new DefaultVersionProvider.Bootstrap()
+                {
+                    ImplementationVersion = "4.5.0"
+                });
+
+            // Act
+
+            var result = provider.Object.GetVersion(bucket.Object);
+
+            // Assert
+
+            Assert.AreEqual(Version45, result);
+        }
+
+        [Test]
+        public void GetVersion_FirstDownloadThrowsException_ReturnsSecond()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket
+                .SetupGet(m => m.Configuration)
+                .Returns(new BucketConfiguration()
+                {
+                    PoolConfiguration = new PoolConfiguration()
+                    {
+                        ClientConfiguration = new ClientConfiguration()
+                        {
+                            Servers = new List<Uri>
+                            {
+                                Uri1,
+                                Uri2
+                            }
+                        }
+                    }
+                });
+
+            var provider = new Mock<DefaultVersionProvider>()
+            {
+                CallBase = true
+            };
+
+            provider
+                .Setup(m => m.Shuffle(It.IsAny<List<Uri>>()))
+                .Returns((List<Uri> p1) => p1);
+            provider
+                .Setup(m => m.DownloadConfig(Uri1))
+                .ThrowsAsync(new ApplicationException());
+            provider
+                .Setup(m => m.DownloadConfig(Uri2))
+                .ReturnsAsync(new DefaultVersionProvider.Bootstrap()
+                {
+                    ImplementationVersion = "4.5.0"
+                });
+
+            // Act
+
+            var result = provider.Object.GetVersion(bucket.Object);
+
+            // Assert
+
+            Assert.AreEqual(Version45, result);
+        }
+
+        #endregion
+
+        #region CacheLookup/CacheStore
+
+        [Test]
+        public void CacheLookup_EmptyCache_ReturnsNull()
+        {
+            // Arrange
+
+            var servers = new List<Uri>
+            {
+                Uri1
+            };
+
+            var provider = new DefaultVersionProvider();
+
+            // Act
+
+            var result = provider.CacheLookup(servers);
+
+            // Assert
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void CacheLookup_IsInCache_ReturnsVersion()
+        {
+            // Arrange
+
+            var servers = new List<Uri>
+            {
+                Uri1
+            };
+
+            var provider = new DefaultVersionProvider();
+
+            provider.CacheStore(servers, Version45);
+
+            // Act
+
+            var result = provider.CacheLookup(servers);
+
+            // Assert
+
+            Assert.AreEqual(Version45, result);
+        }
+
+        [Test]
+        public void CacheLookup_MultipleUrisOneInCache_ReturnsVersion()
+        {
+            // Arrange
+
+            var servers1 = new List<Uri>
+            {
+                Uri1
+            };
+
+            var servers2 = new List<Uri>
+            {
+                Uri2
+            };
+
+            var provider = new DefaultVersionProvider();
+
+            provider.CacheStore(servers2, Version45);
+
+            // Act
+
+            var result = provider.CacheLookup(servers1.Concat(servers2));
+
+            // Assert
+
+            Assert.AreEqual(Version45, result);
+        }
+
+        [Test]
+        public void CacheStore_MultipleUris_StoresAll()
+        {
+            // Arrange
+
+            var servers = new List<Uri>
+            {
+                Uri1,
+                Uri2
+            };
+
+            var provider = new DefaultVersionProvider();
+
+            // Act
+
+            provider.CacheStore(servers, Version45);
+
+            // Assert
+
+            var result = provider.CacheLookup(servers.Take(1));
+            Assert.AreEqual(Version45, result);
+
+            result = provider.CacheLookup(servers.Skip(1));
+            Assert.AreEqual(Version45, result);
+        }
+
+        #endregion
+
+        #region ExtractVersion
+
+        [Test]
+        public void ExtractVersion_NullConfig_ReturnsNull()
+        {
+            // Arrange
+
+            var provider = new DefaultVersionProvider();
+
+            // Act
+
+            var result = provider.ExtractVersion(null);
+
+            // Assert
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ExtractVersion_EmptyVersion_ReturnsNull()
+        {
+            // Arrange
+
+            var provider = new DefaultVersionProvider();
+
+            // Act
+
+            var result = provider.ExtractVersion(new DefaultVersionProvider.Bootstrap()
+            {
+                ImplementationVersion = ""
+            });
+
+            // Assert
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ExtractVersion_VersionWithoutDash_ReturnsVersion()
+        {
+            // Arrange
+
+            var provider = new DefaultVersionProvider();
+
+            // Act
+
+            var result = provider.ExtractVersion(new DefaultVersionProvider.Bootstrap()
+            {
+                ImplementationVersion = "4.5.0"
+            });
+
+            // Assert
+
+            Assert.AreEqual(Version45, result);
+        }
+
+        [Test]
+        public void ExtractVersion_VersionWithDash_ReturnsVersion()
+        {
+            // Arrange
+
+            var provider = new DefaultVersionProvider();
+
+            // Act
+
+            var result = provider.ExtractVersion(new DefaultVersionProvider.Bootstrap()
+            {
+                ImplementationVersion = "4.5.0-somethingelse"
+            });
+
+            // Assert
+
+            Assert.AreEqual(Version45, result);
+        }
+
+        [Test]
+        public void ExtractVersion_InvalidVersion_ReturnsNull()
+        {
+            // Arrange
+
+            var provider = new DefaultVersionProvider();
+
+            // Act
+
+            var result = provider.ExtractVersion(new DefaultVersionProvider.Bootstrap()
+            {
+                ImplementationVersion = "4.5.0a"
+            });
+
+            // Assert
+
+            Assert.IsNull(result);
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -81,6 +81,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -192,6 +193,10 @@
     <Compile Include="QueryParserHelper.cs" />
     <Compile Include="UnixMillisecondsDateTime.cs" />
     <Compile Include="Utils\ExceptionMsgs.cs" />
+    <Compile Include="Versioning\DefaultVersionProvider.cs" />
+    <Compile Include="Versioning\FeatureVersions.cs" />
+    <Compile Include="Versioning\IVersionProvider.cs" />
+    <Compile Include="Versioning\VersionProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
@@ -11,6 +11,7 @@ using Couchbase.Linq.Operators;
 using Couchbase.Linq.QueryGeneration;
 using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
 using Couchbase.Linq.Utils;
+using Couchbase.Linq.Versioning;
 using Couchbase.N1QL;
 using Newtonsoft.Json;
 using Remotion.Linq;
@@ -244,7 +245,8 @@ namespace Couchbase.Linq.Execution
                 MemberNameResolver = memberNameResolver,
                 MethodCallTranslatorProvider = methodCallTranslatorProvider,
                 Serializer = serializer,
-                SelectDocumentMetadata = selectDocumentMetadata
+                SelectDocumentMetadata = selectDocumentMetadata,
+                ClusterVersion = VersionProvider.Current.GetVersion(_bucket)
             };
 
             var visitor = new N1QlQueryModelVisitor(queryGenerationContext);

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLFromQueryPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLFromQueryPart.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Text;
 using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.QueryGeneration
@@ -29,5 +30,37 @@ namespace Couchbase.Linq.QueryGeneration
         /// </summary>
         public string OnKeys { get; set; }
 
+        /// <summary>
+        /// For index joins, the name of the extent on the left side of the join.  Should already be escaped.
+        /// </summary>
+        public string IndexJoinExtentName { get; set; }
+
+        /// <summary>
+        /// If true, indicates that this is an index join where the primary key reference is on the left side instead of the right side.
+        /// </summary>
+        public bool IsIndexJoin
+        {
+            get { return !string.IsNullOrEmpty(IndexJoinExtentName); }
+        }
+
+        public void AppendToStringBuilder(StringBuilder sb)
+        {
+            sb.AppendFormat(" {0} {1} as {2}",
+                JoinType,
+                Source,
+                ItemName);
+
+            if (!string.IsNullOrEmpty(OnKeys))
+            {
+                if (!IsIndexJoin)
+                {
+                    sb.AppendFormat(" ON KEYS {0}", OnKeys);
+                }
+                else
+                {
+                    sb.AppendFormat(" ON KEY {0} FOR {1}", OnKeys, IndexJoinExtentName);
+                }
+            }
+        }
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Core.Serialization;
 using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
+using Couchbase.Linq.Versioning;
 using Newtonsoft.Json.Serialization;
 using Remotion.Linq.Clauses.Expressions;
 
@@ -21,6 +22,7 @@ namespace Couchbase.Linq.QueryGeneration
         public IMethodCallTranslatorProvider MethodCallTranslatorProvider { get; set; }
         public ParameterAggregator ParameterAggregator { get; set; }
         public ITypeSerializer Serializer { get; set; }
+        public Version ClusterVersion { get; set; }
 
         /// <summary>
         /// Stores a reference to the current grouping subquery
@@ -52,7 +54,8 @@ namespace Couchbase.Linq.QueryGeneration
                 MemberNameResolver = MemberNameResolver,
                 MethodCallTranslatorProvider = MethodCallTranslatorProvider,
                 ParameterAggregator = ParameterAggregator,
-                Serializer = Serializer
+                Serializer = Serializer,
+                ClusterVersion = ClusterVersion
             };
         }
     }

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -250,16 +250,8 @@ namespace Couchbase.Linq.QueryGeneration
 
                 foreach (var joinPart in FromParts.Skip(1))
                 {
-                    sb.AppendFormat(" {0} {1} as {2}",
-                        joinPart.JoinType,
-                        joinPart.Source,
-                        joinPart.ItemName);
-
-                    if (!string.IsNullOrEmpty(joinPart.OnKeys))
-                    {
-                        sb.AppendFormat(" ON KEYS {0}", joinPart.OnKeys);
-                    }
-               }
+                    joinPart.AppendToStringBuilder(sb);
+                }
             }
 
             ApplyLetParts(sb);
@@ -343,15 +335,7 @@ namespace Couchbase.Linq.QueryGeneration
 
                 foreach (var joinPart in FromParts.Skip(1))
                 {
-                    sb.AppendFormat(" {0} {1} as {2}",
-                        joinPart.JoinType,
-                        joinPart.Source,
-                        joinPart.ItemName);
-
-                    if (!string.IsNullOrEmpty(joinPart.OnKeys))
-                    {
-                        sb.AppendFormat(" ON KEYS {0}", joinPart.OnKeys);
-                    }
+                    joinPart.AppendToStringBuilder(sb);
                 }
             }
 

--- a/Src/Couchbase.Linq/Versioning/DefaultVersionProvider.cs
+++ b/Src/Couchbase.Linq/Versioning/DefaultVersionProvider.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Common.Logging;
+using Couchbase.Core;
+using Newtonsoft.Json;
+
+namespace Couchbase.Linq.Versioning
+{
+    /// <summary>
+    /// Provides the version for a bucket based on the implementationVersion returned by calls
+    /// to http://node-ip:8091/pools.  Caches the results for quick results on future calls.
+    /// </summary>
+    internal class DefaultVersionProvider : IVersionProvider
+    {
+        private static readonly Random Random = new Random();
+        private static readonly ILog Log = LogManager.GetLogger<DefaultVersionProvider>();
+
+        private readonly ConcurrentDictionary<Uri, Version> _versionsByUri = new ConcurrentDictionary<Uri, Version>();
+        private readonly object _lock = new object();
+
+        /// <summary>
+        /// Gets the version of the cluster hosting a bucket, using the cluster's
+        /// <see cref="Couchbase.Configuration.Client.ClientConfiguration"/>.
+        /// </summary>
+        /// <param name="bucket">Couchbase bucket.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="bucket"/> is null.</exception>
+        /// <returns>The version of the cluster hosting this bucket, or 4.0.0 if unable to determine the version.</returns>
+        public Version GetVersion(IBucket bucket)
+        {
+            if (bucket == null)
+            {
+                throw new ArgumentNullException("bucket");
+            }
+
+            var servers = bucket.Configuration.PoolConfiguration.ClientConfiguration.Servers;
+
+            // First check for an existing result
+            var version = CacheLookup(servers);
+            if (version != null)
+            {
+                return version;
+            }
+
+            var contextCache = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            try
+            {
+                // Only check one cluster at a time, this prevents multiple lookups during bootstrap
+                lock (_lock)
+                {
+                    // In case the version was received while we were waiting for the lock, check for it again
+                    version = CacheLookup(servers);
+                    if (version != null)
+                    {
+                        return version;
+                    }
+
+                    foreach (var server in Shuffle(servers))
+                    {
+                        try
+                        {
+                            var config = DownloadConfig(server).Result;
+
+                            version = ExtractVersion(config);
+                            if (version != null)
+                            {
+                                CacheStore(servers, version);
+
+                                return version;
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            Log.ErrorFormat("Unable to load config from {0}", e, server);
+                        }
+                    }
+
+                    // No version information could be loaded from any node
+                    var fallbackVersion = new Version(4, 0, 0);
+                    CacheStore(servers, fallbackVersion);
+                    return fallbackVersion;
+                }
+            }
+            finally
+            {
+                if (contextCache != null)
+                {
+                    SynchronizationContext.SetSynchronizationContext(contextCache);
+                }
+            }
+        }
+
+        internal virtual async Task<Bootstrap> DownloadConfig(Uri uri)
+        {
+            try
+            {
+                using (var handler = new WebRequestHandler())
+                {
+                    handler.ServerCertificateValidationCallback = ServerCertificateValidationCallback;
+
+                    using (var httpClient = new HttpClient(handler))
+                    {
+                        httpClient.Timeout = TimeSpan.FromSeconds(5);
+
+                        var response = await httpClient.GetAsync(uri);
+
+                        response.EnsureSuccessStatusCode();
+
+                        return JsonConvert.DeserializeObject<Bootstrap>(await response.Content.ReadAsStringAsync());
+                    }
+                }
+            }
+            catch (AggregateException ex)
+            {
+                // Unwrap the aggregate exception
+                throw new HttpRequestException(ex.InnerException.Message, ex.InnerException);
+            }
+        }
+
+        private static bool ServerCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        {
+            Log.Info(m => m("Validating certificate: {0}", sslPolicyErrors));
+            return sslPolicyErrors == SslPolicyErrors.None;
+        }
+
+        internal virtual Version ExtractVersion(Bootstrap config)
+        {
+            if ((config == null) || string.IsNullOrEmpty(config.ImplementationVersion))
+            {
+                return null;
+            }
+
+            var versionStr = config.ImplementationVersion.Split('-')[0];
+
+            Version version;
+            if (Version.TryParse(versionStr, out version))
+            {
+                return version;
+            }
+            else
+            {
+                Log.ErrorFormat("Invalid version string {0}", versionStr);
+                return null;
+            }
+        }
+
+        internal virtual List<T> Shuffle<T>(List<T> list)
+        {
+            list = new List<T>(list);
+
+            var length = list.Count;
+            while (length > 1)
+            {
+                length--;
+                var index = Random.Next(length + 1);
+                var item = list[index];
+                list[index] = list[length];
+                list[length] = item;
+            }
+            return list;
+        }
+
+        internal virtual Version CacheLookup(IEnumerable<Uri> servers)
+        {
+            foreach (var server in servers)
+            {
+                Version version;
+                if (_versionsByUri.TryGetValue(server, out version))
+                {
+                    return version;
+                }
+            }
+
+            return null;
+        }
+
+        internal virtual void CacheStore(IEnumerable<Uri> servers, Version version)
+        {
+            foreach (var server in servers)
+            {
+                _versionsByUri.AddOrUpdate(server, version, (key, oldValue) => version);
+            }
+        }
+
+        // ReSharper disable once ClassNeverInstantiated.Local
+        internal class Bootstrap
+        {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            [JsonProperty("implementationVersion")]
+            public string ImplementationVersion { get; set; }
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
+++ b/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.Versioning
+{
+    /// <summary>
+    /// Constants for the Couchbase versions where new features are implemented.
+    /// </summary>
+    internal static class FeatureVersions
+    {
+        /// <summary>
+        /// Version where support was added for index-based joins where the primary key for the join
+        /// is on the left instead of the right.
+        /// </summary>
+        public static readonly Version IndexJoin = new Version(4, 5, 0);
+    }
+}

--- a/Src/Couchbase.Linq/Versioning/IVersionProvider.cs
+++ b/Src/Couchbase.Linq/Versioning/IVersionProvider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Couchbase.Core;
+
+namespace Couchbase.Linq.Versioning
+{
+    /// <summary>
+    /// Provides the Couchbase version for a bucket.
+    /// </summary>
+    internal interface IVersionProvider
+    {
+        /// <summary>
+        /// Gets the version of the cluster hosting a bucket, using the cluster's
+        /// <see cref="Couchbase.Configuration.Client.ClientConfiguration"/>.
+        /// </summary>
+        /// <param name="bucket">Couchbase bucket.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="bucket"/> is null.</exception>
+        /// <returns>The version of the cluster hosting this bucket, or 4.0.0 if unable to determine the version.</returns>
+        Version GetVersion(IBucket bucket);
+    }
+}

--- a/Src/Couchbase.Linq/Versioning/VersionProvider.cs
+++ b/Src/Couchbase.Linq/Versioning/VersionProvider.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.Versioning
+{
+    /// <summary>
+    /// Singleton for the <see cref="IVersionProvider"/> implementation in use for query generation.
+    /// </summary>
+    internal static class VersionProvider
+    {
+        /// <summary>
+        /// Singleton for the <see cref="IVersionProvider"/> implementation in use for query generation.
+        /// </summary>
+        public static IVersionProvider Current { get; set; } = new DefaultVersionProvider();
+    }
+}


### PR DESCRIPTION
Motivation
----------
Couchbase 4.5 allows for flexible commutative joins, aka index joins.  For
more information, see
http://developer.couchbase.com/documentation/server/4.5-dp/flexible-join-n1ql.html.

Modifications
-------------
Added Versioning namespace, which defines a provider for determining and
caching the version number for a cluster.  This includes a suite of unit
and integration tests.

Updated the query generation system to output index joins when detected in
the LINQ query, but only if the cluster is on version 4.5 or later.  If
the cluster isn't on version 4.5, a NotSupportedException is thrown which
is consistent with previous behaviors.

Results
-------
Index joins can now be used against 4.5 clusters.

The behavior is largely unaffected for clients running against 4.0 and 4.1
clusters.  Differences include additional logs, a slight change to an
exception message, and a miniscule delay on the first query while the
version number of the cluster is determined.