### PR TITLE
Use new SELECT RAW syntax to extract scalar results on Server 5.0

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/BucketQueryExecutorEmulator.cs
+++ b/Src/Couchbase.Linq.UnitTests/BucketQueryExecutorEmulator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Couchbase.Core.Version;
 using Couchbase.Linq.Execution;
 using Couchbase.Linq.QueryGeneration;
 using Couchbase.N1QL;
@@ -21,6 +22,8 @@ namespace Couchbase.Linq.UnitTests
         public TimeSpan? ScanWait { get; set; }
 
         private readonly N1QLTestBase _test;
+        private readonly ClusterVersion _clusterVersion;
+
         public N1QLTestBase Test
         {
             get { return _test; }
@@ -34,7 +37,7 @@ namespace Couchbase.Linq.UnitTests
 
         public bool UseStreaming { get; set; }
 
-        public BucketQueryExecutorEmulator(N1QLTestBase test)
+        public BucketQueryExecutorEmulator(N1QLTestBase test, ClusterVersion clusterVersion)
         {
             if (test == null)
             {
@@ -42,6 +45,7 @@ namespace Couchbase.Linq.UnitTests
             }
 
             _test = test;
+            _clusterVersion = clusterVersion;
         }
 
         public void ConsistentWith(MutationState state)
@@ -73,7 +77,8 @@ namespace Couchbase.Linq.UnitTests
             {
                 MemberNameResolver = Test.MemberNameResolver,
                 MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider(),
-                Serializer = new Core.Serialization.DefaultSerializer()
+                Serializer = new Core.Serialization.DefaultSerializer(),
+                ClusterVersion = _clusterVersion
             };
 
             var visitor = new N1QlQueryModelVisitor(queryGenerationContext);

--- a/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
-using Couchbase.Configuration.Client;
 using Couchbase.Core;
 using Couchbase.Core.Version;
 using Couchbase.Linq.Execution;
@@ -9,7 +8,6 @@ using Couchbase.Linq.QueryGeneration;
 using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
 using Moq;
 using Newtonsoft.Json.Serialization;
-using Remotion.Linq;
 
 namespace Couchbase.Linq.UnitTests
 {
@@ -31,7 +29,7 @@ namespace Couchbase.Linq.UnitTests
             {
                 if (_queryExecutor == null)
                 {
-                    _queryExecutor = new BucketQueryExecutorEmulator(this);
+                    _queryExecutor = new BucketQueryExecutorEmulator(this, DefaultClusterVersion);
                 }
 
                 return _queryExecutor;
@@ -56,8 +54,7 @@ namespace Couchbase.Linq.UnitTests
         protected string CreateN1QlQuery(IBucket bucket, Expression expression, ClusterVersion clusterVersion,
             bool selectDocumentMetadata)
         {
-            ScalarResultBehavior resultBehavior;
-            return CreateN1QlQuery(bucket, expression, clusterVersion, selectDocumentMetadata, out resultBehavior);
+            return CreateN1QlQuery(bucket, expression, clusterVersion, selectDocumentMetadata, out var _);
         }
 
         internal string CreateN1QlQuery(IBucket bucket, Expression expression, ClusterVersion clusterVersion,
@@ -88,6 +85,15 @@ namespace Couchbase.Linq.UnitTests
 
             return new BucketQueryable<T>(mockBucket.Object,
                 QueryParserHelper.CreateQueryParser(), QueryExecutor);
+        }
+
+        internal virtual IQueryable<T> CreateQueryable<T>(string bucketName, IBucketQueryExecutor queryExecutor)
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns(bucketName);
+
+            return new BucketQueryable<T>(mockBucket.Object,
+                QueryParserHelper.CreateQueryParser(), queryExecutor);
         }
 
         protected void SetContractResolver(IContractResolver contractResolver)

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Core;
 using Couchbase.Linq.UnitTests.Documents;
+using Couchbase.Linq.Versioning;
 using Moq;
 using NUnit.Framework;
 
@@ -33,6 +34,21 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         }
 
         [Test]
+        public void Test_Avg_Raw()
+        {
+            var queryExecutor = new BucketQueryExecutorEmulator(this, FeatureVersions.SelectRaw);
+
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Beer>("default", queryExecutor).Average(p => p.Abv);
+            var n1QlQuery = queryExecutor.Query;
+
+            const string expected =
+                "SELECT RAW AVG(`Extent1`.`abv`) FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
         public void Test_Count()
         {
             // ReSharper disable once UnusedVariable
@@ -41,6 +57,21 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             const string expected =
                 "SELECT COUNT(*) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Count_Raw()
+        {
+            var queryExecutor = new BucketQueryExecutorEmulator(this, FeatureVersions.SelectRaw);
+
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Beer>("default", queryExecutor).Count();
+            var n1QlQuery = queryExecutor.Query;
+
+            const string expected =
+                "SELECT RAW COUNT(*) FROM `default` as `Extent1`";
 
             Assert.AreEqual(expected, n1QlQuery);
         }
@@ -56,6 +87,23 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             const string expected =
                 "SELECT COUNT({\"Name\": `Extent1`.`name`, \"Description\": `Extent1`.`description`}) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_CountAfterSelectProjection_Raw()
+        {
+            var queryExecutor = new BucketQueryExecutorEmulator(this, FeatureVersions.SelectRaw);
+
+            // ReSharper disable once UnusedVariable
+            var temp = CreateQueryable<Beer>("default", queryExecutor)
+                .Select(p => new { p.Name, p.Description })
+                .Count();
+            var n1QlQuery = queryExecutor.Query;
+
+            const string expected =
+                "SELECT RAW COUNT({\"Name\": `Extent1`.`name`, \"Description\": `Extent1`.`description`}) FROM `default` as `Extent1`";
 
             Assert.AreEqual(expected, n1QlQuery);
         }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectTests.cs
@@ -2,6 +2,7 @@
 using Couchbase.Core;
 using Couchbase.Linq.Extensions;
 using Couchbase.Linq.UnitTests.Documents;
+using Couchbase.Linq.Versioning;
 using Moq;
 using NUnit.Framework;
 
@@ -57,6 +58,57 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Select_All_Properties_Raw()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                    .Select(e => e);
+
+            const string expected = "SELECT RAW `Extent1` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression, FeatureVersions.SelectRaw);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Select_Single_Property()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                    .Select(e => e.FirstName);
+
+            const string expected = "SELECT `Extent1`.`fname` as `result` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Select_Single_Property_Raw()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object)
+                    .Select(e => e.FirstName);
+
+            const string expected = "SELECT RAW `Extent1`.`fname` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression, FeatureVersions.SelectRaw);
 
             Assert.AreEqual(expected, n1QlQuery);
         }

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -52,6 +52,11 @@ namespace Couchbase.Linq.QueryGeneration
         public List<string> UnionParts { get; set; }
 
         /// <summary>
+        /// If true, then SELECT RAW should be used instead of a plain SELCT
+        /// </summary>
+        public bool RawSelection { get; set; }
+
+        /// <summary>
         /// Indicates the type of query or subquery being generated
         /// </summary>
         /// <remarks>
@@ -217,16 +222,22 @@ namespace Couchbase.Linq.QueryGeneration
                 sb.Append(ExplainPart);
             }
 
+            sb.Append("SELECT ");
+            if (RawSelection)
+            {
+                sb.Append("RAW ");
+            }
+
             if (!string.IsNullOrEmpty(AggregateFunction))
             {
-                sb.AppendFormat("SELECT {0}({1}{2})",
+                sb.AppendFormat("{0}({1}{2})",
                     AggregateFunction,
                     !string.IsNullOrWhiteSpace(DistinctPart) ? DistinctPart : string.Empty,
                     SelectPart);
             }
             else
             {
-                sb.AppendFormat("SELECT {0}{1}",
+                sb.AppendFormat("{0}{1}",
                     !string.IsNullOrWhiteSpace(DistinctPart) ? DistinctPart : string.Empty,
                     SelectPart);
                 //TODO support multiple select parts: http://localhost:8093/tutorial/content/#5

--- a/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
+++ b/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
@@ -27,5 +27,10 @@ namespace Couchbase.Linq.Versioning
         /// Version where support was added for array indexes.
         /// </summary>
         public static readonly ClusterVersion ArrayIndexes = new ClusterVersion(new Version(4, 5, 0));
+
+        /// <summary>
+        /// Version where support was added for SELECT RAW
+        /// </summary>
+        public static readonly ClusterVersion SelectRaw = new ClusterVersion(new Version(5, 0, 0));
     }
 }


### PR DESCRIPTION
Motivation
----------
Couchbase Server 5.0 offers a new SELECT RAW syntax which can extract
raw scalars in the result set, rather than the JSON objects always
returned by SELECT.  The current workaround is to use this syntax:

`SELECT Extent1.property as result FROM bucket as Extent1`

The `result` attribute is then extracted from the object for each row
returned.  The new syntax can be:

`SELECT RAW Extent1.property FROM bucket as Extent1`

This syntax doesn't require the wrapping object with a `result`
attribute.  This reduces data on the wire, heap allocations during
deserialization, and the number of operations to be performed processing
each result row.

This support will also be useful in future commits to implement array
subqueries, another new 5.0 feature.

Modifications
-------------
Use SELECT RAW wherever applicable instead of result extraction, so long
as the cluster is on version 5.0 or greater.

Test each of these circumstances to ensure property queries are
generated on pre-5.0 and post-5.0 servers.

Results
-------
The following types of queries now use SELECT RAW for performance if the
cluster version is 5.0 or greater:

- Selecting a document POCO directly without projection, so long as
change tracking is not enabled
- Selecting scalar properties directly
- Subqueries returning scalar properties directly
- Standalone aggregates