### PR TITLE
Issue #203 Add Support for comparison of DateTimeOffset against a str…

### DIFF
--- a/Src/Couchbase.Linq.NetStandard/Couchbase.Linq.NetStandard.csproj
+++ b/Src/Couchbase.Linq.NetStandard/Couchbase.Linq.NetStandard.csproj
@@ -386,6 +386,9 @@
     <Compile Include="..\Couchbase.Linq\Versioning\VersionProvider.cs">
       <Link>Versioning\VersionProvider.cs</Link>
     </Compile>
+    <Compile Include="..\Couchbase.Linq\UnixMillisecondsDateTimeOffset.cs">
+      <Link>UnixMillisecondsDateTimeOffset.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->

--- a/Src/Couchbase.Linq.UnitTests/Documents/Beer.cs
+++ b/Src/Couchbase.Linq.UnitTests/Documents/Beer.cs
@@ -39,5 +39,8 @@ namespace Couchbase.Linq.UnitTests.Documents
 
         [JsonProperty("updated")]
         public virtual DateTime Updated { get; set; }
+
+        [JsonProperty("updatedOffset")]
+        public virtual DateTimeOffset UpdatedOffset { get; set; }
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/ConstantExpressionTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/ConstantExpressionTests.cs
@@ -95,7 +95,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query =
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Select(e => new { e.FirstName, Value = new[] {1, 2, 3, 4, 5} });
+                .Select(e => new { e.FirstName, Value = new[] { 1, 2, 3, 4, 5 } });
 
             const string expected =
                 "SELECT `Extent1`.`fname` as `FirstName`, [1, 2, 3, 4, 5] as `Value` FROM `default` as `Extent1`";
@@ -149,7 +149,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             var query =
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
-                .Select(e => new {Value = new[] { new {Name = e.FirstName}, new {Name = e.LastName} } });
+                .Select(e => new { Value = new[] { new { Name = e.FirstName }, new { Name = e.LastName } } });
 
             const string expected =
                 "SELECT [{\"Name\": `Extent1`.`fname`}, {\"Name\": `Extent1`.`lname`}] as `Value` FROM `default` as `Extent1`";
@@ -171,6 +171,24 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             const string expected =
                 "SELECT `Extent1`.`fname` as `FirstName`, \"2000-12-01T01:23:45.067Z\" as `Value` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_DateTimeOffset()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                .Select(e => new { e.FirstName, Value = new DateTimeOffset(2017, 2, 24, 23, 20, 34, 67, new TimeSpan(6, 0, 0)) });
+
+            const string expected =
+                "SELECT `Extent1`.`fname` as `FirstName`, \"2017-02-24T23:20:34.067+06:00\" as `Value` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/WhereClauseTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/WhereClauseTests.cs
@@ -21,7 +21,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
                     .Where(e => e.Age > 10 && e.FirstName == "Sam")
                     .OrderBy(e => e.Age)
-                    .Select(e => new {age = e.Age, name = e.FirstName});
+                    .Select(e => new { age = e.Age, name = e.FirstName });
 
             const string expected =
                 "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam')) ORDER BY `Extent1`.`age` ASC";
@@ -42,7 +42,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
                     .Where(e => e.Email == "something@gmail.com")
                     .Where(g => N1QlFunctions.IsMissing(g.Age))
                     .OrderBy(e => e.Age)
-                    .Select(e => new {age = e.Age, name = e.FirstName});
+                    .Select(e => new { age = e.Age, name = e.FirstName });
 
             const string expected =
                 "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (`Extent1`.`email` = 'something@gmail.com') AND `Extent1`.`age` IS MISSING ORDER BY `Extent1`.`age` ASC";
@@ -61,7 +61,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var query =
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
                     .Where(e => e.Age > 10 && e.FirstName == "Sam" && e.LastName.Contains("a"))
-                    .Select(e => new {age = e.Age, name = e.FirstName});
+                    .Select(e => new { age = e.Age, name = e.FirstName });
 
             const string expected =
                 "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam')) AND (`Extent1`.`lname` LIKE '%a%'))";
@@ -118,7 +118,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var query =
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
                     .Where(e => e.Age > 10 && e.FirstName == "Sam")
-                    .Select(e => new {age = e.Age, name = e.FirstName});
+                    .Select(e => new { age = e.Age, name = e.FirstName });
 
 
             const string expected =
@@ -141,7 +141,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var query =
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
                     .Where(e => e.Age > age && e.FirstName == firstName)
-                    .Select(e => new {age = e.Age, name = e.FirstName});
+                    .Select(e => new { age = e.Age, name = e.FirstName });
 
 
             const string expected =
@@ -162,7 +162,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
                     .Where(e => e.Age > 10 && e.FirstName == "Sam")
                     .Where(e => e.Email == "myemail@test.com")
-                    .Select(e => new {age = e.Age, name = e.FirstName});
+                    .Select(e => new { age = e.Age, name = e.FirstName });
 
             const string expected =
                 "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` > 10) AND (`Extent1`.`fname` = 'Sam')) AND (`Extent1`.`email` = 'myemail@test.com')";
@@ -181,7 +181,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var query =
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
                     .Where(e => e.Age > 10 || e.FirstName == "Sam")
-                    .Select(e => new {age = e.Age, name = e.FirstName});
+                    .Select(e => new { age = e.Age, name = e.FirstName });
 
             const string expected =
                 "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE ((`Extent1`.`age` > 10) OR (`Extent1`.`fname` = 'Sam'))";
@@ -200,7 +200,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var query =
                 QueryFactory.Queryable<Contact>(mockBucket.Object)
                     .Where(e => e.Age < 10 + 30)
-                    .Select(e => new {age = e.Age, name = e.FirstName});
+                    .Select(e => new { age = e.Age, name = e.FirstName });
 
             const string expected = "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default` as `Extent1` WHERE (`Extent1`.`age` < 40)";
 
@@ -264,6 +264,27 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             const string expected =
                 "SELECT `Extent1`.`name` as `Name` FROM `default` as `Extent1` " +
                 "WHERE (STR_TO_MILLIS(`Extent1`.`updated`) >= STR_TO_MILLIS(\"2010-01-01T00:00:00Z\"))";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Where_With_DateTimeOffsetComparison()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .Where(e => e.UpdatedOffset >= new DateTimeOffset(2010, 1, 1, 0, 0, 0, new TimeSpan(6, 0, 0)))
+                    .Select(e => new { e.Name });
+
+
+            const string expected =
+                "SELECT `Extent1`.`name` as `Name` FROM `default` as `Extent1` " +
+                "WHERE (STR_TO_MILLIS(`Extent1`.`updatedOffset`) >= STR_TO_MILLIS(\"2010-01-01T00:00:00+06:00\"))";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -192,6 +192,7 @@
     <Compile Include="QueryGeneration\UnclaimedGroupJoin.cs" />
     <Compile Include="QueryParserHelper.cs" />
     <Compile Include="SaveOptions.cs" />
+    <Compile Include="UnixMillisecondsDateTimeOffset.cs" />
     <Compile Include="UnixMillisecondsDateTime.cs" />
     <Compile Include="Utils\ExceptionMsgs.cs" />
     <Compile Include="Versioning\DefaultVersionProvider.cs" />

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
@@ -21,6 +21,10 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
             typeof (UnixMillisecondsDateTime).GetMethod("FromDateTime", new[] { typeof(DateTime) });
         private static readonly MethodInfo FromDateTimeNullableMethod =
             typeof(UnixMillisecondsDateTime).GetMethod("FromDateTime", new[] { typeof(DateTime?) });
+        private static readonly MethodInfo FromDateTimeOffsetMethod =
+            typeof(UnixMillisecondsDateTimeOffset).GetMethod("FromDateTimeOffset", new[] { typeof(DateTimeOffset) });
+        private static readonly MethodInfo FromDateTimeOffsetNullableMethod =
+           typeof(UnixMillisecondsDateTimeOffset).GetMethod("FromDateTimeOffset", new[] { typeof(DateTimeOffset?) });
 
         public ExpressionType[] SupportedExpressionTypes
         {
@@ -70,6 +74,14 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
             else if (side.Type == typeof(DateTime?))
             {
                 return Expression.Call(FromDateTimeNullableMethod, side);
+            }
+            else if(side.Type == typeof(DateTimeOffset))
+            {
+                return Expression.Call(FromDateTimeOffsetMethod, side);
+            }
+            else if (side.Type == typeof(DateTimeOffset?))
+            {
+                return Expression.Call(FromDateTimeOffsetMethod, side);
             }
             else
             {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/UnixMillisecondsMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/UnixMillisecondsMethodCallTranslator.cs
@@ -14,8 +14,13 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
         private static readonly MethodInfo[] SupportedMethodsStatic = {
             typeof (UnixMillisecondsDateTime).GetMethod("FromDateTime", new[] { typeof (DateTime) }),
             typeof (UnixMillisecondsDateTime).GetMethod("FromDateTime", new[] { typeof (DateTime?) }),
+            typeof (UnixMillisecondsDateTimeOffset).GetMethod("FromDateTimeOffset", new[] { typeof (DateTimeOffset) }),
+            typeof (UnixMillisecondsDateTimeOffset).GetMethod("FromDateTimeOffset", new[] { typeof (DateTimeOffset?) }),
             typeof (UnixMillisecondsDateTime).GetMethod("ToDateTime", new[] { typeof (UnixMillisecondsDateTime) }),
-            typeof (UnixMillisecondsDateTime).GetMethod("ToDateTime", new[] { typeof (UnixMillisecondsDateTime?) })
+            typeof (UnixMillisecondsDateTime).GetMethod("ToDateTime", new[] { typeof (UnixMillisecondsDateTime?) }),
+            typeof (UnixMillisecondsDateTimeOffset).GetMethod("ToDateTimeOffset", new[] { typeof (UnixMillisecondsDateTimeOffset) }),
+            typeof (UnixMillisecondsDateTimeOffset).GetMethod("ToDateTimeOffset", new[] { typeof (UnixMillisecondsDateTimeOffset?) })
+
         };
 
         public IEnumerable<MethodInfo> SupportMethods
@@ -45,7 +50,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
             var expression = expressionTreeVisitor.Expression;
 
-            if (methodCallExpression.Method.Name == "FromDateTime")
+            if (methodCallExpression.Method.Name == "FromDateTime" || methodCallExpression.Method.Name == "FromDateTimeOffset")
             {
                 expression.Append("STR_TO_MILLIS(");
             }

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -494,7 +494,7 @@ namespace Couchbase.Linq.QueryGeneration
             {
                 _expression.Append((bool)namedParameter.Value ? "TRUE" : "FALSE");
             }
-            else if (namedParameter.Value is DateTime)
+            else if (namedParameter.Value is DateTime || namedParameter.Value is DateTimeOffset)
             {
                 // For consistency, use the JSON serializer configured for the cluster
                 var serializedDateTime = _queryGenerationContext.Serializer.Serialize(namedParameter.Value);

--- a/Src/Couchbase.Linq/UnixMillisecondsDateTimeOffset.cs
+++ b/Src/Couchbase.Linq/UnixMillisecondsDateTimeOffset.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Used internally during query generation to represent a DateTime in unix milliseconds format.
+    /// This class is not instantiated or used, it only exists in Expression trees.
+    /// </summary>
+    internal struct UnixMillisecondsDateTimeOffset
+    {
+        private readonly DateTimeOffset _dateTimeOffset;
+
+        private UnixMillisecondsDateTimeOffset(DateTimeOffset dateTimeOffset)
+        {
+            _dateTimeOffset = dateTimeOffset;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj.GetType() != typeof (UnixMillisecondsDateTimeOffset))
+            {
+                return false;
+            }
+
+            return _dateTimeOffset == ((UnixMillisecondsDateTimeOffset) obj)._dateTimeOffset;
+        }
+
+        public override int GetHashCode()
+        {
+            return _dateTimeOffset.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            // ReSharper disable once SpecifyACultureInStringConversionExplicitly
+            return _dateTimeOffset.ToString();
+        }
+
+        public static UnixMillisecondsDateTimeOffset FromDateTimeOffset(DateTimeOffset dateTimeOffset)
+        {
+            return new UnixMillisecondsDateTimeOffset(dateTimeOffset);
+        }
+
+        public static UnixMillisecondsDateTimeOffset? FromDateTimeOffset(DateTimeOffset? dateTimeOffset)
+        {
+            if (dateTimeOffset.HasValue)
+            {
+                return new UnixMillisecondsDateTimeOffset(dateTimeOffset.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public static DateTimeOffset ToDateTimeOffset(UnixMillisecondsDateTimeOffset unixMillisecondsDateTimeOffset)
+        {
+            return unixMillisecondsDateTimeOffset._dateTimeOffset;
+        }
+
+        public static DateTimeOffset? ToDateTimeOffset(UnixMillisecondsDateTimeOffset? unixMillisecondsDateTimeOffset)
+        {
+            if (unixMillisecondsDateTimeOffset.HasValue)
+            {
+                return unixMillisecondsDateTimeOffset.Value._dateTimeOffset;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public static bool operator ==(UnixMillisecondsDateTimeOffset left, UnixMillisecondsDateTimeOffset right)
+        {
+            return left._dateTimeOffset == right._dateTimeOffset;
+        }
+
+        public static bool operator !=(UnixMillisecondsDateTimeOffset left, UnixMillisecondsDateTimeOffset right)
+        {
+            return left._dateTimeOffset != right._dateTimeOffset;
+        }
+
+        public static bool operator >(UnixMillisecondsDateTimeOffset left, UnixMillisecondsDateTimeOffset right)
+        {
+            return left._dateTimeOffset > right._dateTimeOffset;
+        }
+
+        public static bool operator <(UnixMillisecondsDateTimeOffset left, UnixMillisecondsDateTimeOffset right)
+        {
+            return left._dateTimeOffset < right._dateTimeOffset;
+        }
+
+        public static bool operator >=(UnixMillisecondsDateTimeOffset left, UnixMillisecondsDateTimeOffset right)
+        {
+            return left._dateTimeOffset >= right._dateTimeOffset;
+        }
+
+        public static bool operator <=(UnixMillisecondsDateTimeOffset left, UnixMillisecondsDateTimeOffset right)
+        {
+            return left._dateTimeOffset <= right._dateTimeOffset;
+        }
+    }
+}


### PR DESCRIPTION
Issue #203 Add Support for comparison of DateTimeOffset against a string constant 

Motivation
----------
Comparing DateTimeOffset values to a constant string value in a where clause will result in an unquoted string.

Modifications
-------------
-Add an ORed expression to an if statement in N1QlExpressionTreeVisitor.VisitConstant

Results
-------
LINQ Where clause can properly quote constants when compared to DateTimeOffset properties.