### PR TITLE
Perform consistency checks when calling SubmitChanges

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/Documents/BeerFiltered.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/Documents/BeerFiltered.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using Newtonsoft.Json;
 
 namespace Couchbase.Linq.IntegrationTests.Documents
@@ -7,36 +8,39 @@ namespace Couchbase.Linq.IntegrationTests.Documents
     public class BeerFiltered
     {
         [JsonProperty("name")]
-        public string Name { get; set; }
+        public virtual string Name { get; set; }
 
         [JsonProperty("abv")]
-        public decimal Abv { get; set; }
+        public virtual decimal Abv { get; set; }
 
         [JsonProperty("ibu")]
-        public decimal Ibu { get; set; }
+        public virtual decimal Ibu { get; set; }
 
         [JsonProperty("srm")]
         public decimal Srm { get; set; }
 
         [JsonProperty("upc")]
-        public decimal Upc { get; set; }
+        public virtual decimal Upc { get; set; }
 
         [JsonProperty("type")]
-        public string Type { get; set; }
+        public virtual string Type { get; set; }
 
         [JsonProperty("brewery_id")]
-        public string BreweryId { get; set; }
+        public virtual string BreweryId { get; set; }
 
         [JsonProperty("description")]
-        public string Description { get; set; }
+        public virtual string Description { get; set; }
 
         [JsonProperty("style")]
-        public string Style { get; set; }
+        public virtual string Style { get; set; }
 
         [JsonProperty("category")]
-        public string Category { get; set; }
+        public virtual string Category { get; set; }
 
         [JsonProperty("updated")]
-        public DateTime Updated { get; set; }
+        public virtual DateTime Updated { get; set; }
+
+        [Key]
+        public string Key { get { return BreweryId + "-" + Name.ToLower().Replace(' ', '_'); } }
     }
 }

--- a/Src/Couchbase.Linq.NetStandard/Couchbase.Linq.NetStandard.csproj
+++ b/Src/Couchbase.Linq.NetStandard/Couchbase.Linq.NetStandard.csproj
@@ -47,6 +47,9 @@
     <Compile Include="..\Couchbase.Linq\Clauses\UseIndexExpressionNode.cs">
       <Link>Clauses\UseIndexExpressionNode.cs</Link>
     </Compile>
+    <Compile Include="..\Couchbase.Linq\CouchbaseConsistencyException.cs">
+      <Link>CouchbaseConsistencyException.cs</Link>
+    </Compile>
     <Compile Include="..\Couchbase.Linq\IChangeTrackableContext.cs">
       <Link>IChangeTrackableContext.cs</Link>
     </Compile>
@@ -358,6 +361,9 @@
     </Compile>
     <Compile Include="..\Couchbase.Linq\QueryParserHelper.cs">
       <Link>QueryParserHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\Couchbase.Linq\SaveOptions.cs">
+      <Link>SaveOptions.cs</Link>
     </Compile>
     <Compile Include="..\Couchbase.Linq\UnixMillisecondsDateTime.cs">
       <Link>UnixMillisecondsDateTime.cs</Link>

--- a/Src/Couchbase.Linq/BucketContext.cs
+++ b/Src/Couchbase.Linq/BucketContext.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
 using Couchbase.Core.Buckets;
+using Couchbase.IO;
 using Couchbase.Linq.Filters;
 using Couchbase.Linq.Metadata;
 using Couchbase.Linq.Proxies;
@@ -78,7 +79,7 @@ namespace Couchbase.Linq
 
         /// <summary>
         /// Saves the specified document to a Couchbase server cluster. If change tracking is enabled via <see cref="BeginChangeTracking"/>
-        /// then the document will be added to the modified list and then saved when <see cref="SubmitChanges"/> is called.
+        /// then the document will be added to the modified list and then saved when <see cref="SubmitChanges()"/> is called.
         /// </summary>
         /// <typeparam name="T">The <see cref="Type"/> of the document being saved.</typeparam>
         /// <param name="document">The document.</param>
@@ -116,7 +117,7 @@ namespace Couchbase.Linq
         }
 
         /// Removes a document from a Couchbase server cluster. If change tracking is enabled, the document will be flagged for deletion
-        /// and deleted when <see cref="SubmitChanges"/> is called on the current <see cref="BucketContext"/>.
+        /// and deleted when <see cref="SubmitChanges()"/> is called on the current <see cref="BucketContext"/>.
         /// <exception cref="KeyAttributeMissingException">The document id could not be found.</exception>
         /// <exception cref="AmbiguousMatchException">More than one of the requested attributes was found. </exception>
         /// <exception cref="TypeLoadException">A custom attribute type cannot be loaded. </exception>
@@ -198,7 +199,7 @@ namespace Couchbase.Linq
         }
 
         /// <summary>
-        /// Begins change tracking for the current request. To complete and save the changes call <see cref="SubmitChanges" />.
+        /// Begins change tracking for the current request. To complete and save the changes call <see cref="SubmitChanges()" />.
         /// </summary>
         /// <exception cref="System.NotImplementedException"></exception>
         public void BeginChangeTracking()
@@ -229,11 +230,27 @@ namespace Couchbase.Linq
 
         /// <summary>
         /// Submits any changes to documents that have been modified if change tracking is enabled via a call to <see cref="BeginChangeTracking"/>.
-        /// Internally a counter is kept so that if n threads call <see cref="BeginChangeTracking"/>, then n threads must call <see cref="SubmitChanges"/>.
+        /// Internally a counter is kept so that if n threads call <see cref="BeginChangeTracking"/>, then n threads must call <see cref="SubmitChanges()"/>.
         /// After submit changes is called, the modified list will be cleared.
         /// </summary>
         public void SubmitChanges()
         {
+            SubmitChanges(new SaveOptions());
+        }
+
+        /// <summary>
+        /// Submits any changes to documents that have been modified if change tracking is enabled via a call to <see cref="BeginChangeTracking"/>.
+        /// Internally a counter is kept so that if n threads call <see cref="BeginChangeTracking"/>, then n threads must call <see cref="SubmitChanges()"/>.
+        /// After submit changes is called, the modified list will be cleared.
+        /// </summary>
+        /// <param name="options">Options to control how changes are submitted.</param>
+        public void SubmitChanges(SaveOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException("options");
+            }
+
             Interlocked.Decrement(ref _beginChangeTrackingCount);
             if(_beginChangeTrackingCount < 1)
             {
@@ -244,38 +261,44 @@ namespace Couchbase.Linq
                         var doc = modified.Value as ITrackedDocumentNode;
                         if (doc != null && doc.IsDeleted)
                         {
-                            var result = _bucket.Remove(modified.Key);
-                            if (!result.Success)
+                            IOperationResult result;
+                            if (options.PerformConsistencyCheck && (doc.Metadata != null))
                             {
-                                throw new CouchbaseWriteException(result);
+                                result = _bucket.Remove(modified.Key, (ulong) doc.Metadata.Cas);
+                            }
+                            else
+                            {
+                                result = _bucket.Remove(modified.Key);
                             }
 
-                            AddToMutationState(result.Token);
+                            HandleSubmitChangesResult(result);
                         }
                         else if (doc != null && doc.IsDirty)
                         {
-                            IOperationResult result = null;
+                            IOperationResult result;
                             if (doc is NewDocumentWrapper)
                             {
                                 var newDocument = (doc as NewDocumentWrapper).Value;
-                                result = _bucket.Upsert(modified.Key, newDocument);
+
+                                if (options.PerformConsistencyCheck)
+                                {
+                                    result = _bucket.Insert(modified.Key, newDocument);
+                                }
+                                else
+                                {
+                                    result = _bucket.Upsert(modified.Key, newDocument);
+                                }
+                            }
+                            else if (options.PerformConsistencyCheck && (doc.Metadata != null))
+                            {
+                                result = _bucket.Upsert(modified.Key, modified.Value, (ulong) doc.Metadata.Cas);
                             }
                             else
                             {
                                 result = _bucket.Upsert(modified.Key, modified.Value);
                             }
 
-                            if (result != null)
-                            {
-                                if (!result.Success)
-                                {
-                                    throw new CouchbaseWriteException(result);
-                                }
-                                else
-                                {
-                                    AddToMutationState(result.Token);
-                                }
-                            }
+                            HandleSubmitChangesResult(result);
                         }
                     }
                 }
@@ -284,6 +307,26 @@ namespace Couchbase.Linq
                     _modified.Clear();
                 }
             }
+        }
+
+        private void HandleSubmitChangesResult(IOperationResult result)
+        {
+            if (result == null)
+            {
+                return;
+            }
+
+            if (!result.Success)
+            {
+                if (result.Status == ResponseStatus.KeyExists)
+                {
+                    throw new CouchbaseConsistencyException(result);
+                }
+
+                throw new CouchbaseWriteException(result);
+            }
+
+            AddToMutationState(result.Token);
         }
 
         #region IChangeTrackableContext
@@ -371,7 +414,7 @@ namespace Couchbase.Linq
         /// <remarks>
         /// This value is updated as mutations are applied via <see cref="Save{T}"/>.  It may be used
         /// to enable read-your-own-write by passing the value to <see cref="Extensions.QueryExtensions.ConsistentWith{T}"/>.
-        /// If you are using change tracking, this value won't be valid until after a call to <see cref="SubmitChanges"/>.
+        /// If you are using change tracking, this value won't be valid until after a call to <see cref="SubmitChanges()"/>.
         /// This function is only supported on Couchbase Server 4.5 or later.
         /// </remarks>
         public MutationState MutationState { get; private set; }

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Clauses\UseIndexClause.cs" />
     <Compile Include="Clauses\ExtentNameExpressionNode.cs" />
     <Compile Include="Clauses\UseIndexExpressionNode.cs" />
+    <Compile Include="CouchbaseConsistencyException.cs" />
     <Compile Include="IChangeTrackableContext.cs" />
     <Compile Include="Clauses\UseKeysExpressionNode.cs" />
     <Compile Include="Clauses\UseKeysClause.cs" />
@@ -201,6 +202,7 @@
     <Compile Include="Execution\ScalarResult.cs" />
     <Compile Include="QueryGeneration\UnclaimedGroupJoin.cs" />
     <Compile Include="QueryParserHelper.cs" />
+    <Compile Include="SaveOptions.cs" />
     <Compile Include="UnixMillisecondsDateTime.cs" />
     <Compile Include="Utils\ExceptionMsgs.cs" />
     <Compile Include="Versioning\DefaultVersionProvider.cs" />

--- a/Src/Couchbase.Linq/CouchbaseConsistencyException.cs
+++ b/Src/Couchbase.Linq/CouchbaseConsistencyException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Thrown if a write operation fails because the document has been modified since it was read.
+    /// </summary>
+    public class CouchbaseConsistencyException : CouchbaseWriteException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CouchbaseConsistencyException"/> class.
+        /// </summary>
+        /// <param name="failedResult">The <see cref="IOperationResult"/> of the failed operation.</param>
+        public CouchbaseConsistencyException(IOperationResult failedResult) : base(failedResult)
+        {
+        }
+    }
+}

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -20,7 +20,7 @@ namespace Couchbase.Linq
         ClientConfiguration Configuration { get; }
 
         /// <summary>
-        /// Begins change tracking for the current request. To complete and save the changes call <see cref="SubmitChanges"/>.
+        /// Begins change tracking for the current request. To complete and save the changes call <see cref="SubmitChanges()"/>.
         /// </summary>
         void BeginChangeTracking();
 
@@ -33,6 +33,12 @@ namespace Couchbase.Linq
         /// Submits the changes.
         /// </summary>
         void SubmitChanges();
+
+        /// <summary>
+        /// Submits the changes with options.
+        /// </summary>
+        /// <param name="options">Options to control how changes are submitted.</param>
+        void SubmitChanges(SaveOptions options);
 
         /// <summary>
         /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
@@ -70,7 +76,7 @@ namespace Couchbase.Linq
         /// <remarks>
         /// This value is updated as mutations are applied via <see cref="Save{T}"/>.  It may be used
         /// to enable read-your-own-write by passing the value to <see cref="Extensions.QueryExtensions.ConsistentWith{T}"/>.
-        /// If you are using change tracking, this value won't be valid until after a call to <see cref="SubmitChanges"/>.
+        /// If you are using change tracking, this value won't be valid until after a call to <see cref="SubmitChanges()"/>.
         /// This function is only supported on Couchbase Server 4.5 or later.
         /// </remarks>
         MutationState MutationState { get; }

--- a/Src/Couchbase.Linq/SaveOptions.cs
+++ b/Src/Couchbase.Linq/SaveOptions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Provides options controlling how changes are saved via <see cref="IBucketContext"/>.
+    /// </summary>
+    public class SaveOptions
+    {
+        /// <summary>
+        /// If true, before saving documents the Couchbase bucket is checked to ensure that another process
+        /// has not modified the document since it was read.  If it was modified, a
+        /// <see cref="CouchbaseConsistencyException"/> is thrown.  For new documents, the exception will be
+        /// thrown if the document already exists.  Defaults to true.
+        /// </summary>
+        public bool PerformConsistencyCheck { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="SaveOptions"/> object.
+        /// </summary>
+        public SaveOptions()
+        {
+            PerformConsistencyCheck = true;
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
It is generally expected behavior from an SDK like this to prevent
modifications to documents that have already been modified by other
processes, unless expressly overridden.

Modifications
-------------
Added SaveOptions class and optional parameter to SubmitChanges to allow
consistency checking to be disabled.  Defaults to enabled.

Updated SubmitChanges logic to pass the CAS from DocumentMetadata if
consistency checks are enabled.

Created CouchbaseConsistencyException, inherited from
CouchbaseWriteException, to differentiate between consistency failures and
other types of write failures.

Created unit and integration tests to cover the new functionality.

Results
-------
Consistency checking is now the default behavior for change tracking.  It
behaves in a simple and easy to understand manner for the consumer.