### PR TITLE
Upgrade to Couchbase SDK 2.4.0

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests.NetCore/project.json
+++ b/Src/Couchbase.Linq.IntegrationTests.NetCore/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
+    "NETStandard.Library": "1.6.1",
     "Microsoft.Extensions.Configuration.Json": "1.0.0",
     "Microsoft.Extensions.Configuration.Binder": "1.0.0",
     "NUnit": "3.5.0",

--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -65,8 +65,8 @@
       <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.1\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.3.10.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.3.10\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.4.0.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.4.0\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/Src/Couchbase.Linq.IntegrationTests/packages.config
+++ b/Src/Couchbase.Linq.IntegrationTests/packages.config
@@ -4,7 +4,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net46" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net46" />
   <package id="Common.Logging.Log4Net1213" version="3.3.1" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.3.10" targetFramework="net46" />
+  <package id="CouchbaseNetClient" version="2.4.0" targetFramework="net46" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="Microsoft.CSharp" version="4.0.1" targetFramework="net45" />
   <package id="Microsoft.Extensions.Configuration" version="1.0.0" targetFramework="net45" />

--- a/Src/Couchbase.Linq.NetStandard/project.json
+++ b/Src/Couchbase.Linq.NetStandard/project.json
@@ -1,11 +1,10 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "Castle.Core": "4.0.0-beta001",
-    "Common.Logging": "3.4.0-Beta2",
-    "CouchbaseNetClient": "2.4.0-dp1",
+    "Castle.Core": "4.0.0",
+    "CouchbaseNetClient": "2.4.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
-    "NETStandard.Library": "1.6.0",
+    "NETStandard.Library": "1.6.1",
     "Newtonsoft.Json": "9.0.1",
     "Remotion.Linq": "2.1.1",
     "System.ComponentModel.Annotations": "4.1.0"

--- a/Src/Couchbase.Linq.UnitTests.NetCore/project.json
+++ b/Src/Couchbase.Linq.UnitTests.NetCore/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
+    "NETStandard.Library": "1.6.1",
     "NUnit": "3.5.0",
     "Moq": "4.6.38-alpha",
     "dotnet-test-nunit": "3.4.0-beta-2"

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -65,8 +65,8 @@
       <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.1\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.3.10.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.3.10\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.4.0.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.4.0\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/Src/Couchbase.Linq.UnitTests/packages.config
+++ b/Src/Couchbase.Linq.UnitTests/packages.config
@@ -4,7 +4,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Log4Net1213" version="3.3.1" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.3.10" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.4.0" targetFramework="net45" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="Microsoft.CSharp" version="4.0.1" targetFramework="net45" />
   <package id="Moq" version="4.5.23" targetFramework="net45" />

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -67,8 +67,8 @@
       <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.3.10.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.3.10\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.4.0.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.4.0\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Common.Logging;
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
 using Couchbase.Core.Buckets;
@@ -13,6 +12,7 @@ using Couchbase.Linq.QueryGeneration;
 using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
 using Couchbase.Linq.Utils;
 using Couchbase.Linq.Versioning;
+using Couchbase.Logging;
 using Couchbase.N1QL;
 using Newtonsoft.Json;
 using Remotion.Linq;
@@ -22,7 +22,7 @@ namespace Couchbase.Linq.Execution
 {
     internal class BucketQueryExecutor : IBucketQueryExecutor
     {
-        private static readonly ILog Log = LogManager.GetLogger<BucketQueryExecutor>();
+        private readonly ILog _log = LogManager.GetLogger<BucketQueryExecutor>();
         private readonly IBucket _bucket;
         private readonly ClientConfiguration _configuration;
         private readonly IBucketContext _bucketContext;
@@ -280,7 +280,7 @@ namespace Couchbase.Linq.Execution
             visitor.VisitQueryModel(queryModel);
 
             var query = visitor.GetQuery();
-            Log.Debug(m => m("Generated query: {0}", query));
+            _log.Debug("Generated query: {0}", query);
 
             scalarResultBehavior = visitor.ScalarResultBehavior;
             return query;

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -2,14 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Common.Logging;
+using Couchbase.Logging;
 using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.QueryGeneration
 {
     internal class QueryPartsAggregator
     {
-        private static readonly ILog Log = LogManager.GetLogger<QueryPartsAggregator>();
+        private readonly ILog _log = LogManager.GetLogger<QueryPartsAggregator>();
 
         public QueryPartsAggregator()
         {
@@ -522,7 +522,7 @@ namespace Couchbase.Linq.QueryGeneration
                     throw new InvalidOperationException(string.Format("Unsupported N1QlQueryType: {0}", QueryType));
             }
 
-            Log.Debug(query);
+            _log.Debug(query);
             return query;
         }
 

--- a/Src/Couchbase.Linq/packages.config
+++ b/Src/Couchbase.Linq/packages.config
@@ -3,7 +3,7 @@
   <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.3.10" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.4.0" targetFramework="net45" />
   <package id="ILRepack" version="2.0.10" targetFramework="net45" />
   <package id="Microsoft.CSharp" version="4.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />


### PR DESCRIPTION
Motivation
----------
Have a consistent version for the .Net Full and .Net Standard versions
of Linq2Couchbase, with a consistent approach to logging.

Modifications
-------------
Upgraded all assemblies to use SDK 2.4.0.  Updated .Net Standard
libraries to use 1.6.1 of  NETStandard.Library.

Removed Common.Logging reference from .Net Standard assemblies.  Changed
all logging to use ILog instances from Couchbase.Logging.LogManager
instead of Common.Logging.LogManager.  These are per-instance of each
class instead of static.

Results
-------
All libraries are updated.  Logging still functions the same way for
.Net Full, but uses Microsoft logging for .Net Core.  The ILog instances
are no longer static in case the Couchbase LogManager is changed after
use to another logger.