### PR TITLE
Issue #225: List dictionary keys and values

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -1443,5 +1443,71 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         #endregion
+
+        #region Dictionary
+
+        [Test]
+        public void DictionaryTests_Indexer()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries =
+                from brewery in context.Query<Dictionary<string, object>>()
+                where brewery["type"].ToString() == "brewery"
+                select brewery;
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+        }
+
+        [Test]
+        public void DictionaryTests_ContainsKey()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries =
+                from brewery in context.Query<Dictionary<string, object>>()
+                where brewery["type"].ToString() == "brewery" && brewery.ContainsKey("address")
+                select brewery;
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+        }
+
+        [Test]
+        public void DictionaryTests_Keys()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries =
+                from brewery in context.Query<Dictionary<string, object>>()
+                where brewery["type"].ToString() == "brewery"
+                select brewery.Keys.ToList();
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+            Assert.Greater(results[0].Count, 0);
+        }
+
+        [Test]
+        public void DictionaryTests_Values()
+        {
+            var bucket = ClusterHelper.GetBucket("beer-sample");
+            var context = new BucketContext(bucket);
+
+            var breweries =
+                from brewery in context.Query<Dictionary<string, object>>()
+                where brewery["type"].ToString() == "brewery"
+                select brewery.Values.ToList();
+
+            var results = breweries.Take(1).ToList();
+            Assert.AreEqual(1, results.Count);
+            Assert.Greater(results[0].Count, 0);
+        }
+
+        #endregion
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/DictionaryTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/DictionaryTests.cs
@@ -64,7 +64,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
         #endregion
 
-        #region Index
+        #region ContainsKey
 
         [Test]
         public void Test_ContainsKey_Interface()
@@ -108,6 +108,110 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
                 .Where(p => p.Dictionary.Contains("key"));
 
             const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE `Extent1`.`Dictionary`.`key` IS NOT MISSING";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
+        #region Keys
+
+        [Test]
+        public void Test_Keys_Interface()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryInterface>(mockBucket.Object)
+                .Select(p => p.Dictionary.Keys);
+
+            const string expected = "SELECT OBJECT_NAMES(`Extent1`.`Dictionary`) as `result` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Keys_Class()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryClass>(mockBucket.Object)
+                .Select(p => p.Dictionary.Keys);
+
+            const string expected = "SELECT OBJECT_NAMES(`Extent1`.`Dictionary`) as `result` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Keys_InterfaceUntyped()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryInterfaceUntyped>(mockBucket.Object)
+                .Select(p => p.Dictionary.Keys);
+
+            const string expected = "SELECT OBJECT_NAMES(`Extent1`.`Dictionary`) as `result` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
+
+        #region Values
+
+        [Test]
+        public void Test_Values_Interface()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryInterface>(mockBucket.Object)
+                .Select(p => p.Dictionary.Values);
+
+            const string expected = "SELECT OBJECT_VALUES(`Extent1`.`Dictionary`) as `result` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Values_Class()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryClass>(mockBucket.Object)
+                .Select(p => p.Dictionary.Values);
+
+            const string expected = "SELECT OBJECT_VALUES(`Extent1`.`Dictionary`) as `result` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_Values_InterfaceUntyped()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<DictionaryInterfaceUntyped>(mockBucket.Object)
+                .Select(p => p.Dictionary.Values);
+
+            const string expected = "SELECT OBJECT_VALUES(`Extent1`.`Dictionary`) as `result` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryKeysMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryKeysMethodCallTranslator.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
+{
+    internal class DictionaryKeysMethodCallTranslator  : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (IDictionary).GetMethod("get_Keys"),
+            typeof (IDictionary<,>).GetMethod("get_Keys"),
+            typeof (Dictionary<,>).GetMethod("get_Keys")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException(nameof(methodCallExpression));
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("OBJECT_NAMES(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expression.Append(')');
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryValuesMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryValuesMethodCallTranslator.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
+{
+    internal class DictionaryValuesMethodCallTranslator  : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (IDictionary).GetMethod("get_Values"),
+            typeof (IDictionary<,>).GetMethod("get_Values"),
+            typeof (Dictionary<,>).GetMethod("get_Values")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException(nameof(methodCallExpression));
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("OBJECT_VALUES(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expression.Append(')');
+
+            return methodCallExpression;
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
Allow the enumeration of dictionary keys and values within N1QL queries.

Modifications
-------------
May Dictionary.Keys to the OBJECT_NAMES function, and Dictionary.Values
to the OBJECT_VALUES function.

Create supporting unit tests, and also fill in some missing integration
tests for all supported dictionary functions.

Results
-------
Dictionary keys and values can now be enumerated within N1QL queries.

Note: To return one of these lists in the select projection, it is
necessary to call .ToList() on them.  The type returned by is not
deserializable because it has a private constructor.  This is only
necessary when returning the list in the select projection, not for
using the list in other clauses.