### PR TITLE
Support for USE INDEX statements in queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ NuGet will install the package and all dependencies. Once you have the resolved 
 - [Array Filtering, Projections, and Sorting](docs/array-filtering-projections.md)
 - [Grouping and Aggregation](docs/grouping-aggregation.md)
 - [The UseKeys Method](docs/use-keys.md)
+- [The UseIndex Method](docs/use-index.md)
 - [JOINing Documents](docs/joins.md)
 - [NESTing Documents](docs/nest.md)
 - [UNNESTing Documents](docs/unnest.md)

--- a/Src/Couchbase.Linq.IntegrationTests/App.config
+++ b/Src/Couchbase.Linq.IntegrationTests/App.config
@@ -9,6 +9,10 @@
       <section name="couchbase" type="Couchbase.Configuration.Client.Providers.CouchbaseClientSection, Couchbase.NetClient" />
     </sectionGroup>
   </configSections>
+  <appSettings>
+    <add key="adminusername" value="Administrator" />
+    <add key="adminpassword" value="password" />
+  </appSettings>
   <couchbaseClients>
     <couchbase enableConfigHeartBeat="false">
       <servers>

--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -111,7 +111,7 @@
     <Compile Include="Documents\Brewery.cs" />
     <Compile Include="Documents\BreweryFilter.cs" />
     <Compile Include="Documents\Geo.cs" />
-    <Compile Include="N1QLTestBase.cs" />
+    <Compile Include="N1QlTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestSetup.cs" />
     <Compile Include="TestConfigurations.cs" />

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 namespace Couchbase.Linq.IntegrationTests
 {
     [TestFixture]
-    public class QueryTests
+    public class QueryTests : N1QlTestBase
     {
         [SetUp]
         public void TestSetUp()
@@ -369,6 +369,33 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void UseIndex_SelectDocuments()
+        {
+            // This test simply confirms that the USE INDEX clause generated is valid N1QL.  There's not much point
+            // in the actual USE INDEX clause itself in this query, since the index isn't used in the predicate.
+            // In a real world query, this should be a specific index helpful to the query.
+
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+
+            EnsureIndexExists(bucket, "brewery_id", "brewery_id");
+
+            var context = new BucketContext(bucket);
+
+            var query =
+                from brewery in
+                    context.Query<Brewery>().UseIndex("brewery_id")
+                select new { name = brewery.Name };
+
+            var results = query.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var brewery in results)
+            {
+                Console.WriteLine("Brewery {0}", brewery.name);
+            }
+        }
+
+        [Test]
         public void AnyAllTests_AnyNestedArrayWithFilter()
         {
             var bucket = ClusterHelper.GetBucket("beer-sample");
@@ -625,10 +652,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void JoinTests_InnerJoin_IndexJoin()
         {
-            // To make required index:
-            // CREATE INDEX brewery_id ON `beer-sample` (brewery_id)
-
             var bucket = ClusterHelper.GetBucket("beer-sample");
+
+            EnsureIndexExists(bucket, "brewery_id", "brewery_id");
 
             var clusterVersion = VersionProvider.Current.GetVersion(bucket);
             if (clusterVersion < FeatureVersions.IndexJoin)
@@ -723,10 +749,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void JoinTests_LeftJoin_IndexJoin()
         {
-            // To make required index:
-            // CREATE INDEX brewery_id ON `beer-sample` (brewery_id)
-
             var bucket = ClusterHelper.GetBucket("beer-sample");
+
+            EnsureIndexExists(bucket, "brewery_id", "brewery_id");
 
             var clusterVersion = VersionProvider.Current.GetVersion(bucket);
             if (clusterVersion < FeatureVersions.IndexJoin)
@@ -794,10 +819,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void NestTests_Nest_IndexJoin()
         {
-            // To make required index:
-            // CREATE INDEX brewery_id ON `beer-sample` (brewery_id)
-
             var bucket = ClusterHelper.GetBucket("beer-sample");
+
+            EnsureIndexExists(bucket, "brewery_id", "brewery_id");
 
             var clusterVersion = VersionProvider.Current.GetVersion(bucket);
             if (clusterVersion < FeatureVersions.IndexJoin)
@@ -827,10 +851,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void NestTests_Nest_IndexJoinPrefiltered()
         {
-            // To make required index:
-            // CREATE INDEX brewery_id ON `beer-sample` (brewery_id)
-
             var bucket = ClusterHelper.GetBucket("beer-sample");
+
+            EnsureIndexExists(bucket, "brewery_id", "brewery_id");
 
             var clusterVersion = VersionProvider.Current.GetVersion(bucket);
             if (clusterVersion < FeatureVersions.IndexJoin)

--- a/Src/Couchbase.Linq.IntegrationTests/TestSetup.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/TestSetup.cs
@@ -4,12 +4,14 @@ using NUnit.Framework;
 namespace Couchbase.Linq.IntegrationTests
 {
     [SetUpFixture]
-    public class TestSetup
+    public class TestSetup : N1QlTestBase
     {
         [SetUp]
         public void SetUp()
         {
             ClusterHelper.Initialize(TestConfigurations.DefaultConfig());
+
+            EnsurePrimaryIndexExists(ClusterHelper.GetBucket("beer-sample"));
         }
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/N1QlHelpersTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/N1QlHelpersTests.cs
@@ -33,5 +33,27 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             Assert.Throws<ArgumentNullException>(() => N1QlHelpers.EscapeIdentifier(null));
         }
 
+        [TestCase("index")]
+        [TestCase("INDEX")]
+        public void IsValidKeyword_ReturnsTrue(string identifier)
+        {
+            var result = N1QlHelpers.IsValidKeyword(identifier);
+
+            Assert.IsTrue(result);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("ABC1")]
+        [TestCase("a-b")]
+        [TestCase("`ABC`")]
+        [TestCase("/*ABC*/")]
+        [TestCase("TWO WORDS")]
+        public void IsValidKeyword_ReturnsFalse(string identifier)
+        {
+            var result = N1QlHelpers.IsValidKeyword(identifier);
+
+            Assert.IsFalse(result);
+        }
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectTests.cs
@@ -78,5 +78,73 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             Assert.AreEqual(expected, n1QlQuery);
         }
+
+        [Test]
+        public void Test_Select_UseIndex()
+        {
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Contact>("default")
+                    .UseIndex("IndexName")
+                    .Where(e => e.Type == "contact")
+                    .ToArray();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* " +
+                "FROM `default` as `Extent1` USE INDEX (`IndexName` USING GSI) " +
+                "WHERE (`Extent1`.`type` = 'contact')";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Select_UseIndexWithType()
+        {
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Contact>("default")
+                    .UseIndex("IndexName", N1QlIndexType.View)
+                    .Where(e => e.Type == "contact")
+                    .ToArray();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* " +
+                "FROM `default` as `Extent1` USE INDEX (`IndexName` USING VIEW) " +
+                "WHERE (`Extent1`.`type` = 'contact')";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Select_UseIndex_Any()
+        {
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Contact>("default")
+                    .UseIndex("IndexName")
+                    .Any(e => e.Type == "contact");
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT true as result " +
+                "FROM `default` as `Extent1` USE INDEX (`IndexName` USING GSI) " +
+                "WHERE (`Extent1`.`type` = 'contact') " +
+                "LIMIT 1";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Select_UseIndexWithType_Any()
+        {
+            // ReSharper disable once UnusedVariable
+            var query = CreateQueryable<Contact>("default")
+                    .UseIndex("IndexName", N1QlIndexType.View)
+                    .Any(e => e.Type == "contact");
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT true as result " +
+                "FROM `default` as `Extent1` USE INDEX (`IndexName` USING VIEW) " +
+                "WHERE (`Extent1`.`type` = 'contact') " +
+                "LIMIT 1";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
     }
 }

--- a/Src/Couchbase.Linq/Clauses/UseIndexClause.cs
+++ b/Src/Couchbase.Linq/Clauses/UseIndexClause.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Linq.Expressions;
+using Couchbase.Linq.QueryGeneration;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.Linq.Clauses
+{
+    internal class UseIndexClause : IBodyClause
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="UseIndexClause" /> class.
+        /// </summary>
+        /// <param name="indexName">Name of the index to use.</param>
+        /// <param name="indexType">Type of the index to use.</param>
+        public UseIndexClause(string indexName, N1QlIndexType indexType)
+        {
+            if (string.IsNullOrEmpty(indexName))
+            {
+                throw new ArgumentNullException("indexName");
+            }
+
+            IndexName = indexName;
+            IndexType = indexType;
+        }
+
+        /// <summary>
+        ///     Name of the index to use.
+        /// </summary>
+        public string IndexName { get; set; }
+
+        /// <summary>
+        ///     Type of the index to use.
+        /// </summary>
+        public N1QlIndexType IndexType { get; set; }
+
+        /// <summary>
+        ///     Accepts the specified visitor
+        /// </summary>
+        /// <param name="visitor">The visitor to accept.</param>
+        /// <param name="queryModel">The query model in whose context this clause is visited.</param>
+        /// <param name="index">
+        ///     The index of this clause in the <paramref name="queryModel" />'s
+        ///     <see cref="QueryModel.BodyClauses" /> collection.
+        /// </param>
+        public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
+        {
+            var visotorx = visitor as IN1QlQueryModelVisitor;
+            if (visotorx != null) visotorx.VisitUseIndexClause(this, queryModel, index);
+        }
+
+        /// <summary>
+        ///     Transforms all the expressions in this clause and its child objects via the given
+        ///     <paramref name="transformation" /> delegate.
+        /// </summary>
+        /// <param name="transformation">
+        ///     The transformation object. This delegate is called for each <see cref="Expression" /> within this
+        ///     clause, and those expressions will be replaced with what the delegate returns.
+        /// </param>
+        public void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+        }
+
+        IBodyClause IBodyClause.Clone(CloneContext cloneContext)
+        {
+            return Clone(cloneContext);
+        }
+
+        /// <summary>
+        ///     Clones this clause.
+        /// </summary>
+        /// <param name="cloneContext">The clones of all query source clauses are registered with this <see cref="CloneContext" />.</param>
+        /// <returns></returns>
+        public virtual UseIndexClause Clone(CloneContext cloneContext)
+        {
+            var clone = new UseIndexClause(IndexName, IndexType);
+            return clone;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("use index {0} using {1}", IndexName, IndexType.ToString().ToUpper());
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/UseIndexExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/UseIndexExpressionNode.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    internal class UseIndexExpressionNode : MethodCallExpressionNodeBase
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+            typeof(QueryExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(p => p.Name == "UseIndex")
+                .ToArray();
+
+        public UseIndexExpressionNode(MethodCallExpressionParseInfo parseInfo, ConstantExpression indexName, ConstantExpression indexType)
+            : base(parseInfo)
+        {
+            if (indexName == null)
+            {
+                throw new ArgumentNullException("indexName");
+            }
+            if (indexName.Type != typeof(string))
+            {
+                throw new ArgumentException("indexName must return a string", "indexName");
+            }
+
+            if (indexType.Type != typeof(N1QlIndexType))
+            {
+                throw new ArgumentException("indexType must return a N1QlIndexType", "indexType");
+            }
+
+            IndexName = indexName;
+            IndexType = indexType;
+        }
+
+        public ConstantExpression IndexName { get; private set; }
+        public ConstantExpression IndexType { get; private set; }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            queryModel.BodyClauses.Add(new UseIndexClause((string) IndexName.Value, (N1QlIndexType) IndexType.Value));
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -93,6 +93,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Clauses\UseIndexClause.cs" />
+    <Compile Include="Clauses\UseIndexExpressionNode.cs" />
     <Compile Include="IChangeTrackableContext.cs" />
     <Compile Include="Clauses\UseKeysExpressionNode.cs" />
     <Compile Include="Clauses\UseKeysClause.cs" />
@@ -105,6 +107,7 @@
     <Compile Include="Execution\IBucketQueryExecutor.cs" />
     <Compile Include="Execution\IBucketQueryExecutorProvider.cs" />
     <Compile Include="KeyAttributeMissingException.cs" />
+    <Compile Include="N1QlIndexType.cs" />
     <Compile Include="N1QlDatePart.cs" />
     <Compile Include="N1QlFunctions.Core.cs" />
     <Compile Include="N1QlFunctions.DateTime.cs" />
@@ -185,6 +188,7 @@
     <Compile Include="QueryGeneration\N1QlQueryGenerationContext.cs" />
     <Compile Include="QueryGeneration\N1QLQueryModelVisitor.cs" />
     <Compile Include="QueryGeneration\N1QLQueryType.cs" />
+    <Compile Include="QueryGeneration\N1QlUseIndexPart.cs" />
     <Compile Include="QueryGeneration\NamedParameter.cs" />
     <Compile Include="QueryGeneration\ParameterAggregator.cs" />
     <Compile Include="QueryGeneration\QueryPartsAggregator.cs" />

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
@@ -246,6 +246,50 @@ namespace Couchbase.Linq.Extensions
             return source.Provider.Execute<dynamic>(newExpression);
         }
 
+        #region Use Index
+
+        /// <summary>
+        /// Provides an index hint to the query engine.
+        /// </summary>
+        /// <typeparam name="T">Type of items being queried.</typeparam>
+        /// <param name="source">Items being queried.</param>
+        /// <param name="indexName">Name of the index to use.</param>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<T> UseIndex<T>(this IQueryable<T> source, string indexName)
+        {
+            return source.UseIndex(indexName, N1QlIndexType.Gsi);
+        }
+
+        /// <summary>
+        /// Provides an index hint to the query engine.
+        /// </summary>
+        /// <typeparam name="T">Type of items being queried.</typeparam>
+        /// <param name="source">Items being queried.</param>
+        /// <param name="indexName">Name of the index to use.</param>
+        /// <param name="indexType">Type of the index to use.</param>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<T> UseIndex<T>(this IQueryable<T> source, string indexName, N1QlIndexType indexType)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+            if (!Enum.IsDefined(typeof(N1QlIndexType), indexType))
+            {
+                throw new ArgumentOutOfRangeException("indexType");
+            }
+
+            return source.Provider.CreateQuery<T>(
+                    Expression.Call(
+                        ((MethodInfo)MethodBase.GetCurrentMethod())
+                            .MakeGenericMethod(typeof(T)),
+                        source.Expression,
+                        Expression.Constant(indexName),
+                        Expression.Constant(indexType)));
+        }
+
+        #endregion
+
         #region Async
 
         /// <summary>

--- a/Src/Couchbase.Linq/N1QlIndexType.cs
+++ b/Src/Couchbase.Linq/N1QlIndexType.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Types of indices supported by N1QL query <see cref="QueryExtensions.UseIndex{T}(IQueryable{T}, string, N1QlIndexType)"/>.
+    /// </summary>
+    public enum N1QlIndexType
+    {
+        /// <summary>
+        /// Global secondary index
+        /// </summary>
+        Gsi,
+
+        /// <summary>
+        /// View index
+        /// </summary>
+        View
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/IN1QlQueryModelVisitor.cs
@@ -14,5 +14,7 @@ namespace Couchbase.Linq.QueryGeneration
         void VisitNestClause(NestClause clause, QueryModel queryModel, int index);
 
         void VisitUseKeysClause(UseKeysClause clause, QueryModel queryModel, int index);
+
+        void VisitUseIndexClause(UseIndexClause clause, QueryModel queryModel, int index);
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -267,6 +267,26 @@ namespace Couchbase.Linq.QueryGeneration
             _queryPartsAggregator.AddUseKeysPart(GetN1QlExpression(clause.Keys));
         }
 
+        public virtual void VisitUseIndexClause(UseIndexClause clause, QueryModel queryModel, int index)
+        {
+            if (_queryPartsAggregator.UseIndexPart != null)
+            {
+                throw new NotSupportedException("Only one UseIndex clause is allowed per query.");
+            }
+
+            var indexType = clause.IndexType.ToString().ToUpper();
+            if (!N1QlHelpers.IsValidKeyword(indexType))
+            {
+                throw new InvalidOperationException("Invalid index type for the UseIndex clause");
+            }
+
+            _queryPartsAggregator.UseIndexPart = new N1QlUseIndexPart()
+            {
+                IndexName = N1QlHelpers.EscapeIdentifier(clause.IndexName),
+                IndexType = indexType
+            };
+        }
+
         public override void VisitSelectClause(SelectClause selectClause, QueryModel queryModel)
         {
             if (_queryPartsAggregator.QueryType == N1QlQueryType.SubqueryAny)

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlHelpers.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlHelpers.cs
@@ -35,5 +35,31 @@ namespace Couchbase.Linq.QueryGeneration
             return string.Concat("`", identifier, "`");
         }
 
+        /// <summary>
+        /// Checks to see if the identifier may be a valid keyword.
+        /// </summary>
+        /// <param name="identifier">Identifier to check.</param>
+        /// <returns>True if the identifier may be a valid keyword.</returns>
+        /// <remarks>This method doesn't guarantee that they identifier is a currently known N1QL keyword, as this list
+        /// may change over time.  It merely confirms that it is formatted as a plain string of alphabetic characters which
+        /// may be a single keyword.  This provides security control against N1QL injection attacks where a single keyword
+        /// is known to be safe but additional characters could be malicious.</remarks>
+        public static bool IsValidKeyword(string identifier)
+        {
+            if (string.IsNullOrWhiteSpace(identifier))
+            {
+                return false;
+            }
+
+            for (var i = 0; i < identifier.Length; i++)
+            {
+                if (!char.IsLetter(identifier, i))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlUseIndexPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlUseIndexPart.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.QueryGeneration
+{
+    internal class N1QlUseIndexPart
+    {
+        /// <summary>
+        /// Name of the index being used, already escaped.
+        /// </summary>
+        public string IndexName { get; set; }
+
+        /// <summary>
+        /// Type of the index being used.  Should be alphanumeric only.
+        /// </summary>
+        public string IndexType { get; set; }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -22,6 +22,7 @@ namespace Couchbase.Linq.QueryGeneration
         public string SelectPart { get; set; }
         public List<N1QlFromQueryPart> FromParts { get; set; }
         public string UseKeysPart { get; set; }
+        public N1QlUseIndexPart UseIndexPart { get; set; }
         public List<N1QlLetQueryPart> LetParts { get; set; }
         public List<string> WhereParts { get; set; }
         public List<string> OrderByParts { get; set; }
@@ -247,6 +248,10 @@ namespace Couchbase.Linq.QueryGeneration
                 {
                     sb.AppendFormat(" USE KEYS {0}", UseKeysPart);
                 }
+                else if (UseIndexPart != null)
+                {
+                    sb.AppendFormat(" USE INDEX ({0} USING {1})", UseIndexPart.IndexName, UseIndexPart.IndexType);
+                }
 
                 foreach (var joinPart in FromParts.Skip(1))
                 {
@@ -331,6 +336,10 @@ namespace Couchbase.Linq.QueryGeneration
                 if (!string.IsNullOrEmpty(UseKeysPart))
                 {
                     sb.AppendFormat(" USE KEYS {0}", UseKeysPart);
+                }
+                else if (UseIndexPart != null)
+                {
+                    sb.AppendFormat(" USE INDEX ({0} USING {1})", UseIndexPart.IndexName, UseIndexPart.IndexType);
                 }
 
                 foreach (var joinPart in FromParts.Skip(1))

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -27,6 +27,10 @@ namespace Couchbase.Linq
             customNodeTypeRegistry.Register(UseKeysExpressionNode.SupportedMethods,
                 typeof(UseKeysExpressionNode));
 
+            //register the "UseIndex" expression node parser
+            customNodeTypeRegistry.Register(UseIndexExpressionNode.SupportedMethods,
+                typeof(UseIndexExpressionNode));
+
             //register the "ToQueryRequest" expression node parser
             customNodeTypeRegistry.Register(ToQueryRequestExpressionNode.SupportedMethods,
                 typeof(ToQueryRequestExpressionNode));

--- a/docs/use-index.md
+++ b/docs/use-index.md
@@ -1,0 +1,29 @@
+The UseIndex Method
+==================
+The UseIndex method is used to provide an index hint to the query engine.  This can help improve query performance in cases where Explain shows that the index being used by default is inefficient.
+
+**Note:** You must import the `Couchbase.Linq.Extensions` namespace to use the UseIndex method.
+
+**Note:** You may only call UseIndex on the first, primary keyspace being queried.  It cannot be used after join clauses.
+
+##Basic Usage
+The call to UseIndex should be immediately after the call to Query<T>.
+
+	var context = new BucketContext(bucket);
+
+	var query = from beer in context.Query<Beer>().UseIndex("beer_abv")
+				where beer.Abv > 6
+				select beer;
+
+The query in this example will return all Beer documents which have an ABV greater than 6.  It will use an index named "beer_abv" to optimize the query, if it exists.
+
+##Index Types
+By default, UseIndex assumes you are using a GSI index.  However, it is also possible to query a View index.  UseIndex accepts an optional second parameter indicating the index type.
+
+	var context = new BucketContext(bucket);
+
+	var query = from beer in context.Query<Beer>().UseIndex("beer_abv", N1QlIndexType.View)
+				where beer.Abv > 6
+				select beer;
+
+Note that views must be defined using a `CREATE INDEX` statement in order to be usable via N1QL queries.


### PR DESCRIPTION
Motivation
----------
Allow LINQ based query systems to supply index hints to the N1QL query
engine for improved performance.

Modifications
-------------
Added a new IQueryable extension, UseIndex, which applies the clause to
the query.  Accepts two possible parameters, the name of the index and the
optional type of the index.

Added constants for currently known index types under the N1QlIndexType class.

Added IsValidKeyword to N1QlHelpers to test for and prevent N1QL injection
attacks using invalid index types.

Added unit and integration tests for the new feature, plus documentation.

Results
-------
Users may now improve query performance by providing index hints when
using LINQ generated queries.  Both GSI and VIEW index types are
supported.  Because this support is provided via string constants, we are
already futureproofed for index types that might be added in future
versions of Couchbase Server.