### PR TITLE
Add support for Ordinal string comparison in linq expressions

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/StringTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/StringTests.cs
@@ -536,6 +536,95 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         }
 
         [Test]
+        public void Test_StringCompare_EqualOrdinal()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from contact in QueryFactory.Queryable<Contact>(mockBucket.Object)
+                        where string.Compare(contact.FirstName, "M", StringComparison.Ordinal) == 0
+                        select new { contact.FirstName };
+
+            const string expected =
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`fname` = 'M')";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_StringCompare_EqualOrginalIgnoreCase()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from contact in QueryFactory.Queryable<Contact>(mockBucket.Object)
+                        where string.Compare(contact.FirstName, "M", StringComparison.OrdinalIgnoreCase) == 0
+                        select new { contact.FirstName };
+
+            const string expected =
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (LOWER(`Extent1`.`fname`) = LOWER('M'))";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_StringCompare_EqualCurrCultureIgnoreCase()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from contact in QueryFactory.Queryable<Contact>(mockBucket.Object)
+                        where string.Compare(contact.FirstName, "M", StringComparison.CurrentCultureIgnoreCase) == 0
+                        select new { contact.FirstName };
+
+            const string expected =
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (LOWER(`Extent1`.`fname`) = LOWER('M'))";
+
+            Assert.Throws<NotSupportedException>(() => CreateN1QlQuery(mockBucket.Object, query.Expression));
+        }
+
+        [Test]
+        public void Test_StringCompare_EqualCurrCultureCase()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from contact in QueryFactory.Queryable<Contact>(mockBucket.Object)
+                        where string.Compare(contact.FirstName, "M", StringComparison.CurrentCulture) == 0
+                        select new { contact.FirstName };
+
+            const string expected =
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (LOWER(`Extent1`.`fname`) = LOWER('M'))";
+
+            Assert.Throws<NotSupportedException>(() => CreateN1QlQuery(mockBucket.Object, query.Expression));
+        }
+
+        [Test]
+        public void Test_StringCompare_EqualCurrCulturegnoreCase()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = from contact in QueryFactory.Queryable<Contact>(mockBucket.Object)
+                        where string.Compare(contact.FirstName, "M", StringComparison.CurrentCultureIgnoreCase) == 0
+                        select new { contact.FirstName };
+
+            const string expected =
+                "SELECT `Extent1`.`fname` as `FirstName` FROM `default` as `Extent1` " +
+                "WHERE (LOWER(`Extent1`.`fname`) = LOWER('M'))";
+
+            Assert.Throws<NotSupportedException>(() => CreateN1QlQuery(mockBucket.Object, query.Expression));
+        }
+
+        [Test]
         public void Test_StringCompare_NotEqual()
         {
             var mockBucket = new Mock<IBucket>();

--- a/Src/Couchbase.Linq/QueryGeneration/Expressions/StringComparisonExpression.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/Expressions/StringComparisonExpression.cs
@@ -26,6 +26,7 @@ namespace Couchbase.Linq.QueryGeneration.Expressions
         public ExpressionType Operation { get; private set; }
         public Expression Left { get; private set; }
         public Expression Right { get; private set; }
+        public StringComparison? Comparison { get; set; }
 
         public override ExpressionType NodeType
         {
@@ -37,10 +38,10 @@ namespace Couchbase.Linq.QueryGeneration.Expressions
 
         public override Type Type
         {
-            get { return typeof (bool); }
+            get { return typeof(bool); }
         }
 
-        public static StringComparisonExpression Create(ExpressionType operation, Expression left, Expression right)
+        public static StringComparisonExpression Create(ExpressionType operation, Expression left, Expression right, StringComparison? comparison = null)
         {
             if (!SupportedOperations.Contains(operation))
             {
@@ -63,14 +64,15 @@ namespace Couchbase.Linq.QueryGeneration.Expressions
                 throw new ArgumentException("Expressions must be strings.", "right");
             }
 
-            return new StringComparisonExpression(operation, left, right);
+            return new StringComparisonExpression(operation, left, right, comparison);
         }
 
-        private StringComparisonExpression(ExpressionType operation, Expression left, Expression right)
+        private StringComparisonExpression(ExpressionType operation, Expression left, Expression right, StringComparison? comparison = null)
         {
             Operation = operation;
             Left = left;
             Right = right;
+            Comparison = comparison;
         }
 
         protected override Expression VisitChildren(ExpressionVisitor visitor)
@@ -80,7 +82,7 @@ namespace Couchbase.Linq.QueryGeneration.Expressions
 
             if ((Left != newLeft) || (Right != newRight))
             {
-                return Create(Operation, newLeft, newRight);
+                return Create(Operation, newLeft, newRight, Comparison);
             }
             else
             {


### PR DESCRIPTION
The ASP .NET OData query string parser uses the 3 argument overload of `String.Compare` to specify an ordinal string comparison. I don't thing N1QL is culture aware which is where this seems to be more relevant so it is probably just necessary to accommodate that overload in `StringComparisonExpressionTransformer` However adding support for this overload does tend to imply that the Ignore Case variations of the `StringComparison` options is supported so that may need a treatment of some sort.