### PR TITLE
Fix startup exception if framework doesn't have TrimStart/TrimEnd

### DIFF
--- a/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
@@ -33,7 +33,9 @@ namespace Couchbase.Linq.QueryGeneration
                 {
                     var instance = (IMethodCallTranslator) Activator.CreateInstance(type);
 
-                    return instance.SupportMethods.Select(method => new {instance, method});
+                    return instance.SupportMethods
+                        .Where(method => method != null)
+                        .Select(method => new {instance, method});
                 });
 
             return query.ToDictionary(p => p.method, p => p.instance);

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
@@ -15,7 +15,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             typeof (string).GetMethod("Trim", Type.EmptyTypes),
             typeof (string).GetMethod("Trim", new[] { typeof (char[]) }),
             typeof (string).GetMethod("TrimStart", Type.EmptyTypes),
-            typeof (string).GetMethod("TrimEnd", Type.EmptyTypes)
+            typeof (string).GetMethod("TrimEnd", Type.EmptyTypes),
+            typeof (string).GetMethod("TrimStart", new [] { typeof(char[])}),
+            typeof (string).GetMethod("TrimEnd", new [] { typeof(char[])}),
         };
 
         public IEnumerable<MethodInfo> SupportMethods


### PR DESCRIPTION
Motivation
----------
All LINQ queries will fail with a type initializer exception if the
target .NET Framework doesn't implement string.TrimStart and
string.TrimEnd with no parameters.

Modifications
-------------
Load both TrimStart and TrimEnd with no parameters and with a char[]
parameter.

Skip null MethodInfo values when building the
DefaultMethodCallTranslatorProvider, so unsupported methods on the given
framework are ignored.

Results
-------
Queries now function correctly.