### PR TITLE
Issue #153: Support for controlling array subquery extent names

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/ArrayOperatorTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/ArrayOperatorTests.cs
@@ -6,6 +6,7 @@ using Couchbase.Linq.UnitTests.Documents;
 using Moq;
 using Newtonsoft.Json.Serialization;
 using NUnit.Framework;
+using Couchbase.Linq.Extensions;
 
 namespace Couchbase.Linq.UnitTests.QueryGeneration
 {
@@ -32,6 +33,26 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         }
 
         [Test]
+        public void Test_ArrayAnyWithExtentName()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<DocumentWithArray>(mockBucket.Object)
+                    .Where(e => e.Array.AsQueryable("ExtentName").Any(p => p == "abc"));
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` " +
+                "WHERE ANY `ExtentName` IN `Extent1`.`Array` SATISFIES (`ExtentName` = 'abc') END";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
         public void Test_ListContains()
         {
             SetContractResolver(new DefaultContractResolver());
@@ -44,6 +65,26 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
                     .Where(e => e.List.Contains("abc"));
 
             const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE 'abc' IN (`Extent1`.`List`)";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_ListAnyWithExtentName()
+        {
+            SetContractResolver(new DefaultContractResolver());
+
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<DocumentWithIList>(mockBucket.Object)
+                    .Where(e => e.List.AsQueryable("ExtentName").Any(p => p == "abc"));
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` " +
+                "WHERE ANY `ExtentName` IN `Extent1`.`List` SATISFIES (`ExtentName` = 'abc') END";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq/Clauses/ExtentNameExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/ExtentNameExpressionNode.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    internal class ExtentNameExpressionNode : MethodCallExpressionNodeBase
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+            { typeof(EnumerableExtensions).GetMethod("AsQueryable") };
+
+        /// <summary>
+        /// The <see cref="QueryModel.MainFromClause"/> will have an <see cref="IQuerySource.ItemName"/> composed of
+        /// this prefix followed by the <see cref="ExtentName"/>.
+        /// </summary>
+        public const string ItemNamePrefix = "__ExtentName_";
+
+        public ExtentNameExpressionNode(MethodCallExpressionParseInfo parseInfo, ConstantExpression extentName)
+            : base(parseInfo)
+        {
+            if (extentName == null)
+            {
+                throw new ArgumentNullException("extentName");
+            }
+            if (extentName.Type != typeof(string))
+            {
+                throw new ArgumentException("extentName must return a string", "extentName");
+            }
+
+            ExtentName = extentName;
+        }
+
+        public ConstantExpression ExtentName { get; private set; }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            queryModel.MainFromClause.ItemName = ItemNamePrefix + (string) ExtentName.Value;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -94,6 +94,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Clauses\UseIndexClause.cs" />
+    <Compile Include="Clauses\ExtentNameExpressionNode.cs" />
     <Compile Include="Clauses\UseIndexExpressionNode.cs" />
     <Compile Include="IChangeTrackableContext.cs" />
     <Compile Include="Clauses\UseKeysExpressionNode.cs" />

--- a/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
@@ -157,5 +157,33 @@ namespace Couchbase.Linq.Extensions
 
         #endregion
 
+        #region AsQueryable
+
+        /// <summary>
+        /// Converts a nested array into a queryable array, specifying the extent name to use in the generated N1QL query.
+        /// This may be important to ensure that array indexes are used for query optimization.
+        /// </summary>
+        /// <typeparam name="T">Type of items being queried.</typeparam>
+        /// <param name="source">Items being queried.</param>
+        /// <param name="extentName">Name of the extent to use.</param>
+        /// <returns></returns>
+        public static IQueryable<T> AsQueryable<T>(this IEnumerable<T> source, string extentName)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+
+            var queryable = source.AsQueryable();
+
+            return queryable.Provider.CreateQuery<T>(
+                Expression.Call(
+                    ((MethodInfo)MethodBase.GetCurrentMethod())
+                        .MakeGenericMethod(typeof(T)),
+                    queryable.Expression,
+                    Expression.Constant(extentName)));
+        }
+
+        #endregion
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -165,6 +165,15 @@ namespace Couchbase.Linq.QueryGeneration
         /// <exception cref="NotSupportedException">N1Ql Bucket Subqueries Require A UseKeys Call</exception>
         public override void VisitMainFromClause(MainFromClause fromClause, QueryModel queryModel)
         {
+            if (fromClause.ItemName.StartsWith(ExtentNameExpressionNode.ItemNamePrefix))
+            {
+                // There is a hardcoded value for the extent name to be used, so use this value instead
+                // of automatically generating a value.
+
+                _queryGenerationContext.ExtentNameProvider.SetExtentName(fromClause,
+                    fromClause.ItemName.Substring(ExtentNameExpressionNode.ItemNamePrefix.Length));
+            }
+
             var bucketConstantExpression = fromClause.FromExpression as ConstantExpression;
             if ((bucketConstantExpression != null) &&
                 typeof(IBucketQueryable).IsAssignableFrom(bucketConstantExpression.Type))

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlExtentNameProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlExtentNameProvider.cs
@@ -105,6 +105,25 @@ namespace Couchbase.Linq.QueryGeneration
             _extentDictionary[querySource] = "";
         }
 
+        public void SetExtentName(IQuerySource querySource, string extentName)
+        {
+            if (querySource == null)
+            {
+                throw new ArgumentNullException("extentName");
+            }
+            if (string.IsNullOrEmpty(extentName))
+            {
+                return;
+            }
+
+            if (_extentDictionary.ContainsKey(querySource))
+            {
+                throw new InvalidOperationException("Cannot set the extent name on a query source which already has a name.");
+            }
+
+            _extentDictionary[querySource] = N1QlHelpers.EscapeIdentifier(extentName);
+        }
+
         /// <summary>
         /// Change the extent name of a query source to a newly generated name, replacing any previously generated name.
         /// </summary>

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -31,6 +31,10 @@ namespace Couchbase.Linq
             customNodeTypeRegistry.Register(UseIndexExpressionNode.SupportedMethods,
                 typeof(UseIndexExpressionNode));
 
+            //register the "ExtentName" expression node parser
+            customNodeTypeRegistry.Register(ExtentNameExpressionNode.SupportedMethods,
+                typeof(ExtentNameExpressionNode));
+
             //register the "ToQueryRequest" expression node parser
             customNodeTypeRegistry.Register(ToQueryRequestExpressionNode.SupportedMethods,
                 typeof(ToQueryRequestExpressionNode));

--- a/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
+++ b/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
@@ -21,5 +21,10 @@ namespace Couchbase.Linq.Versioning
         /// Version where support was added for RYOW consistency.
         /// </summary>
         public static readonly Version ReadYourOwnWrite = new Version(4, 5, 0);
+
+        /// <summary>
+        /// Version where support was added for array indexes.
+        /// </summary>
+        public static readonly Version ArrayIndexes = new Version(4, 5, 0);
     }
 }


### PR DESCRIPTION
Motivation
----------
To use the new array index feature in Couchbase Server 4.5, the extent
names in array subqueries must exactly match the extent names used when
creating the array index.  This is incompatible with the current approach
of automatically generated extent names.

Modifications
-------------
Add IEnumerable<T> extension AsQueryable(extentName).  This overloads the
existing .Net AsQueryable() method.

When found, this expression node causes the ExtentNameProvider to use the
hard-coded extent name instead of an automatically generated name.

Created unit and integration tests for the new functionality.

Results
-------
It is now possible for SDK consumers to programatically control the extent
name used for array subqueries.  The consumer is responsible for ensuring
that they don't create naming conflicts in the resulting N1QL query.