### PR TITLE
Remove ILRepack dependency and update to SDK 2.4.5

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -65,8 +65,8 @@
       <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.1\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.4.0.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.4.0\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.4.5.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.4.5\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/Src/Couchbase.Linq.IntegrationTests/packages.config
+++ b/Src/Couchbase.Linq.IntegrationTests/packages.config
@@ -4,7 +4,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net46" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net46" />
   <package id="Common.Logging.Log4Net1213" version="3.3.1" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.4.0" targetFramework="net46" />
+  <package id="CouchbaseNetClient" version="2.4.5" targetFramework="net46" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="Microsoft.CSharp" version="4.0.1" targetFramework="net45" />
   <package id="Microsoft.Extensions.Configuration" version="1.0.0" targetFramework="net45" />

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -65,8 +65,8 @@
       <HintPath>..\packages\Common.Logging.Log4Net1213.3.3.1\lib\net40\Common.Logging.Log4Net1213.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.4.0.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.4.0\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.4.5.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.4.5\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/Src/Couchbase.Linq.UnitTests/packages.config
+++ b/Src/Couchbase.Linq.UnitTests/packages.config
@@ -4,7 +4,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Log4Net1213" version="3.3.1" targetFramework="net45" />
-  <package id="CouchbaseNetClient" version="2.4.0" targetFramework="net45" />
+  <package id="CouchbaseNetClient" version="2.4.5" targetFramework="net45" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="Microsoft.CSharp" version="4.0.1" targetFramework="net45" />
   <package id="Moq" version="4.5.23" targetFramework="net45" />

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -13,7 +13,6 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <ILRepackPath>$(SolutionDir)\packages\ILRepack.2.0.10\tools\ILRepack.exe</ILRepackPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,17 +35,6 @@
     <DocumentationFile>bin\Release\Couchbase.Linq.xml</DocumentationFile>
     <LangVersion>5</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'RepackedRelease|AnyCPU'">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\RepackedRelease\</OutputPath>
-    <DefineConstants>TRACE;NET45</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ILRepack>true</ILRepack>
-    <DocumentationFile>bin\RepackedRelease\Couchbase.Linq.xml</DocumentationFile>
-    <LangVersion>5</LangVersion>
-  </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
@@ -67,8 +55,8 @@
       <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Couchbase.NetClient, Version=2.4.0.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
-      <HintPath>..\packages\CouchbaseNetClient.2.4.0\lib\net45\Couchbase.NetClient.dll</HintPath>
+    <Reference Include="Couchbase.NetClient, Version=2.4.5.0, Culture=neutral, PublicKeyToken=05e9c6b5a9ec94c2, processorArchitecture=MSIL">
+      <HintPath>..\packages\CouchbaseNetClient.2.4.5\lib\net45\Couchbase.NetClient.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -220,34 +208,8 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <BuildDependsOn>ILRepackPrebuild;$(BuildDependsOn);ILRepackPostbuild</BuildDependsOn>
+    <BuildDependsOn>$(BuildDependsOn);</BuildDependsOn>
   </PropertyGroup>
-  <Target Name="ILRepackPrebuild" Condition="'$(ILRepack)' == 'true'">
-    <!-- Save the modified timestamp from the output assembly before build starts -->
-    <PropertyGroup>
-      <ILRepackCompileTimestamp>%(IntermediateAssembly.ModifiedTime)</ILRepackCompileTimestamp>
-    </PropertyGroup>
-  </Target>
-  <Target Name="ILRepackPostbuild" Condition="'$(ILRepack)' == 'true'">
-    <!-- If the output assembly was modified, then start the repack -->
-    <CallTarget Condition="'$(ILRepackCompileTimestamp)' != '%(IntermediateAssembly.ModifiedTime)'" Targets="ILRepack" />
-    <!-- Remove repacked files from the output directory -->
-    <ItemGroup>
-      <ToBeDeleted Include="$(OutputPath)Remotion.Linq.*" />
-      <ToBeDeleted Include="$(OutputPath)Castle.Core.*" />
-    </ItemGroup>
-    <Delete Files="@(ToBeDeleted)" />
-  </Target>
-  <Target Name="ILRepack" Condition="'$(ILRepack)' == 'true'">
-    <!-- This will be triggered by ILRepackPostbuild only if the output assembly was modified by the build -->
-    <!-- Ensure that ILRepack.exe exists -->
-    <PropertyGroup>
-      <ErrorText>Cannot find ILRepack executable: {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(ILRepackPath)')" Text="$([System.String]::Format('$(ErrorText)', '$(ILRepackPath)'))" />
-    <!-- Perform repack -->
-    <Exec WorkingDirectory="$(OutputPath)" Command="&quot;$(ILRepackPath)&quot; /internalize /parallel /out:Couchbase.Linq.dll Couchbase.Linq.dll Remotion.Linq.dll Castle.Core.dll" Outputs="$(OutputPath)Couchbase.Linq.dll" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Src/Couchbase.Linq/Couchbase.Linq.nuspec
+++ b/Src/Couchbase.Linq/Couchbase.Linq.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Linq2Couchbase</id>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <title>The official Linq provider for Couchbase N1QL</title>
     <authors>Couchbase, Inc.</authors>
     <owners>Couchbase, Inc.</owners>
@@ -15,11 +15,14 @@
     <tags>couchbase linq n1ql nosql database</tags>
     <dependencies>
       <group targetFramework="net45">
+        <dependency id="CouchbaseNetClient" version="2.4.5" />
         <dependency id="Newtonsoft.Json" version="9.0.1" />
         <dependency id="Common.Logging" version="3.3.1" />
+        <dependency id="Castle.Core" version="3.3.3" />
+        <dependency id="Remotion.Linq" version="2.1.1" />
       </group>
       <group targetFramework="netstandard1.5">
-        <dependency id="Castle.Core" version="4.0.0" />
+        <dependency id="Castle.Core" version="3.3.3" />
         <dependency id="CouchbaseNetClient" version="2.4.5" />
         <dependency id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" />
         <dependency id="NETStandard.Library" version="1.6.1" />

--- a/Src/Couchbase.Linq/packages.config
+++ b/Src/Couchbase.Linq/packages.config
@@ -4,7 +4,6 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="CouchbaseNetClient" version="2.4.5" targetFramework="net45" />
-  <package id="ILRepack" version="2.0.10" targetFramework="net45" />
   <package id="Microsoft.CSharp" version="4.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.1.1" targetFramework="net45" />

--- a/Src/couchbase-net-linq.sln
+++ b/Src/couchbase-net-linq.sln
@@ -33,8 +33,8 @@ Global
 		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.RepackedRelease|Any CPU.ActiveCfg = RepackedRelease|Any CPU
-		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.RepackedRelease|Any CPU.Build.0 = RepackedRelease|Any CPU
+		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.RepackedRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{C0254649-0162-47A4-B3D3-354E0B3FF7D0}.RepackedRelease|Any CPU.Build.0 = Release|Any CPU
 		{8B5F339F-6E52-4E03-9FFA-12C1C025E591}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8B5F339F-6E52-4E03-9FFA-12C1C025E591}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8B5F339F-6E52-4E03-9FFA-12C1C025E591}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Motivation
----------
We no longer need ILRepack and it doesn't support .NET Core, so removing
the dependency.

Modifications
-------------
 - Remove ILRepack package and project dependencies
 - Update to Couchbase.NET SDK 2.4.5
 - Revert Castle dependency to 3.3.3 (from 4.0.0)

Results
-------
Dependencies are now managed through NuGet.