### PR TITLE
Make Save behavior on BucketContext more logical during change tracking

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/Documents/Beer.cs
+++ b/Src/Couchbase.Linq.UnitTests/Documents/Beer.cs
@@ -8,36 +8,36 @@ namespace Couchbase.Linq.UnitTests.Documents
     {
         [Key]
         [JsonProperty("name")]
-        public string Name { get; set; }
+        public virtual string Name { get; set; }
 
         [JsonProperty("abv")]
-        public decimal Abv { get; set; }
+        public virtual decimal Abv { get; set; }
 
         [JsonProperty("ibu")]
-        public decimal Ibu { get; set; }
+        public virtual decimal Ibu { get; set; }
 
         [JsonProperty("srm")]
-        public decimal Srm { get; set; }
+        public virtual decimal Srm { get; set; }
 
         [JsonProperty("upc")]
-        public decimal Upc { get; set; }
+        public virtual decimal Upc { get; set; }
 
         [JsonProperty("type")]
-        public string Type { get; set; }
+        public virtual string Type { get; set; }
 
         [JsonProperty("brewery_id")]
-        public string BreweryId { get; set; }
+        public virtual string BreweryId { get; set; }
 
         [JsonProperty("description")]
-        public string Description { get; set; }
+        public virtual string Description { get; set; }
 
         [JsonProperty("style")]
-        public string Style { get; set; }
+        public virtual string Style { get; set; }
 
         [JsonProperty("category")]
-        public string Category { get; set; }
+        public virtual string Category { get; set; }
 
         [JsonProperty("updated")]
-        public DateTime Updated { get; set; }
+        public virtual DateTime Updated { get; set; }
     }
 }

--- a/Src/Couchbase.Linq/Proxies/DocumentProxyDataMapper.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentProxyDataMapper.cs
@@ -92,9 +92,6 @@ namespace Couchbase.Linq.Proxies
                         // Track the document
                         context.Track(row);
 
-                        // Register the context so that it can handled the changed document
-                        status.RegisterChangeTracking(context);
-
                         // Clear the deserialization flags to start change tracking
                         status.ClearStatus();
                     }


### PR DESCRIPTION
Motivation
----------
When using Save on BucketContext with documents other than new documents
it doesn't behave in a logical manner.

Modifications
-------------
Move RegisterChangeTracking call into Track method on BucketContext for
improved consistency.  Also ensure that Untrack calls
UnregisterChangeTracking.

When a document is removed then readded to the context, treat as a
modification instead of as a delete.

Calling Save on a document already flagged as modified has no effect.

Calling Save on an already tracked document flags the document as
modified and dirty so that it posts to Couchbase on SubmitChanges.

Results
-------
Behavior of Save is more consistent with what a consumer would expect.