### PR TITLE
add skip_branch_with_pr option

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 1.0.{build}
+skip_branch_with_pr: true
 install:
   - cmd: appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v3.5.0/NuGet.exe
 before_build:


### PR DESCRIPTION
## Motivation
When AppVeyor is triggered for a PR, two builds are queued. One for the push and one for the PR. This is not required as it's exactly the same content being built.

## Modifications
Add the `skip_branch_with_pr` option to only trigger one CI build for branches with an open PR.

## Result
Only one build is queued when a commit is made against a branch with an open PR.