### PR TITLE
Issue #191: Allow ExecuteAsync to be used with in-memory collections

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Proxies\DocumentProxyTypeCreatorTests.cs" />
     <Compile Include="Proxies\DocumentProxyDataMapperTests.cs" />
     <Compile Include="Proxies\DocumentProxyTests.cs" />
+    <Compile Include="Extensions\QueryExtensionsTests.cs" />
     <Compile Include="QueryGeneration\LinqQueryRequestTests.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\KeyMethodCallTranslatorTests.cs" />
     <Compile Include="QueryGeneration\MethodCallTranslators\ContainsMethodCallTranslatorTests.cs" />

--- a/Src/Couchbase.Linq.UnitTests/Extensions/QueryExtensionsTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Extensions/QueryExtensionsTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.Extensions
+{
+    [TestFixture]
+    public class QueryExtensionsTests
+    {
+        #region ExecuteAsync
+
+        [Test(Description = "https://github.com/couchbaselabs/Linq2Couchbase/issues/191")]
+        public async Task ExecuteAsync_EnumerableQuery_ReturnsResult()
+        {
+            // Arrange
+
+            var query = Enumerable.Range(1, 100).AsQueryable();
+
+            // Act
+
+            var result = await query.Skip(5).Take(1).ExecuteAsync();
+
+            // Assert
+
+            Assert.AreEqual(6, result.Sum());
+        }
+
+        [Test(Description = "https://github.com/couchbaselabs/Linq2Couchbase/issues/191")]
+        public async Task ExecuteAsync_EnumerableQueryWithAdditionalFunction_ReturnsResult()
+        {
+            // Arrange
+
+            var query = Enumerable.Range(1, 100).AsQueryable();
+
+            // Act
+
+            var result = await query.ExecuteAsync(p => p.Sum());
+
+            // Assert
+
+            Assert.AreEqual(query.Sum(), result);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Motivation
----------
If working with a mock IBucketContext, calling Query<T> will normally
return an in-memory collection converted to an IQueryable.  In this
case, it will be useful if ExecuteAsync simply processes the in-memory
collection synchronously for the test rather than throwing an exception.

Modifications
-------------
Detect an in-memory collection (based on EnumerableQuery) and execute
synchronously.

Results
-------
Consumers mocking IBucketContext may now use ExecuteAsync against
in-memory collections.