### PR TITLE
Support for RYOW with Couchbase Server 4.5

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/App.config
+++ b/Src/Couchbase.Linq.IntegrationTests/App.config
@@ -6,8 +6,7 @@
     </sectionGroup>
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
     <sectionGroup name="couchbaseClients">
-      <section name="couchbase"
-               type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+      <section name="couchbase" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
     </sectionGroup>
   </configSections>
   <couchbaseClients>
@@ -17,7 +16,7 @@
         <add uri="http://localhost:8091"></add>
       </servers>
       <buckets>
-        <add></add>
+        <add name="beer-sample" useEnhancedDurability="true"></add>
       </buckets>
     </couchbase>
   </couchbaseClients>
@@ -46,11 +45,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -51,28 +51,28 @@
       <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.3.3.0\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.Core.3.3.0\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging.Log4Net1213, Version=3.3.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.0\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
+    <Reference Include="Common.Logging.Log4Net1213, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.1\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.2.2.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.2.2\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.3.1.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.3.1\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Src/Couchbase.Linq.IntegrationTests/TestConfigurations.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/TestConfigurations.cs
@@ -14,7 +14,8 @@ namespace Couchbase.Linq.IntegrationTests
         private static ClientConfiguration DefaultLocalhostConfig()
         {
             var section = (CouchbaseClientSection)ConfigurationManager.GetSection("couchbaseClients/couchbase");
-            return new ClientConfiguration(section);
+            var config = new ClientConfiguration(section);
+            return config;
         }
     }
 }

--- a/Src/Couchbase.Linq.IntegrationTests/packages.config
+++ b/Src/Couchbase.Linq.IntegrationTests/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="Common.Logging" version="3.3.0" targetFramework="net45" />
-  <package id="Common.Logging.Core" version="3.3.0" targetFramework="net45" />
-  <package id="Common.Logging.Log4Net1213" version="3.3.0" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.2.2" targetFramework="net45" />
+  <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
+  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
+  <package id="Common.Logging.Log4Net1213" version="3.3.1" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.3.1" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.0.1" targetFramework="net45" />

--- a/Src/Couchbase.Linq.UnitTests/App.config
+++ b/Src/Couchbase.Linq.UnitTests/App.config
@@ -6,8 +6,7 @@
     </sectionGroup>
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
     <sectionGroup name="couchbaseClients">
-      <section name="couchbase"
-               type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
+      <section name="couchbase" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
     </sectionGroup>
   </configSections>
   <couchbaseClients>
@@ -46,11 +45,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Src/Couchbase.Linq.UnitTests/BucketQueryExecutorEmulator.cs
+++ b/Src/Couchbase.Linq.UnitTests/BucketQueryExecutorEmulator.cs
@@ -42,6 +42,10 @@ namespace Couchbase.Linq.UnitTests
             _test = test;
         }
 
+        public void ConsistentWith(MutationState state)
+        {
+        }
+
         public IEnumerable<T> ExecuteCollection<T>(QueryModel queryModel)
         {
             _query = ExecuteCollection(queryModel);

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -47,28 +47,28 @@
     <DelaySign>false</DelaySign>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging, Version=3.3.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.3.3.0\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.Core.3.3.0\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging.Log4Net1213, Version=3.3.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.0\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
+    <Reference Include="Common.Logging.Log4Net1213, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.1\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.2.2.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.2.2\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.3.1.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.3.1\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Src/Couchbase.Linq.UnitTests/packages.config
+++ b/Src/Couchbase.Linq.UnitTests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Common.Logging" version="3.3.0" targetFramework="net45" />
-  <package id="Common.Logging.Core" version="3.3.0" targetFramework="net45" />
-  <package id="Common.Logging.Log4Net1213" version="3.3.0" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.2.2" targetFramework="net45" />
+  <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
+  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
+  <package id="Common.Logging.Log4Net1213" version="3.3.1" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.3.1" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.0.1" targetFramework="net45" />

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -59,16 +59,16 @@
       <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.3.3.0\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.Core.3.3.0\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.2.2.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.2.2\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.3.1.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.3.1\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Src/Couchbase.Linq/Execution/IBucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/IBucketQueryExecutor.cs
@@ -20,10 +20,17 @@ namespace Couchbase.Linq.Execution
         ScanConsistency? ScanConsistency { get; set; }
 
         /// <summary>
-        /// Specifies the maximum time the client is willing to wait for an index to catch up to the vector timestamp in the request.
+        /// Specifies the maximum time the client is willing to wait for an index to catch up to the consistency requirement in the request.
         /// If an index has to catch up, and the time is exceed doing so, an error is returned.
         /// </summary>
         TimeSpan? ScanWait { get; set; }
+
+        /// <summary>
+        /// Requires that the indexes but up to date with a <see cref="MutationState"/> before the query is executed.
+        /// </summary>
+        /// <param name="state"><see cref="MutationState"/> used for conistency controls.</param>
+        /// <remarks>If called multiple times, the states from the calls are combined.</remarks>
+        void ConsistentWith(MutationState state);
 
         /// <summary>
         /// Asynchronously execute a <see cref="LinqQueryRequest"/>.

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
+using Couchbase.N1QL;
 
 namespace Couchbase.Linq
 {
@@ -59,5 +60,31 @@ namespace Couchbase.Linq
         /// If true, generate change tracking proxies for documents during deserialization. Defaults to false for higher performance queries.
         /// </summary>
         bool ChangeTrackingEnabled { get; }
+
+        #region Mutation State
+
+        /// <summary>
+        /// The current <see cref="N1QL.MutationState"/>.  May return null if there
+        /// have been no mutations.
+        /// </summary>
+        /// <remarks>
+        /// This value is updated as mutations are applied via <see cref="Save{T}"/>.  It may be used
+        /// to enable read-your-own-write by passing the value to <see cref="Extensions.QueryExtensions.ConsistentWith{T}"/>.
+        /// If you are using change tracking, this value won't be valid until after a call to <see cref="SubmitChanges"/>.
+        /// This function is only supported on Couchbase Server 4.5 or later.
+        /// </remarks>
+        MutationState MutationState { get; }
+
+        /// <summary>
+        /// Resets the <see cref="MutationState"/> to start a new set of mutations.
+        /// </summary>
+        /// <remarks>
+        /// If you are using an <see cref="IBucketContext"/> over and extended period of time,
+        /// performing a reset regularly is recommend.  This will help keep the size of the
+        /// <see cref="MutationState"/> to a minimum.
+        /// </remarks>
+        void ResetMutationState();
+
+        #endregion
     }
 }

--- a/Src/Couchbase.Linq/Proxies/DocumentProxyDataMapper.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentProxyDataMapper.cs
@@ -56,7 +56,7 @@ namespace Couchbase.Linq.Proxies
         /// <typeparam name="T">The type of document to deserialize.</typeparam>
         /// <param name="stream">The <see cref="Stream"/> results of the query.</param>
         /// <returns>An object deserialized to it's T type.</returns>
-        public T Map<T>(Stream stream)
+        public T Map<T>(Stream stream) where T : class
         {
             var queryResults = _serializer.Deserialize<T>(stream);
 

--- a/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
+++ b/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
@@ -16,5 +16,10 @@ namespace Couchbase.Linq.Versioning
         /// is on the left instead of the right.
         /// </summary>
         public static readonly Version IndexJoin = new Version(4, 5, 0);
+
+        /// <summary>
+        /// Version where support was added for RYOW consistency.
+        /// </summary>
+        public static readonly Version ReadYourOwnWrite = new Version(4, 5, 0);
     }
 }

--- a/Src/Couchbase.Linq/packages.config
+++ b/Src/Couchbase.Linq/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="Common.Logging" version="3.3.0" targetFramework="net45" />
-  <package id="Common.Logging.Core" version="3.3.0" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.2.2" targetFramework="net45" />
+  <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
+  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.3.1" targetFramework="net45" />
   <package id="ILRepack" version="2.0.10" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.0.1" targetFramework="net45" />


### PR DESCRIPTION
Motivation
----------
Allow LINQ consumers to use the new read-your-own-write features supplied
with Couchbase Server 4.5.

Modifications
-------------
Updated to Couchbase .Net SDK 2.3.0 to get RYOW support.

Added MutationState property and ResetMutationState method to
IBucketContext.

Added ConsistentWith method to IQueryable extensions, which forwards the
MutationState on to the BucketQueryExecutor.

Added unit and integration tests around the new feature.

Results
-------
Mutation state is available on the BucketContext as mutations are applied
via Save, Remove, and SubmitChanges.  These can then be passed to
subsequent queries using the ConsistentWith extension to support RYOW.