### PR TITLE
Issue #161: Fix change tracking with SDK 2.3.8

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -63,8 +63,8 @@
       <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.1\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=0.0.0.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.3.3\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.3.8.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.3.8\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/Src/Couchbase.Linq.IntegrationTests/packages.config
+++ b/Src/Couchbase.Linq.IntegrationTests/packages.config
@@ -4,7 +4,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Log4Net1213" version="3.3.1" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.3.3" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.3.8" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -59,8 +59,8 @@
       <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.1\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=0.0.0.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.3.3\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.3.8.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.3.8\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyDataMapperTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyDataMapperTests.cs
@@ -31,7 +31,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
             // Act/Assert
 
             // ReSharper disable once ObjectCreationAsStatement
-            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper(configuration, new Mock<IChangeTrackableContext>().Object));
+            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper<Document>(configuration, new Mock<IChangeTrackableContext>().Object));
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
             // Act/Assert
 
             // ReSharper disable once ObjectCreationAsStatement
-            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper(configuration, new Mock<IChangeTrackableContext>().Object));
+            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper<Document>(configuration, new Mock<IChangeTrackableContext>().Object));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
                 Serializer = () => new FakeSerializer()
             };
 
-            var dataMapper = new DocumentProxyDataMapper(configuration, new Mock<IChangeTrackableContext>().Object);
+            var dataMapper = new DocumentProxyDataMapper<Document>(configuration, new Mock<IChangeTrackableContext>().Object);
 
             // Act
 
@@ -88,7 +88,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
                 Serializer = () => new FakeSerializer()
             };
 
-            var dataMapper = new DocumentProxyDataMapper(configuration, new Mock<IChangeTrackableContext>().Object);
+            var dataMapper = new DocumentProxyDataMapper<Document>(configuration, new Mock<IChangeTrackableContext>().Object);
 
             // Act
 

--- a/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyTests.cs
@@ -49,7 +49,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
             // Arrange
 
             var configuration = new ClientConfiguration();
-            var dataMapper = new DocumentProxyDataMapper(configuration, null);
+            var dataMapper = new DocumentProxyDataMapper<DocumentRoot>(configuration, null);
 
             DocumentRoot proxy;
             using (var stream = new System.IO.MemoryStream(Encoding.UTF8.GetBytes("{\"stringProperty\":\"value\",\"__metadata\":{\"id\":\"test\"}}")))

--- a/Src/Couchbase.Linq.UnitTests/packages.config
+++ b/Src/Couchbase.Linq.UnitTests/packages.config
@@ -3,7 +3,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Log4Net1213" version="3.3.1" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.3.3" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.3.8" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -67,8 +67,8 @@
       <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=0.0.0.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.3.3\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.3.8.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.3.8\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
@@ -138,7 +138,7 @@ namespace Couchbase.Linq.Execution
             if (generateProxies)
             {
                 // Proxy generation was requested, and the
-                queryRequest.DataMapper = new Proxies.DocumentProxyDataMapper(_configuration, (IChangeTrackableContext)_bucketContext);
+                queryRequest.DataMapper = new Proxies.DocumentProxyDataMapper<T>(_configuration, (IChangeTrackableContext)_bucketContext);
             }
 
             if (queryModel.ResultOperators.Any(p => p is ToQueryRequestResultOperator))

--- a/Src/Couchbase.Linq/packages.config
+++ b/Src/Couchbase.Linq/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.3.3" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.3.8" targetFramework="net45" />
   <package id="ILRepack" version="2.0.10" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.0.1" targetFramework="net45" />


### PR DESCRIPTION
Motivation
----------
Change tracking proxies can't be created from query results of SDK 2.3.8
or later due to TypeLoadException: Access is denied.

Modifications
-------------
Remove direct tests for IQueryResult<T> to prevent proxy creation on the
query result wrapper.  Instead, block for all types in Couchbase.NetClient
assembly.

Change row enumeration in the query result to use a property search method
to find the result rows, looking for IEnumerablt<TRow>.

Results
-------
Both QueryResult<T> and QueryResultData<T>, and new subsidiary classes
like MetricsData, are not proxied.

After deserialization, QueryResult<T>.Rows and QueryResultData<T>.results
properties can be found to enumerate the rows and complete proxy
initialization.

Tested against SDK 2.3.8, and also against downgrade to 2.3.4 for
backwards compatibility.