### PR TITLE
Issue #157: Allow non-string Key attributes on documents

### DIFF
--- a/Src/Couchbase.Linq/BucketContext.cs
+++ b/Src/Couchbase.Linq/BucketContext.cs
@@ -185,7 +185,14 @@ namespace Couchbase.Linq
                         return (string)metadataPi.GetValue(((ITrackedDocumentNode)document).Metadata);
                     }
                     _cachedKeyProperties.TryAdd(type, pi);
-                    return (string)pi.GetValue(document);
+
+                    var value = pi.GetValue(document);
+                    if (value == null)
+                    {
+                        throw new KeyNullException(ExceptionMsgs.KeyNull);
+                    }
+
+                    return value.ToString();
                 }
             }
             throw new KeyAttributeMissingException(ExceptionMsgs.KeyAttributeMissing);

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -107,6 +107,7 @@
     <Compile Include="IBucketContext.cs" />
     <Compile Include="Execution\IBucketQueryExecutor.cs" />
     <Compile Include="Execution\IBucketQueryExecutorProvider.cs" />
+    <Compile Include="KeyNullException.cs" />
     <Compile Include="KeyAttributeMissingException.cs" />
     <Compile Include="N1QlIndexType.cs" />
     <Compile Include="N1QlDatePart.cs" />

--- a/Src/Couchbase.Linq/KeyNullException.cs
+++ b/Src/Couchbase.Linq/KeyNullException.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Thrown if a the identifier property in a document returns null. The identifier maps
+    /// to the primary key for the document in couchbase.
+    /// </summary>
+    public class KeyNullException : Exception
+    {
+        /// <summary>
+        /// Creates a new KeyNullException.
+        /// </summary>
+        /// <param name="message">Exception message.</param>
+        public KeyNullException(string message)
+            : base(message)
+        {
+        }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/Src/Couchbase.Linq/Utils/ExceptionMsgs.cs
+++ b/Src/Couchbase.Linq/Utils/ExceptionMsgs.cs
@@ -13,6 +13,9 @@ namespace Couchbase.Linq.Utils
         public const string KeyAttributeMissing = "No KeyAttribute could be found for the document. Please " +
                                                   "mark a key property with a KeyAttribute";
 
+        public const string KeyNull = "KeyAttribute marks a property which returned null.  Please " +
+                                      "be sure the key property is non-null.";
+
         public const string QueryExecutionException = "An error occurred executing the N1QL query.  See the " +
                                                       "inner exception for details.";
 


### PR DESCRIPTION
Motivation
----------
Currently, attributes marked as Key must be strings.  Converting other
types such as integers and GUIDs to strings would be simpler and more
obvious.

Modifications
-------------
Call ToString() instead of casting the result to a string.

To prevent a possible NRE, check for nulls before calling ToString() and
throw KeyMissingException.

Results
-------
Non-string key attributes are now supported.