### PR TITLE
Issue #225: Support for Dictionary<TKey, TValue>.ContainsKey(TKey)

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/DictionaryTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/DictionaryTests.cs
@@ -64,6 +64,58 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
         #endregion
 
+        #region Index
+
+        [Test]
+        public void Test_ContainsKey_Interface()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryInterface>(mockBucket.Object)
+                .Where(p => p.Dictionary.ContainsKey("key"));
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`Dictionary`.`key` IS NOT MISSING";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_ContainsKey_Class()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryClass>(mockBucket.Object)
+                .Where(p => p.Dictionary.ContainsKey("key"));
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`Dictionary`.`key` IS NOT MISSING";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_ContainsKey_InterfaceUntyped()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryInterfaceUntyped>(mockBucket.Object)
+                .Where(p => p.Dictionary.Contains("key"));
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`Dictionary`.`key` IS NOT MISSING";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
         // ReSharper disable ClassNeverInstantiated.Local
         // ReSharper disable CollectionNeverUpdated.Local
         // ReSharper disable UnusedAutoPropertyAccessor.Local

--- a/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
@@ -189,14 +189,13 @@ namespace Couchbase.Linq.QueryGeneration
             {
                 var interfaceMap = key.DeclaringType.GetTypeInfo().GetRuntimeInterfaceMap(interfaceType);
 
-                var interfaceMethod = interfaceMap.TargetMethods
-                    .Where(p => p == key)
-                    .Select((p, i) => interfaceMap.InterfaceMethods[i])
-                    .FirstOrDefault();
+                var matchedMapping = interfaceMap.TargetMethods
+                    .Select((p, i) => new {ClassMethod = p, InterfaceMethod = interfaceMap.InterfaceMethods[i]})
+                    .FirstOrDefault(p => p.ClassMethod == key);
 
-                if (interfaceMethod != null)
+                if (matchedMapping != null)
                 {
-                    var translator = GetItem(interfaceMethod);
+                    var translator = GetItem(matchedMapping.InterfaceMethod);
                     if (translator != null)
                     {
                         return translator;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryContainsKeyMethodCallTranslator .cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryContainsKeyMethodCallTranslator .cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
+{
+    internal class DictionaryContainsKeyMethodCallTranslator  : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (IDictionary).GetMethod("Contains"),
+            typeof (IDictionary<,>).GetMethod("ContainsKey")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException(nameof(methodCallExpression));
+            }
+
+            if (methodCallExpression.Arguments[0] is ConstantExpression keyExpression)
+            {
+                var expression = expressionTreeVisitor.Expression;
+
+                expressionTreeVisitor.Visit(methodCallExpression.Object);
+                expression.Append('.');
+                expression.Append(N1QlHelpers.EscapeIdentifier(keyExpression.Value.ToString()));
+                expression.Append(" IS NOT MISSING");
+            }
+            else
+            {
+                throw new NotSupportedException("Dictionary keys must be constants");
+            }
+
+            return methodCallExpression;
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
Allow queries to test for the presense of a particular key on an object
which is serialized from a Dictionary implementation.

Modifications
-------------
Implement DictionaryContainsKeyMethodCallTranslator, along with matching
unit tests.

Fix a bug in the DefaultMethodCallTranslatorProvider related to
detecting interface method translations from a class.

Results
-------
ContainsKey method calls on dictionaries may now be used in queries.