### PR TITLE
Fix ScanWait test

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/LinqQueryRequestTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/LinqQueryRequestTests.cs
@@ -232,7 +232,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             // Assert
 
             Assert.NotNull(result);
-            Assert.AreEqual(((uint)scanWait.TotalMilliseconds).ToString(), result.GetFormValues()["scan_wait"]);
+            Assert.AreEqual(scanWait.TotalMilliseconds + "ms", result.GetFormValues()["scan_wait"]);
         }
     }
 }


### PR DESCRIPTION
A bug in the CouchbaseNetClient library was fixed to append "ms" to ScanWait operations. This updates the test to expect the same suffix.