### PR TITLE
Use N1QL result streaming for query requests

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
@@ -116,6 +116,27 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void Query_EnableProxyGenerationAndStreaming_ReturnsProxyBeerWithCas()
+        {
+            var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));
+            db.BeginChangeTracking();
+
+            const string documentId = "21st_amendment_brewery_cafe-21a_ipa";
+
+            var query = from x in db.Query<Beer>().UseStreaming(true).UseKeys(new[] { documentId })
+                        where x.Type == "beer"
+                        select x;
+
+            var beer = query.First();
+
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            var status = beer as ITrackedDocumentNode;
+
+            Assert.NotNull(status);
+            Assert.Greater(status.Metadata.Cas, 0);
+        }
+
+        [Test]
         public void Query_DisableProxyGeneration_ReturnsNoProxy()
         {
             var db = new BucketContext(ClusterHelper.GetBucket("beer-sample"));

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -57,6 +57,24 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void Map2PocoTests_Simple_Projections_Streamed()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var beers = from b in context.Query<Beer>().UseStreaming(true)
+                        select new { name = b.Name, abv = b.Abv };
+
+            var results = beers.Take(10).ToList();
+            Assert.AreEqual(10, results.Count());
+
+            foreach (var b in results)
+            {
+                Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
+            }
+        }
+
+        [Test]
         public void Map2PocoTests_StronglyTyped_Projections()
         {
             var bucket = ClusterHelper.GetBucket("beer-sample");

--- a/Src/Couchbase.Linq.UnitTests/BucketQueryExecutorEmulator.cs
+++ b/Src/Couchbase.Linq.UnitTests/BucketQueryExecutorEmulator.cs
@@ -32,6 +32,8 @@ namespace Couchbase.Linq.UnitTests
             get { return _query; }
         }
 
+        public bool UseStreaming { get; set; }
+
         public BucketQueryExecutorEmulator(N1QLTestBase test)
         {
             if (test == null)

--- a/Src/Couchbase.Linq/Execution/IBucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/IBucketQueryExecutor.cs
@@ -26,6 +26,12 @@ namespace Couchbase.Linq.Execution
         TimeSpan? ScanWait { get; set; }
 
         /// <summary>
+        /// Specifies if the query results should be streamed, reducing memory utilzation for large result sets.
+        /// </summary>
+        /// <remarks>The default is true.</remarks>
+        bool UseStreaming { get; set; }
+
+        /// <summary>
         /// Requires that the indexes but up to date with a <see cref="MutationState"/> before the query is executed.
         /// </summary>
         /// <param name="state"><see cref="MutationState"/> used for conistency controls.</param>

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
@@ -414,6 +414,32 @@ namespace Couchbase.Linq.Extensions
             return source;
         }
 
+        /// <summary>
+        /// Specifies if the query results should be streamed, reducing memory utilzation for large result sets.
+        /// </summary>
+        /// <param name="source">Sets scan consistency for this query.  Must be a Couchbase LINQ query.</param>
+        /// <param name="useStreaming">Specifies if query results should be streamed.</param>
+        /// <remarks>
+        /// Streaming is not supported in combination with change tracking.  If change tracking is enabled,
+        /// this setting will be ignored.  Streaming is enabled by default.
+        /// </remarks>
+        public static IQueryable<T> UseStreaming<T>(this IQueryable<T> source, bool useStreaming)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+            if (!(source is IBucketQueryExecutorProvider))
+            {
+                // do nothing if this isn't a Couchbase LINQ query
+                return source;
+            }
+
+            ((IBucketQueryExecutorProvider)source).BucketQueryExecutor.UseStreaming = useStreaming;
+
+            return source;
+        }
+
         #endregion
 
         private static void EnsureBucketQueryable<T>(IQueryable<T> source, string methodName, string paramName)


### PR DESCRIPTION
Motivation
----------
Reduce memory footprint for deserialized POCOs when executing large
queries.

Modifications
-------------
Turn on streaming by default for all queries except when change tracking
is enabled.

Add .UseStreaming(bool) extension to allow consumers to disable
streaming if desired.

Results
-------
Reduced memory consumption for large queries so long as they are
enumerated and not put into a list (.ToList()).

Note that this is specifically disabled if change tracking is enabled.
It is incompatible because of the streaming client doesn't use a data
mapper.  Additionally, it wouldn't be advantageous because the change
tracking system keeps the deserialized objects in memory anyway.