### PR TITLE
Issue #171: Fix direct selection of unnest of scalar arrays

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -846,6 +846,25 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void NestTests_Unnest_Scalar()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries = from brewery in context.Query<Brewery>()
+                            from address in brewery.Address
+                            select address;
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
+            {
+                Console.WriteLine(b);
+            }
+        }
+
+        [Test]
         public void NestTests_Nest_IndexJoin()
         {
             var bucket = ClusterHelper.GetBucket("beer-sample");


### PR DESCRIPTION
Motivation
----------
Queries fail if you use a second from clause or .SelectMany() to unnest
an array of scalars and use that array directly as your select
projection.

Modifications
-------------
Test for arrays of scalars in select projections, and wrap them in
the result property of an object.  This accounts for the fact that N1QL
can't directly return an array of scalars, only objects.

Refactor the GetSelectClause method to separate
QuerySourceReferenceExpression select clauses for better code
organization and readability.

Add unit and integration tests for this type of unnest clause.  Added
overload of CreateN1QlQuery that returns the ScalarResultBehavior so we
can confirm that queries have ResultExtractionRequired = true.

Results
-------
These queries now function, existing behavior for other queries remains
unaffected.

The current definition of scalar arrays might be a bit broad at the
moment, detecting any .Net value types as well as strings.  This should
capture all numerics, enumerations, strings, and dates.  However, there
is a risk of unintentionally capturing structs.