### PR TITLE
Change to Couchbase SDK cluster versioning

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -454,7 +454,7 @@ namespace Couchbase.Linq.IntegrationTests
                 Explain();
 
             Assert.AreEqual("DistinctScan", explanation.plan["~children"][0]["#operator"].ToString());
-            Assert.AreEqual("IndexScan", explanation.plan["~children"][0].scan["#operator"].ToString());
+            Assert.True(explanation.plan["~children"][0].scan["#operator"].ToString().StartsWith("IndexScan"));
             Assert.AreEqual("brewery_address", explanation.plan["~children"][0].scan.index.ToString());
         }
 

--- a/Src/Couchbase.Linq.IntegrationTests/config.json
+++ b/Src/Couchbase.Linq.IntegrationTests/config.json
@@ -5,6 +5,8 @@
   },
 
   "couchbase": {
+    "username": "Administrator",
+    "password": "password",
     "enableConfigHeartbeart": false,
     "servers": [
       "http://localhost:8091"

--- a/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
+using Couchbase.Core.Version;
 using Couchbase.Linq.Execution;
 using Couchbase.Linq.QueryGeneration;
 using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
@@ -15,7 +16,7 @@ namespace Couchbase.Linq.UnitTests
 // ReSharper disable once InconsistentNaming
     public class N1QLTestBase
     {
-        protected static readonly Version DefaultClusterVersion = new Version(4, 0, 0);
+        protected static readonly ClusterVersion DefaultClusterVersion = new ClusterVersion(new Version(4, 0, 0));
 
         private IMemberNameResolver _memberNameResolver = new JsonNetMemberNameResolver(new DefaultContractResolver());
         internal IMemberNameResolver MemberNameResolver
@@ -42,7 +43,7 @@ namespace Couchbase.Linq.UnitTests
             return CreateN1QlQuery(bucket, expression, false);
         }
 
-        protected string CreateN1QlQuery(IBucket bucket, Expression expression, Version clusterVersion)
+        protected string CreateN1QlQuery(IBucket bucket, Expression expression, ClusterVersion clusterVersion)
         {
             return CreateN1QlQuery(bucket, expression, clusterVersion, false);
         }
@@ -52,14 +53,14 @@ namespace Couchbase.Linq.UnitTests
             return CreateN1QlQuery(bucket, expression, DefaultClusterVersion, selectDocumentMetadata);
         }
 
-        protected string CreateN1QlQuery(IBucket bucket, Expression expression, Version clusterVersion,
+        protected string CreateN1QlQuery(IBucket bucket, Expression expression, ClusterVersion clusterVersion,
             bool selectDocumentMetadata)
         {
             ScalarResultBehavior resultBehavior;
             return CreateN1QlQuery(bucket, expression, clusterVersion, selectDocumentMetadata, out resultBehavior);
         }
 
-        internal string CreateN1QlQuery(IBucket bucket, Expression expression, Version clusterVersion,
+        internal string CreateN1QlQuery(IBucket bucket, Expression expression, ClusterVersion clusterVersion,
             bool selectDocumentMetadata, out ScalarResultBehavior resultBehavior)
         {
             var queryModel = QueryParserHelper.CreateQueryParser().GetParsedQuery(expression);

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/JoinTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/JoinTests.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Core;
+using Couchbase.Core.Version;
 using Couchbase.Linq.Extensions;
 using Couchbase.Linq.UnitTests.Documents;
 using Moq;
@@ -168,7 +169,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 
             Assert.Throws<NotSupportedException>(
-                () => CreateN1QlQuery(mockBucket.Object, query.Expression, new Version(4, 1, 0)));
+                () => CreateN1QlQuery(mockBucket.Object, query.Expression, new ClusterVersion(new Version(4, 1, 0))));
         }
 
         [Test]
@@ -187,7 +188,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
                 "INNER JOIN `default` as `Extent2` " +
                 "ON KEY `Extent2`.`brewery_id` FOR `Extent1`";
 
-            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression, new Version(4, 5, 0));
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression, new ClusterVersion(new Version(4, 5, 0)));
 
             Assert.AreEqual(expected, n1QlQuery);
         }
@@ -205,7 +206,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
                         select new { beer.Name, beer.Abv, BreweryName = brewery.Name };
 
             Assert.Throws<NotSupportedException>(
-                () => CreateN1QlQuery(mockBucket.Object, query.Expression, new Version(4, 1, 0)));
+                () => CreateN1QlQuery(mockBucket.Object, query.Expression, new ClusterVersion(new Version(4, 1, 0))));
         }
 
         [Test]
@@ -225,7 +226,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
                 "LEFT JOIN `default` as `Extent2` " +
                 "ON KEY `Extent2`.`brewery_id` FOR `Extent1`";
 
-            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression, new Version(4, 5, 0));
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression, new ClusterVersion(new Version(4, 5, 0)));
 
             Assert.AreEqual(expected, n1QlQuery);
         }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/LinqQueryRequestTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/LinqQueryRequestTests.cs
@@ -25,6 +25,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             {
                 PoolConfiguration = new PoolConfiguration(new ClientConfiguration())
             });
+            bucket.Setup(m => m.Cluster).Returns(new Mock<ICluster>().Object);
 
             var context = new BucketContext(bucket.Object);
             var query = context.Query<Brewery>().Where(p => p.Name == "name");
@@ -52,6 +53,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             {
                 PoolConfiguration = new PoolConfiguration(new ClientConfiguration())
             });
+            bucket.Setup(m => m.Cluster).Returns(new Mock<ICluster>().Object);
 
             var context = new BucketContext(bucket.Object);
             var query = context.Query<Beer>().Where(p => p.Name == "name");
@@ -80,6 +82,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             {
                 PoolConfiguration = new PoolConfiguration(new ClientConfiguration())
             });
+            bucket.Setup(m => m.Cluster).Returns(new Mock<ICluster>().Object);
 
             var context = new BucketContext(bucket.Object);
             var query = context.Query<Brewery>().Where(p => p.Name == "name");
@@ -108,6 +111,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             {
                 PoolConfiguration = new PoolConfiguration(new ClientConfiguration())
             });
+            bucket.Setup(m => m.Cluster).Returns(new Mock<ICluster>().Object);
 
             var context = new BucketContext(bucket.Object);
             var query = context.Query<Brewery>().Where(p => p.Name == "name");
@@ -136,6 +140,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             {
                 PoolConfiguration = new PoolConfiguration(new ClientConfiguration())
             });
+            bucket.Setup(m => m.Cluster).Returns(new Mock<ICluster>().Object);
 
             var context = new BucketContext(bucket.Object);
             var query = context.Query<Brewery>();
@@ -165,6 +170,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             {
                 PoolConfiguration = new PoolConfiguration(new ClientConfiguration())
             });
+            bucket.Setup(m => m.Cluster).Returns(new Mock<ICluster>().Object);
 
             var context = new BucketContext(bucket.Object);
             var query = context.Query<Brewery>();
@@ -194,6 +200,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             {
                 PoolConfiguration = new PoolConfiguration(new ClientConfiguration())
             });
+            bucket.Setup(m => m.Cluster).Returns(new Mock<ICluster>().Object);
 
             var context = new BucketContext(bucket.Object);
             var query = context.Query<Brewery>().ScanConsistency(ScanConsistency.RequestPlus).Where(p => p.Name == "name");
@@ -219,6 +226,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             {
                 PoolConfiguration = new PoolConfiguration(new ClientConfiguration())
             });
+            bucket.Setup(m => m.Cluster).Returns(new Mock<ICluster>().Object);
 
             var scanWait = TimeSpan.FromMinutes(1);
 

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="2.4.5" />
+    <PackageReference Include="CouchbaseNetClient" Version="2.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Remotion.Linq" Version="2.1.1" />
   </ItemGroup>

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Core.Serialization;
+using Couchbase.Core.Version;
 using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
 using Couchbase.Linq.Versioning;
 using Newtonsoft.Json.Serialization;
@@ -22,7 +23,7 @@ namespace Couchbase.Linq.QueryGeneration
         public IMethodCallTranslatorProvider MethodCallTranslatorProvider { get; set; }
         public ParameterAggregator ParameterAggregator { get; set; }
         public ITypeSerializer Serializer { get; set; }
-        public Version ClusterVersion { get; set; }
+        public ClusterVersion ClusterVersion { get; set; }
 
         /// <summary>
         /// Stores a reference to the current grouping subquery

--- a/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
+++ b/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Couchbase.Core.Version;
 
 namespace Couchbase.Linq.Versioning
 {
@@ -15,16 +16,16 @@ namespace Couchbase.Linq.Versioning
         /// Version where support was added for index-based joins where the primary key for the join
         /// is on the left instead of the right.
         /// </summary>
-        public static readonly Version IndexJoin = new Version(4, 5, 0);
+        public static readonly ClusterVersion IndexJoin = new ClusterVersion(new Version(4, 5, 0));
 
         /// <summary>
         /// Version where support was added for RYOW consistency.
         /// </summary>
-        public static readonly Version ReadYourOwnWrite = new Version(4, 5, 0);
+        public static readonly ClusterVersion ReadYourOwnWrite = new ClusterVersion(new Version(4, 5, 0));
 
         /// <summary>
         /// Version where support was added for array indexes.
         /// </summary>
-        public static readonly Version ArrayIndexes = new Version(4, 5, 0);
+        public static readonly ClusterVersion ArrayIndexes = new ClusterVersion(new Version(4, 5, 0));
     }
 }

--- a/Src/Couchbase.Linq/Versioning/IVersionProvider.cs
+++ b/Src/Couchbase.Linq/Versioning/IVersionProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Couchbase.Core;
+using Couchbase.Core.Version;
 
 namespace Couchbase.Linq.Versioning
 {
@@ -9,12 +10,11 @@ namespace Couchbase.Linq.Versioning
     internal interface IVersionProvider
     {
         /// <summary>
-        /// Gets the version of the cluster hosting a bucket, using the cluster's
-        /// <see cref="Couchbase.Configuration.Client.ClientConfiguration"/>.
+        /// Gets the version of the cluster hosting a bucket.
         /// </summary>
         /// <param name="bucket">Couchbase bucket.</param>
         /// <exception cref="ArgumentNullException"><paramref name="bucket"/> is null.</exception>
         /// <returns>The version of the cluster hosting this bucket, or 4.0.0 if unable to determine the version.</returns>
-        Version GetVersion(IBucket bucket);
+        ClusterVersion GetVersion(IBucket bucket);
     }
 }


### PR DESCRIPTION
Motivation
----------
Current cluster versioning is incompatible with Couchbase Server 5.0 due
to RBAC.  Also, the current approach doesn't handle clusters with mixed
versions across nodes.

Modifications
-------------
Upgrade to Couchbase SDK 2.5.0.

Replaced the internal cluster version approach with the new Couchbase
SDK approach.

Updated unit tests to handle the new cluster version source.

Fixed one integration test that should expect IndexScan plan for pre-5.0
and IndexScan2 for 5.0.

Results
-------
Cluster version is more accurate, and also includes build numbers which
may be useful for some features in the future.

Cluster version is provided correctly for Couchbase Server 5.0 clusters.