### PR TITLE
Issue #232: ANSI NEST for .Nest and .LeftOuterNest

### DIFF
--- a/Src/Couchbase.Linq/QueryGeneration/FromParts/AnsiJoinPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/FromParts/AnsiJoinPart.cs
@@ -19,6 +19,11 @@ namespace Couchbase.Linq.QueryGeneration.FromParts
         public string InnerKey { get; set; }
 
         /// <summary>
+        /// Join operator, defaults to "="
+        /// </summary>
+        public string Operator { get; set; } = "=";
+
+        /// <summary>
         /// Additional predicates to apply to the inner sequence.
         /// </summary>
         public string AdditionalInnerPredicates { get; set; }
@@ -27,7 +32,7 @@ namespace Couchbase.Linq.QueryGeneration.FromParts
         {
             base.AppendToStringBuilder(sb);
 
-            sb.AppendFormat(" ON ({0} = {1})", OuterKey, InnerKey);
+            sb.AppendFormat(" ON ({0} {1} {2})", OuterKey, Operator, InnerKey);
 
             if (!string.IsNullOrEmpty(AdditionalInnerPredicates))
             {


### PR DESCRIPTION
Motivation
----------
Couchbase Server 5.5 supports replacing the ON KEYS syntax for NEST
clauses with ANSI syntax using META().id.  However, mixing ANSI and ON
KEYS syntax is not allowed.  To prevent failed queries, we must use the
ANSI syntax for all joins, including nests via calls to .Nest and
.LeftOuterNest.

Modifications
-------------
Updated parsing of NestClause to default to the ANSI syntax whenever the
cluster version is >= 5.5.

Added supporting unit tests which confirm the behavior for different
cluster versions.

Results
-------
Mixed queries with regular joins, group joins, and calls to Nest methods
are possible.