### PR TITLE
enforce C# 5 via csproj, updated a static initializer to use constructor

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq.Views/Couchbase.Linq.Views.csproj
+++ b/Src/Couchbase.Linq.Views/Couchbase.Linq.Views.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Couchbase.Linq.xml</DocumentationFile>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Src/Couchbase.Linq/Versioning/VersionProvider.cs
+++ b/Src/Couchbase.Linq/Versioning/VersionProvider.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Couchbase.Linq.Versioning
+﻿namespace Couchbase.Linq.Versioning
 {
     /// <summary>
     /// Singleton for the <see cref="IVersionProvider"/> implementation in use for query generation.
     /// </summary>
     internal static class VersionProvider
     {
+        static VersionProvider()
+        {
+            Current = new DefaultVersionProvider();
+        }
+
         /// <summary>
         /// Singleton for the <see cref="IVersionProvider"/> implementation in use for query generation.
         /// </summary>
-        public static IVersionProvider Current { get; set; } = new DefaultVersionProvider();
+        public static IVersionProvider Current { get; set; }
     }
 }


### PR DESCRIPTION
This will enforce the use of C# 5 via csproj files.

I also removed a use of a C# 6 language feature (see https://github.com/couchbaselabs/Linq2Couchbase/commit/0f17237e1f3ca07e680981f145ad6a3c2d5165a8)