### PR TITLE
Add .NET Core 2.0 to test suite

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
@@ -11,7 +11,10 @@
     <DefineConstants>$(DefineConstants);NET46</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCORE;NETCORE11</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <DefineConstants>$(DefineConstants);NETCORE;NETCORE20</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
@@ -11,7 +11,10 @@
     <DefineConstants>$(DefineConstants);NET46</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCORE;NETCORE11</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <DefineConstants>$(DefineConstants);NETCORE;NETCORE20</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/StringTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/StringTests.cs
@@ -248,7 +248,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             mockBucket.SetupGet(e => e.Name).Returns("default");
 
             var query = from contact in QueryFactory.Queryable<Contact>(mockBucket.Object)
-                        select new { name = contact.FirstName.Split(' ') };
+                        select new { name = contact.FirstName.Split(new[] {' '}) };
 
             const string expected =
                 "SELECT SPLIT(`Extent1`.`fname`, ' ') as `name` FROM `default` as `Extent1`";


### PR DESCRIPTION
Motivation
----------
Ensure compatibility with .NET Core 2.0 during testing.

Modifications
-------------
Added netcoreapp20 framework to integration and unit test projects.

Adjusted one test that was incompatible with netcoreapp20 due to
framework method signature differences (change is inconsequential to
net46 and netcoreapp11).

Results
-------
Tests now run against net46, netcore11, and netcore20.