### PR TITLE
Issue #199: Add option to suppress document filters

### DIFF
--- a/Src/Couchbase.Linq.NetStandard/Couchbase.Linq.NetStandard.csproj
+++ b/Src/Couchbase.Linq.NetStandard/Couchbase.Linq.NetStandard.csproj
@@ -38,6 +38,9 @@
     <DocumentationFile>bin\Release\Couchbase.Linq.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Couchbase.Linq\BucketQueryOptions.cs">
+      <Link>BucketQueryOptions.cs</Link>
+    </Compile>
     <Compile Include="..\Couchbase.Linq\Clauses\UseIndexClause.cs">
       <Link>Clauses\UseIndexClause.cs</Link>
     </Compile>

--- a/Src/Couchbase.Linq.UnitTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/BucketContextTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Linq.Expressions;
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
 using Couchbase.Core.Buckets;
@@ -177,6 +178,64 @@ namespace Couchbase.Linq.UnitTests
 
             //assert
             Assert.AreEqual("Key2", result);
+        }
+
+        [Test]
+        public void Query_NoOptions_AppliesFilters()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+            var ctx = new BucketContext(bucket.Object);
+
+            // Act
+
+            var query = ctx.Query<BeerFiltered>();
+
+            // Assert
+
+            var methodCall = query.Expression as MethodCallExpression;
+            Assert.IsNotNull(methodCall);
+            Assert.AreEqual("Where", methodCall.Method.Name);
+        }
+
+        [Test]
+        public void Query_None_AppliesFilters()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+            var ctx = new BucketContext(bucket.Object);
+
+            // Act
+
+            var query = ctx.Query<BeerFiltered>(BucketQueryOptions.None);
+
+            // Assert
+
+            var methodCall = query.Expression as MethodCallExpression;
+            Assert.IsNotNull(methodCall);
+            Assert.AreEqual("Where", methodCall.Method.Name);
+        }
+
+        [Test]
+        public void Query_SuppressFilters_DoesntApplyFilters()
+        {
+            // Arrange
+
+            var bucket = new Mock<IBucket>();
+            bucket.Setup(x => x.Configuration).Returns(new ClientConfiguration().BucketConfigs.First().Value);
+            var ctx = new BucketContext(bucket.Object);
+
+            // Act
+
+            var query = ctx.Query<BeerFiltered>(BucketQueryOptions.SuppressFilters);
+
+            // Assert
+
+            Assert.IsAssignableFrom<ConstantExpression>(query.Expression);
         }
 
         [Test]

--- a/Src/Couchbase.Linq/BucketContext.cs
+++ b/Src/Couchbase.Linq/BucketContext.cs
@@ -66,7 +66,26 @@ namespace Couchbase.Linq
         /// <returns><see cref="IQueryable{T}" /> which can be used to query the bucket.</returns>
         public IQueryable<T> Query<T>()
         {
-            return DocumentFilterManager.ApplyFilters(new BucketQueryable<T>(Bucket, Configuration, this));
+            return Query<T>(BucketQueryOptions.None);
+        }
+
+        /// <summary>
+        /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
+        /// a LINQ query and requires that the associated JSON document have a type property that is the same as T.
+        /// </summary>
+        /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
+        /// <param name="options">Options to control the returned query.</param>
+        /// <returns><see cref="IQueryable{T}" /> which can be used to query the bucket.</returns>
+        public IQueryable<T> Query<T>(BucketQueryOptions options)
+        {
+            IQueryable<T> query = new BucketQueryable<T>(Bucket, Configuration, this);
+
+            if ((options & BucketQueryOptions.SuppressFilters) == BucketQueryOptions.None)
+            {
+                query = DocumentFilterManager.ApplyFilters(query);
+            }
+
+            return query;
         }
 
         /// <summary>

--- a/Src/Couchbase.Linq/BucketQueryOptions.cs
+++ b/Src/Couchbase.Linq/BucketQueryOptions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Couchbase.Linq.Filters;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Options to control queries against an <see cref="IBucketContext"/>.
+    /// </summary>
+    [Flags]
+    public enum BucketQueryOptions
+    {
+        /// <summary>
+        /// No special options, use default behavior.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Supress all registered filters in the <see cref="DocumentFilterManager"/>.
+        /// </summary>
+        SuppressFilters = 1
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -82,6 +82,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BucketQueryOptions.cs" />
     <Compile Include="Clauses\UseIndexClause.cs" />
     <Compile Include="Clauses\ExtentNameExpressionNode.cs" />
     <Compile Include="Clauses\UseIndexExpressionNode.cs" />

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -55,6 +55,15 @@ namespace Couchbase.Linq
         IQueryable<T> Query<T>();
 
         /// <summary>
+        /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
+        /// a LINQ query and requires that the associated JSON document have a type property that is the same as T.
+        /// </summary>
+        /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
+        /// <param name="options">Options to control the returned query.</param>
+        /// <returns><see cref="IQueryable{T}" /> which can be used to query the bucket.</returns>
+        IQueryable<T> Query<T>(BucketQueryOptions options);
+
+        /// <summary>
         /// Saves the specified document.
         /// </summary>
         /// <typeparam name="T"></typeparam>


### PR DESCRIPTION
Motivation
----------
When performing LEFT JOINs, filters which are automatically injected via
the DocumentFilterManager can produce unexpected behaviors.  This is due
to a N1QL limitation that you cannot apply filters before a JOIN, only
after the JOIN is complete.

Modifications
-------------
Added BucketContext.Query overload that allows the user to suppress the
filters, such as the DocumentTypeFilter.

Added unit tests for all variants to ensure proper behavior.

Results
-------
When performing a LEFT JOIN, the user can apply
BucketQueryOptions.SuppressFilters to the right hand side of the join.
This will prevent the LINQ expressions which cannot be translated to
N1QL from being applied to the query.