### PR TITLE
Issue #145: Support for StartsWith and EndWith

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -153,6 +153,45 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void Map2PocoTests_Simple_Projections_StartsWith()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from b in context.Query<Beer>()
+                        where b.Type == "beer" && b.Name.StartsWith("563")
+                        select new { name = b.Name, abv = b.Abv };
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+
+            foreach (var b in results)
+            {
+                Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
+            }
+        }
+
+        [Test]
+        public void Map2PocoTests_Simple_Projections_EndsWithExpression()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            // This query is not useful, but tests more advanced string contains use cases
+            var beers = from b in context.Query<Beer>()
+                        where b.Type == "beer" && b.Name.EndsWith(b.Name.Substring(b.Name.Length - 3))
+                        select new { name = b.Name, abv = b.Abv };
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+
+            foreach (var b in results)
+            {
+                Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
+            }
+        }
+
+        [Test]
         public void Map2PocoTests_Simple_Projections_Limit()
         {
             var bucket = ClusterHelper.GetBucket("beer-sample");

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Proxies\DocumentProxyTests.cs" />
     <Compile Include="QueryGeneration\LinqQueryRequestTests.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\KeyMethodCallTranslatorTests.cs" />
+    <Compile Include="QueryGeneration\MethodCallTranslators\ContainsMethodCallTranslatorTests.cs" />
     <Compile Include="QueryGeneration\SelectDocumentMetadataTests.cs" />
     <Compile Include="QueryGeneration\UnionTests.cs" />
     <Compile Include="QueryGeneration\ArrayOperatorTests.cs" />

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/MethodCallTranslators/ContainsMethodCallTranslatorTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/MethodCallTranslators/ContainsMethodCallTranslatorTests.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.QueryGeneration;
+using Couchbase.Linq.QueryGeneration.MethodCallTranslators;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.QueryGeneration.MethodCallTranslators
+{
+    class ContainsMethodCallTranslatorTests
+    {
+        #region Translate
+
+        [Test]
+        public void Translate_NoMethod_ThrowsArgumentNullException()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var transformer = new ContainsMethodCallTranslator();
+
+            // Act/Assert
+
+            var result = Assert.Throws<ArgumentNullException>(() => transformer.Translate(null, visitor.Object));
+
+            Assert.AreEqual("methodCallExpression", result.ParamName);
+        }
+
+        [Test]
+        public void Translate_NoVisitor_ThrowsArgumentNullException()
+        {
+            // Arrange
+
+            var method = typeof(string).GetMethod("Contains", new[] { typeof(string) });
+            var expression = Expression.Call(Expression.Constant("test"), method, Expression.Constant("t"));
+
+            var transformer = new ContainsMethodCallTranslator();
+
+            // Act/Assert
+
+            var result = Assert.Throws<ArgumentNullException>(() => transformer.Translate(expression, null));
+
+            Assert.AreEqual("expressionTreeVisitor", result.ParamName);
+        }
+
+        [Test]
+        public void Translate_ContainsConstant_RendersCorrectly()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var method = typeof(string).GetMethod("Contains", new[] { typeof(string) });
+            var expression = Expression.Call(Expression.Constant("test"), method, Expression.Constant("t"));
+
+            var transformer = new ContainsMethodCallTranslator();
+
+            // Act
+
+            transformer.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            Assert.AreEqual("('test' LIKE '%t%')", result);
+        }
+
+        [Test]
+        public void Translate_ContainsExpression_RendersCorrectly()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+            visitor.Setup(m => m.Visit(It.IsAny<ParameterExpression>())).Callback((Expression p) =>
+            {
+                visitor.Object.Expression.Append("FAKE");
+            });
+
+            var method = typeof(string).GetMethod("Contains", new[] { typeof(string) });
+            var expression = Expression.Call(Expression.Constant("test"), method,
+                Expression.Parameter(typeof(string)));
+
+            var transformer = new ContainsMethodCallTranslator();
+
+            // Act
+
+            transformer.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            Assert.AreEqual("('test' LIKE '%' || FAKE || '%')", result);
+        }
+
+        [Test]
+        public void Translate_StartsWithConstant_RendersCorrectly()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var method = typeof(string).GetMethod("StartsWith", new[] { typeof(string) });
+            var expression = Expression.Call(Expression.Constant("test"), method, Expression.Constant("t"));
+
+            var transformer = new ContainsMethodCallTranslator();
+
+            // Act
+
+            transformer.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            Assert.AreEqual("('test' LIKE 't%')", result);
+        }
+
+        [Test]
+        public void Translate_StartsWithExpression_RendersCorrectly()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+            visitor.Setup(m => m.Visit(It.IsAny<ParameterExpression>())).Callback((Expression p) =>
+            {
+                visitor.Object.Expression.Append("FAKE");
+            });
+
+            var method = typeof(string).GetMethod("StartsWith", new[] { typeof(string) });
+            var expression = Expression.Call(Expression.Constant("test"), method,
+                Expression.Parameter(typeof(string)));
+
+            var transformer = new ContainsMethodCallTranslator();
+
+            // Act
+
+            transformer.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            Assert.AreEqual("('test' LIKE FAKE || '%')", result);
+        }
+
+        [Test]
+        public void Translate_EndsWithConstant_RendersCorrectly()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var method = typeof(string).GetMethod("EndsWith", new[] {typeof(string)});
+            var expression = Expression.Call(Expression.Constant("test"), method, Expression.Constant("t"));
+
+            var transformer = new ContainsMethodCallTranslator();
+
+            // Act
+
+            transformer.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            Assert.AreEqual("('test' LIKE '%t')", result);
+        }
+
+        [Test]
+        public void Translate_EndsWithExpression_RendersCorrectly()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+            visitor.Setup(m => m.Visit(It.IsAny<ParameterExpression>())).Callback((Expression p) =>
+            {
+                visitor.Object.Expression.Append("FAKE");
+            });
+
+            var method = typeof(string).GetMethod("EndsWith", new[] { typeof(string) });
+            var expression = Expression.Call(Expression.Constant("test"), method,
+                Expression.Parameter(typeof(string)));
+
+            var transformer = new ContainsMethodCallTranslator();
+
+            // Act
+
+            transformer.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            Assert.AreEqual("('test' LIKE '%' || FAKE)", result);
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/WhereClauseTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/WhereClauseTests.cs
@@ -72,6 +72,44 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         }
 
         [Test]
+        public void Test_Where_With_StartsWith()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                    .Where(e => e.Age > 10 && e.FirstName == "Sam" && e.LastName.StartsWith("a"))
+                    .Select(e => new { age = e.Age, name = e.FirstName });
+
+            const string expected =
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam')) AND (`Extent1`.`lname` LIKE 'a%'))";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Where_With_EndsWith()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                    .Where(e => e.Age > 10 && e.FirstName == "Sam" && e.LastName.EndsWith("a"))
+                    .Select(e => new { age = e.Age, name = e.FirstName });
+
+            const string expected =
+                "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam')) AND (`Extent1`.`lname` LIKE '%a'))";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
         public void Test_Where()
         {
             var mockBucket = new Mock<IBucket>();


### PR DESCRIPTION
Motivation
----------
Currently, only string.Contains is supported for string partial matching.
StartsWith and EndsWith support will make more advanced partial match
support easier.  Additionally, string.Contains will currently only work
with string constants, support for any Expression type will be more
useful.

Modifications
-------------
Added support for StartsWith and EndsWith to ContainsMethodCallTranslator.

Added support for dynamically building the right side of the LIKE
expression in N1QL if the input isn't a string constant.

Added unit and integration tests for the new functionality.

Results
-------
string.StartsWith and string.EndsWith are now supported in LINQ queries to
Couchbase.

Both of these methods, plus string.Contains, will also accept any
Expression type now, not just string ConstantExpressions.