### PR TITLE
Mutation State Fix

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/BucketContextTests.cs
@@ -1080,6 +1080,82 @@ namespace Couchbase.Linq.UnitTests
         }
 
         [Test]
+        public void AddToMutationState_TokenWithNullBucketRef_DoesNothing()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket.SetupGet(m => m.Name).Returns("default");
+
+            var db = new BucketContext(bucket.Object);
+
+            // Act
+
+            db.AddToMutationState(new MutationToken(null, 1, 2, 3));
+
+            // Assert
+
+            Assert.IsNull(db.MutationState);
+        }
+
+        [Test]
+        public void AddToMutationState_TokenWithSequenceNumberLessThan1_DoesNothing()
+        {
+          // Arrange
+
+          var bucket = new Mock<IBucket>();
+          bucket.SetupGet(m => m.Name).Returns("default");
+
+          var db = new BucketContext(bucket.Object);
+
+          // Act
+
+          db.AddToMutationState(new MutationToken("default", 1, 2, 0));
+
+          // Assert
+
+          Assert.IsNull(db.MutationState);
+        }
+
+        [Test]
+        public void AddToMutationState_TokenWithVBucketIdLessThan1_DoesNothing()
+        {
+          // Arrange
+
+          var bucket = new Mock<IBucket>();
+          bucket.SetupGet(m => m.Name).Returns("default");
+
+          var db = new BucketContext(bucket.Object);
+
+          // Act
+
+          db.AddToMutationState(new MutationToken("default", 0, 2, 3));
+
+          // Assert
+
+          Assert.IsNull(db.MutationState);
+        }
+
+        [Test]
+        public void AddToMutationState_TokenWithVBucketUUIDLessThan1_DoesNothing()
+        {
+          // Arrange
+
+          var bucket = new Mock<IBucket>();
+          bucket.SetupGet(m => m.Name).Returns("default");
+
+          var db = new BucketContext(bucket.Object);
+
+          // Act
+
+          db.AddToMutationState(new MutationToken("default", 1, 0, 3));
+
+          // Assert
+
+          Assert.IsNull(db.MutationState);
+        }
+
+        [Test]
         public void AddToMutationState_FirstRealToken_CreatesMutationState()
         {
             // Arrange

--- a/Src/Couchbase.Linq/BucketContext.cs
+++ b/Src/Couchbase.Linq/BucketContext.cs
@@ -458,7 +458,7 @@ namespace Couchbase.Linq
 
         internal virtual void AddToMutationState(MutationToken token)
         {
-            if ((token == null) || (token.VBucketId < 0))
+            if (token == null || !IsTokenSet(token))
             {
                 // No token was returned, so don't add to the mutation state
                 return;
@@ -473,6 +473,14 @@ namespace Couchbase.Linq
             {
                 Token = token
             });
+        }
+
+        private bool IsTokenSet(MutationToken token)
+        {
+            return token.VBucketId > 0 &&
+                   token.VBucketUUID > 0 &&
+                   token.SequenceNumber > 0 &&
+                   token.BucketRef != null;
         }
 
         /// <summary>


### PR DESCRIPTION
Updated guard clause on BucketContext.AddToMutationState to match the logic in Couchbase .NET Client library, this was to fix an issue where sometimes the .NET Client Library returned an invalid Token.