### PR TITLE
Issue #192: Change Castle.Core dependency to 4.0.0 for .NET Standard

### DIFF
--- a/Src/Couchbase.Linq/Couchbase.Linq.nuspec
+++ b/Src/Couchbase.Linq/Couchbase.Linq.nuspec
@@ -22,7 +22,7 @@
         <dependency id="Remotion.Linq" version="2.1.1" />
       </group>
       <group targetFramework="netstandard1.5">
-        <dependency id="Castle.Core" version="3.3.3" />
+        <dependency id="Castle.Core" version="4.0.0" />
         <dependency id="CouchbaseNetClient" version="2.4.5" />
         <dependency id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" />
         <dependency id="NETStandard.Library" version="1.6.1" />


### PR DESCRIPTION
Motivation
----------
Can't install Linq2Couchbase on .NET Core because Castle.Core 3.3.3
doesn't support .NET Standard.

Modifications
-------------
Increased Castle.Core dependency to 4.0.0 for .NET Standard 1.5 only.

Results
-------
.NET 4.5 version is unaffected, but .NET Standard 1.5 version will
require Castle.Core 4.0.0.  This will allow it to be installed on .NET
Core or other platforms that use .NET Standard.