### PR TITLE
Issue #225: Support for dictionary index accessors

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/DictionaryTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/DictionaryTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Couchbase.Core;
+using Couchbase.Linq.UnitTests.Documents;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.QueryGeneration
+{
+    [TestFixture]
+    public class DictionaryTests : N1QLTestBase
+    {
+        #region Index
+
+        [Test]
+        public void Test_Index_Interface()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryInterface>(mockBucket.Object)
+                .Select(p => p.Dictionary["key"]);
+
+            const string expected = "SELECT `Extent1`.`Dictionary`.`key` as `result` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Index_Class()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryClass>(mockBucket.Object)
+                .Select(p => p.Dictionary["key"]);
+
+            const string expected = "SELECT `Extent1`.`Dictionary`.`key` as `result` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Index_InterfaceUntyped()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryInterfaceUntyped>(mockBucket.Object)
+                .Select(p => p.Dictionary["key"]);
+
+            const string expected = "SELECT `Extent1`.`Dictionary`.`key` as `result` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
+        // ReSharper disable ClassNeverInstantiated.Local
+        // ReSharper disable CollectionNeverUpdated.Local
+        // ReSharper disable UnusedAutoPropertyAccessor.Local
+
+        private class DictionaryInterface
+        {
+            public IDictionary<string, Beer> Dictionary { get; set; }
+        }
+
+        private class DictionaryClass
+        {
+            public Dictionary<string, Beer> Dictionary { get; set; }
+        }
+
+        private class DictionaryInterfaceUntyped
+        {
+            public IDictionary Dictionary { get; set; }
+        }
+
+
+        // ReSharper restore ClassNeverInstantiated.Local
+        // ReSharper restore CollectionNeverUpdated.Local
+        // ReSharper restore UnusedAutoPropertyAccessor.Local
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryItemMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryItemMethodCallTranslator.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
+{
+    internal class DictionaryItemMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (IDictionary).GetMethod("get_Item"),
+            typeof (IDictionary<,>).GetMethod("get_Item")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            if (methodCallExpression.Arguments[0] is ConstantExpression keyExpression)
+            {
+                var expression = expressionTreeVisitor.Expression;
+
+                expressionTreeVisitor.Visit(methodCallExpression.Object);
+                expression.Append('.');
+                expression.Append(N1QlHelpers.EscapeIdentifier(keyExpression.Value.ToString()));
+            }
+            else
+            {
+                throw new NotSupportedException("Dictionary keys must be constants");
+            }
+
+            return methodCallExpression;
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
.NET dictionarys are serialized as JSON objects, but there is currently
no way to query against the inner contents of these objects via LINQ.

Modifications
-------------
Adjusted DefaultMethodCallTranslatorProvider to support detecting
generic methods based on generic parameters of the type, not just the
method.

Added a method call translator for IDictionary.get_Item, with supporting
unit tests.

Results
-------
Calls to `dictionary["key"]` will now be correctly translated to
`dictionary.key` in N1QL.