### PR TITLE
Disable result streaming by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Full code list available [here](https://gist.github.com/jeffrymorris/c3bf85d73a1
 - [The META Keyword](docs/meta-keyword.md)
 - [Working With Enumerations](docs/enum.md)
 - [Asynchronous Queries](docs/async-queries.md)
+- [Result Streaming](docs/result-streaming.md)
 - [Custom JSON Serializers](docs/custom-serializers.md)
 - [Using Read Your Own Write (RYOW) Consistency](docs/ryow.md)
 - [Change Tracking (Experimental Developer Preview)](docs/change-tracking.md)

--- a/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
@@ -67,8 +67,6 @@ namespace Couchbase.Linq.Execution
             _bucket = bucket;
             _configuration = configuration;
             _bucketContext = bucketContext;
-
-            UseStreaming = true;
         }
 
         /// <summary>

--- a/Src/Couchbase.Linq/Execution/IBucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/IBucketQueryExecutor.cs
@@ -28,7 +28,7 @@ namespace Couchbase.Linq.Execution
         /// <summary>
         /// Specifies if the query results should be streamed, reducing memory utilzation for large result sets.
         /// </summary>
-        /// <remarks>The default is true.</remarks>
+        /// <remarks>The default is false.</remarks>
         bool UseStreaming { get; set; }
 
         /// <summary>

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
@@ -440,7 +440,7 @@ namespace Couchbase.Linq.Extensions
         /// <param name="useStreaming">Specifies if query results should be streamed.</param>
         /// <remarks>
         /// Streaming is not supported in combination with change tracking.  If change tracking is enabled,
-        /// this setting will be ignored.  Streaming is enabled by default.
+        /// this setting will be ignored.  Streaming is disabled by default.
         /// </remarks>
         public static IQueryable<T> UseStreaming<T>(this IQueryable<T> source, bool useStreaming)
         {

--- a/docs/result-streaming.md
+++ b/docs/result-streaming.md
@@ -1,0 +1,28 @@
+# Result Streaming
+By default, Linq2Couchbase loads the entire result set into memory before returning the result to you.  However, for very large result sets this can result in high memory utilization.  Result streaming can be used to reduce the memory footprint for these queries.
+
+## Caveats
+- Result streaming is incompatible with custom deserializers.  Results will always be streamed using Newtonsoft.Json.
+- Result streaming is always disabled when [change tracking](change-tracking.md) is enabled, even if you request streaming.
+- The benefits of result streaming are lost if you call `.ToList()` or otherwise load the results into memory yourself.  Instead, you should always iterate the collection, only using items from the collection for the lifetime of the iteration step.
+
+## Usage
+The call to UseStreaming should be immediately after the call to Query<T>.  It is only required on the first call if performing joins.
+
+```csharp
+using (var cluster = new Cluster())
+{
+    using (var bucket = cluster.OpenBucket("beer-sample"))
+    {
+        var context = new BucketContext(bucket);
+
+        var query = from beer in context.Query<Beer>().UseStreaming(true)
+                    select beer;
+
+        foreach (var beer in query)
+        {
+            // Do something here, but don't save beer outside of the loop
+        }
+    }
+}
+```


### PR DESCRIPTION
Motivation
----------
Streaming of query results is incompatible with custom deserializers, as
internally it uses Newtonsoft.Json.  Therefore, enabling streaming by
default was a breaking change for consumers using custom serializers.

Modifications
-------------
Disable query streaming by default.

Added streaming documentation, which was missing.

Results
-------
Existing consumers who have not manually specified a streaming mode will
now not use streaming.  Consumers performing change tracking will be
unaffected, as this mode already disabled streaming.  Compatibility with
custom serializers is now the default mode.

There is a small risk of an unexpected increase in memory consumption
upon upgrade if users were expecting the default setting to be enabled
and are querying very large result sets which are processed iteratively.
This should be addressed in release notes.