### PR TITLE
Support for advanced array sorting

### DIFF
--- a/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
+++ b/Src/Couchbase.Linq/Versioning/FeatureVersions.cs
@@ -32,5 +32,10 @@ namespace Couchbase.Linq.Versioning
         /// Version where support was added for SELECT RAW
         /// </summary>
         public static readonly ClusterVersion SelectRaw = new ClusterVersion(new Version(5, 0, 0));
+
+        /// <summary>
+        /// Version where support was added for SELECT ... FROM queries on arrays
+        /// </summary>
+        public static readonly ClusterVersion ArrayInFromClause = new ClusterVersion(new Version(5, 0, 0));
     }
 }


### PR DESCRIPTION
Motivation
----------
Couchbase Server 5.0 allows arrays in the FROM clause of subqueries.
This in turn allows more advanced array sorting options using ORDER BY
clauses.  Previously only arrays of scalars could be sorted.

Modifications
-------------
When advanced sorting requests are detected on array queries, and if the
cluster version is 5.0 or greater, automatically switches to using
SELECT FROM syntax instead of ARRAY IN syntax.  Doesn't throw a
NotSupportedException.

Results
-------
Advanced sorting of arrays of objects in queries is now possible on
Couchbase Server 5.0 and later.  Prior versions continue to throw a
NotSupportedException.