### PR TITLE
Issue #232: Accept hints on ANSI NEST clauses

### DIFF
--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -1341,6 +1341,11 @@ namespace Couchbase.Linq.QueryGeneration
                     ansiJoinPart.AdditionalInnerPredicates = string.Join(" AND ",
                         subQuery.QueryModel.BodyClauses.OfType<WhereClause>()
                             .Select(p => GetN1QlExpression(p.Predicate)));
+
+                    foreach (var hintClause in subQuery.QueryModel.BodyClauses.OfType<HintClause>())
+                    {
+                        VisitHintClause(hintClause, fromPart);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Motivation
----------
When performing ANSI NEST operations, USE INDEX and USE HASH hints
should be supported.

Modifications
-------------
When parsing group joins against a subquery, check the subquery for
hints and apply them to the AnsiJoinPart.

Results
-------
Hints are applied to the right hand extent of ANSI NEST operations.