### PR TITLE
Fixes NetStandard 2.0 exception thrown when querying with a WHERE cla…

### DIFF
--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -19,6 +19,7 @@
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <VersionPrefix>1.3.2</VersionPrefix>
+    <Version>1.3.2.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
@@ -14,8 +14,8 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
         {
             typeof (string).GetMethod("Trim", Type.EmptyTypes),
             typeof (string).GetMethod("Trim", new[] { typeof (char[]) }),
-            typeof (string).GetMethod("TrimStart"),
-            typeof (string).GetMethod("TrimEnd")
+            typeof (string).GetMethod("TrimStart", Type.EmptyTypes),
+            typeof (string).GetMethod("TrimEnd", Type.EmptyTypes)
         };
 
         public IEnumerable<MethodInfo> SupportMethods


### PR DESCRIPTION
I just upgraded my projects to the release versions of VS 15.03 and NET Core 2.0 and am seeing the following exception thrown when attempting a Couchbase Linq query with a **WHERE** clause.

````
System.AggregateException occurred
  HResult=0x80131500
  Message=One or more errors occurred. (The type initializer for 'Couchbase.Linq.QueryGeneration.DefaultMethodCallTranslatorProvider' threw an exception.)
  Source=<Cannot evaluate the exception source>
  StackTrace:
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Test.TypeFilterAttribute.Program.Main(String[] args) in C:\src\Linq2Couchbase\Src\Test\Program.cs:line 119

Inner Exception 1:
TypeInitializationException: The type initializer for 'Couchbase.Linq.QueryGeneration.DefaultMethodCallTranslatorProvider' threw an exception.

Inner Exception 2:
TypeInitializationException: The type initializer for 'Couchbase.Linq.QueryGeneration.MethodCallTranslators.StringTrimMethodCallTranslator' threw an exception.

Inner Exception 3:
AmbiguousMatchException: Ambiguous match found.
````
I tracked this down to the `StringTrimMethodCallTranslator.SupportedMethodsStatic` field initializer.  The problem is with the `TrimStart` and `TrimEnd` `GetMethod()` calls.  These assume that there's only one method signature for these methods but it appears that NETStandard 2.0 has added a couple additional overrides for each that allow the developer to specify the trimmed characters.

The fix is to simply specify `Type.EmptyTypes` so that the original parameter-less method should be returned.  This should be backwards compatible with older frameworks.
