### PR TITLE
Issue #223: DateTime fields as Unix milliseconds

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/Documents/Beer.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/Documents/Beer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using Couchbase.Core.Serialization;
 using Newtonsoft.Json;
 
 namespace Couchbase.Linq.IntegrationTests.Documents
@@ -38,5 +39,11 @@ namespace Couchbase.Linq.IntegrationTests.Documents
 
         [JsonProperty("updated")]
         public virtual DateTime Updated { get; set; }
+
+        // This property isn't normally on beers in the beer-sample bucket
+        // But we need it for some integration tests so we'll add it
+        [JsonProperty("updatedUnixMillis")]
+        [JsonConverter(typeof(UnixMillisecondsConverter))]
+        public virtual DateTime? UpdatedUnixMillis { get; set; }
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyDataMapperTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyDataMapperTests.cs
@@ -23,15 +23,12 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var configuration = new ClientConfiguration()
-            {
-                Serializer = () => new Mock<ITypeSerializer>().Object
-            };
+            var serializer = new Mock<ITypeSerializer>();
 
             // Act/Assert
 
             // ReSharper disable once ObjectCreationAsStatement
-            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper<Document>(configuration, new Mock<IChangeTrackableContext>().Object));
+            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper<Document>(serializer.Object, new Mock<IChangeTrackableContext>().Object));
         }
 
         [Test]
@@ -45,15 +42,10 @@ namespace Couchbase.Linq.UnitTests.Proxies
                 CustomObjectCreator = false
             });
 
-            var configuration = new ClientConfiguration()
-            {
-                Serializer = () => serializer.Object
-            };
-
             // Act/Assert
 
             // ReSharper disable once ObjectCreationAsStatement
-            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper<Document>(configuration, new Mock<IChangeTrackableContext>().Object));
+            Assert.Throws<NotSupportedException>(() => new DocumentProxyDataMapper<Document>(serializer.Object, new Mock<IChangeTrackableContext>().Object));
         }
 
         [Test]
@@ -61,12 +53,9 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var configuration = new ClientConfiguration()
-            {
-                Serializer = () => new FakeSerializer()
-            };
+            var serializer = new FakeSerializer();
 
-            var dataMapper = new DocumentProxyDataMapper<Document>(configuration, new Mock<IChangeTrackableContext>().Object);
+            var dataMapper = new DocumentProxyDataMapper<Document>(serializer, new Mock<IChangeTrackableContext>().Object);
 
             // Act
 
@@ -83,12 +72,9 @@ namespace Couchbase.Linq.UnitTests.Proxies
         {
             // Arrange
 
-            var configuration = new ClientConfiguration()
-            {
-                Serializer = () => new FakeSerializer()
-            };
+            var serializer = new FakeSerializer();
 
-            var dataMapper = new DocumentProxyDataMapper<Document>(configuration, new Mock<IChangeTrackableContext>().Object);
+            var dataMapper = new DocumentProxyDataMapper<Document>(serializer, new Mock<IChangeTrackableContext>().Object);
 
             // Act
 

--- a/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Proxies/DocumentProxyTests.cs
@@ -49,7 +49,7 @@ namespace Couchbase.Linq.UnitTests.Proxies
             // Arrange
 
             var configuration = new ClientConfiguration();
-            var dataMapper = new DocumentProxyDataMapper<DocumentRoot>(configuration, null);
+            var dataMapper = new DocumentProxyDataMapper<DocumentRoot>(configuration.Serializer.Invoke(), null);
 
             DocumentRoot proxy;
             using (var stream = new System.IO.MemoryStream(Encoding.UTF8.GetBytes("{\"stringProperty\":\"value\",\"__metadata\":{\"id\":\"test\"}}")))

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/MethodCallTranslators/UnixMillisecondsMethodCallTranslatorTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/MethodCallTranslators/UnixMillisecondsMethodCallTranslatorTests.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Core.Serialization;
+using Couchbase.Linq.QueryGeneration;
+using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
+using Couchbase.Linq.QueryGeneration.MethodCallTranslators;
+using Moq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+
+namespace Couchbase.Linq.UnitTests.QueryGeneration.MethodCallTranslators
+{
+    class UnixMillisecondsMethodCallTranslatorTests
+    {
+        private static readonly DateTime ExampleDateTime = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private const string ExampleDateTimeString = "2010-01-01T00:00:00Z";
+        private const long ExampleDateTimeUnixMilliseconds = 1262304000000;
+
+        #region Translate
+
+        [Test]
+        public void Translate_NoMethod_ThrowsArgumentNullException()
+        {
+            // Arrange
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext())
+            {
+                CallBase = true
+            };
+
+            var translator = new UnixMillisecondsMethodCallTranslator();
+
+            // Act/Assert
+
+            var result = Assert.Throws<ArgumentNullException>(() => translator.Translate(null, visitor.Object));
+
+            Assert.AreEqual("methodCallExpression", result.ParamName);
+        }
+
+        [Test]
+        public void Translate_NoVisitor_ThrowsArgumentNullException()
+        {
+            // Arrange
+
+            var method = typeof(UnixMillisecondsDateTime).GetTypeInfo().GetMethod("FromDateTime", new [] {typeof(DateTime)});
+            Assert.NotNull(method);
+
+            var expression = Expression.Call(method,
+                Expression.Constant(ExampleDateTime));
+
+            var translator = new UnixMillisecondsMethodCallTranslator();
+
+            // Act/Assert
+
+            var result = Assert.Throws<ArgumentNullException>(() => translator.Translate(expression, null));
+
+            Assert.AreEqual("expressionTreeVisitor", result.ParamName);
+        }
+
+        [Test]
+        public void Translate_FromDateTimeConstant_RendersCorrectly()
+        {
+            // Arrange
+
+            var serializer = new DefaultSerializer();
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext()
+            {
+                Serializer = serializer,
+                MemberNameResolver = new ExtendedTypeSerializerMemberNameResolver(serializer)
+            })
+            {
+                CallBase = true
+            };
+
+            var method = typeof(UnixMillisecondsDateTime).GetTypeInfo().GetMethod("FromDateTime", new[] { typeof(DateTime) });
+            Assert.NotNull(method);
+
+            var expression = Expression.Call(method,
+                Expression.Constant(ExampleDateTime));
+
+            var translator = new UnixMillisecondsMethodCallTranslator();
+
+            // Act
+
+            translator.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            Assert.AreEqual($"STR_TO_MILLIS(\"{ExampleDateTimeString}\")", result);
+        }
+
+        [Test]
+        public void Translate_FromDateTimeIso_RendersCorrectly()
+        {
+            // Arrange
+
+            var serializer = new DefaultSerializer();
+            var extentNameProvider = new N1QlExtentNameProvider();
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext
+            {
+                Serializer = serializer,
+                MemberNameResolver = new ExtendedTypeSerializerMemberNameResolver(serializer),
+                ExtentNameProvider = extentNameProvider
+            })
+            {
+                CallBase = true
+            };
+
+            var method = typeof(UnixMillisecondsDateTime).GetTypeInfo().GetMethod("FromDateTime", new[] { typeof(DateTime) });
+            Assert.NotNull(method);
+
+            var property = typeof(Iso).GetTypeInfo().GetProperty("Value");
+            Assert.NotNull(property);
+
+            var querySource = new Mock<IQuerySource>();
+            querySource.SetupGet(m => m.ItemName).Returns("p");
+            querySource.SetupGet(m => m.ItemType).Returns(typeof(Iso));
+
+            var querySourceReference = new QuerySourceReferenceExpression(querySource.Object);
+
+            var expression = Expression.Call(method,
+                Expression.MakeMemberAccess(
+                    querySourceReference,
+                    property));
+
+            var translator = new UnixMillisecondsMethodCallTranslator();
+
+            // Act
+
+            translator.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            var extentName = extentNameProvider.GetExtentName(querySource.Object);
+            Assert.AreEqual($"STR_TO_MILLIS({extentName}.`value`)", result);
+        }
+
+        [Test]
+        public void Translate_FromDateTimeUnix_RendersCorrectly()
+        {
+            // Arrange
+
+            var serializer = new DefaultSerializer();
+            var extentNameProvider = new N1QlExtentNameProvider();
+
+            var visitor = new Mock<N1QlExpressionTreeVisitor>(new N1QlQueryGenerationContext
+            {
+                Serializer = serializer,
+                MemberNameResolver = new ExtendedTypeSerializerMemberNameResolver(serializer),
+                ExtentNameProvider = extentNameProvider
+            })
+            {
+                CallBase = true
+            };
+
+            var method = typeof(UnixMillisecondsDateTime).GetTypeInfo().GetMethod("FromDateTime", new[] { typeof(DateTime) });
+            Assert.NotNull(method);
+
+            var property = typeof(UnixMillis).GetTypeInfo().GetProperty("Value");
+            Assert.NotNull(property);
+
+            var querySource = new Mock<IQuerySource>();
+            querySource.SetupGet(m => m.ItemName).Returns("p");
+            querySource.SetupGet(m => m.ItemType).Returns(typeof(UnixMillis));
+
+            var querySourceReference = new QuerySourceReferenceExpression(querySource.Object);
+
+            var expression = Expression.Call(method,
+                Expression.MakeMemberAccess(
+                    querySourceReference,
+                    property));
+
+            var translator = new UnixMillisecondsMethodCallTranslator();
+
+            // Act
+
+            translator.Translate(expression, visitor.Object);
+            var result = visitor.Object.GetN1QlExpression();
+
+            // Assert
+
+            var extentName = extentNameProvider.GetExtentName(querySource.Object);
+            Assert.AreEqual($"{extentName}.`value`", result);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private class Iso
+        {
+            public DateTime Value { get; set; }
+        }
+
+        private class UnixMillis
+        {
+            [JsonConverter(typeof(UnixMillisecondsConverter))]
+            public DateTime Value { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -16,7 +16,7 @@
     <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <RootNamespace>Couchbase.Linq</RootNamespace>
     <AssemblyName>Couchbase.Linq</AssemblyName>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.1</NetStandardImplicitPackageVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <VersionPrefix>1.3.2</VersionPrefix>
     <Version>1.3.2.1</Version>
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="2.5.0" />
+    <PackageReference Include="CouchbaseNetClient" Version="2.6.0-beta" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Remotion.Linq" Version="2.1.1" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/Src/Couchbase.Linq/Proxies/DocumentProxyDataMapper.cs
+++ b/Src/Couchbase.Linq/Proxies/DocumentProxyDataMapper.cs
@@ -24,21 +24,11 @@ namespace Couchbase.Linq.Proxies
         private readonly IExtendedTypeSerializer _serializer;
         private readonly IChangeTrackableContext _context;
 
-        public DocumentProxyDataMapper(ClientConfiguration configuration, IChangeTrackableContext context)
+        public DocumentProxyDataMapper(ITypeSerializer serializer, IChangeTrackableContext context)
         {
+            _serializer = (serializer ?? throw new ArgumentNullException(nameof(serializer))) as IExtendedTypeSerializer;
 
-            if (configuration == null)
-            {
-                throw new ArgumentNullException("configuration");
-            }
-
-            _serializer = configuration.Serializer.Invoke() as IExtendedTypeSerializer;
-            if (_serializer == null)
-            {
-                throw new NotSupportedException("Change tracking is not supported without an IExtendedTypeSerializer which supports CustomObjectCreator.");
-            }
-
-            if (!_serializer.SupportedDeserializationOptions.CustomObjectCreator)
+            if (_serializer == null || !_serializer.SupportedDeserializationOptions.CustomObjectCreator)
             {
                 throw new NotSupportedException("Change tracking is not supported without an IExtendedTypeSerializer which supports CustomObjectCreator.");
             }

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/N1QlFunctionMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/N1QlFunctionMethodCallTranslator.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+using Couchbase.Linq.Serialization;
 
 namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
@@ -77,7 +74,18 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                     expressionTreeVisitor.Expression.Append(", ");
                 }
 
-                expressionTreeVisitor.Visit(methodCallExpression.Arguments[i]);
+                var argument = methodCallExpression.Arguments[i];
+
+                if (argument.Type == typeof(DateTime) && expressionTreeVisitor.QueryGenerationContext.IsUnixMillisecondsMember(argument))
+                {
+                    expressionTreeVisitor.Expression.Append("MILLIS_TO_STR(");
+                    expressionTreeVisitor.Visit(methodCallExpression.Arguments[i]);
+                    expressionTreeVisitor.Expression.Append(')');
+                }
+                else
+                {
+                    expressionTreeVisitor.Visit(methodCallExpression.Arguments[i]);
+                }
             }
 
             expressionTreeVisitor.Expression.Append(')');

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlQueryGenerationContext.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Couchbase.Core.Serialization;
 using Couchbase.Core.Version;
 using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
+using Couchbase.Linq.Serialization;
 using Couchbase.Linq.Versioning;
 using Newtonsoft.Json.Serialization;
 using Remotion.Linq.Clauses.Expressions;
@@ -17,6 +18,7 @@ namespace Couchbase.Linq.QueryGeneration
     /// </summary>
     internal class N1QlQueryGenerationContext
     {
+        private IDateTimeSerializationFormatProvider _dateTimeSerializationFormatProvider;
 
         public N1QlExtentNameProvider ExtentNameProvider { get; set; }
         public IMemberNameResolver MemberNameResolver { get; set; }
@@ -34,6 +36,25 @@ namespace Couchbase.Linq.QueryGeneration
         /// If true, indicates that the document metadata should also be included in the select projection as "__metadata"
         /// </summary>
         public bool SelectDocumentMetadata { get; set; }
+
+        /// <summary>
+        /// <see cref="IDateTimeSerializationFormatProvider"/> to use when determining the serialization format
+        /// of DateTime properties.
+        /// </summary>
+        public IDateTimeSerializationFormatProvider DateTimeSerializationFormatProvider
+        {
+            get
+            {
+                if (_dateTimeSerializationFormatProvider == null)
+                {
+                    // ReSharper disable once SuspiciousTypeConversion.Global
+                    _dateTimeSerializationFormatProvider = Serializer as IDateTimeSerializationFormatProvider ??
+                                                           new DefaultDateTimeSerializationFormatProvider(Serializer);
+                }
+
+                return _dateTimeSerializationFormatProvider;
+            }
+        }
 
         public N1QlQueryGenerationContext()
         {

--- a/Src/Couchbase.Linq/Serialization/DateTimeQueryGenerationContextExtensions.cs
+++ b/Src/Couchbase.Linq/Serialization/DateTimeQueryGenerationContextExtensions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.QueryGeneration;
+
+namespace Couchbase.Linq.Serialization
+{
+    /// <summary>
+    /// Extensions to <see cref="N1QlQueryGenerationContext"/> to assist with DateTime serialization.
+    /// </summary>
+    internal static class DateTimeQueryGenerationContextExtensions
+    {
+        /// <summary>
+        /// Tests an <see cref="Expression"/> returning a DateTime to see if it is serialized as
+        /// Unix milliseconds using the <see cref="N1QlQueryGenerationContext.DateTimeSerializationFormatProvider"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="N1QlQueryGenerationContext"/>.</param>
+        /// <param name="expression">Expression which returns a DateTime.</param>
+        /// <returns>True if the member is serialized as Unix milliseconds.</returns>
+        public static bool IsUnixMillisecondsMember(this N1QlQueryGenerationContext context, Expression expression)
+        {
+            var memberInfo = ExtractMemberInfo(expression);
+
+            if (memberInfo != null)
+            {
+                return context.DateTimeSerializationFormatProvider.GetDateTimeSerializationFormat(memberInfo) ==
+                       DateTimeSerializationFormat.UnixMilliseconds;
+            }
+
+            return false;
+        }
+
+        private static MemberInfo ExtractMemberInfo(Expression expression)
+        {
+            if (expression is UnaryExpression convertExpression)
+            {
+                if (convertExpression.NodeType == ExpressionType.Convert && convertExpression.IsLifted)
+                {
+                    var typeInfo = convertExpression.Operand.Type.GetTypeInfo();
+
+                    if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    {
+                        // Expression is a call to Nullable<DateTime>.Value, so we should really be testing the inner operand
+
+                        expression = convertExpression.Operand;
+                    }
+                }
+            }
+
+            return (expression as MemberExpression)?.Member;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Serialization/DateTimeSerializationFormat.cs
+++ b/Src/Couchbase.Linq/Serialization/DateTimeSerializationFormat.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Couchbase.Linq.Serialization
+{
+    /// <summary>
+    /// Indicates how a <see cref="DateTime"/> property is serialized. This does not affect
+    /// the actual serialization or deserialization, a JsonConverter or similar method
+    /// should be used. This setting simply informs the query generator what format to expect.
+    /// </summary>
+    public enum DateTimeSerializationFormat
+    {
+        Iso8601,
+        UnixMilliseconds
+    }
+}

--- a/Src/Couchbase.Linq/Serialization/DefaultDateTimeSerializationFormatProvider.cs
+++ b/Src/Couchbase.Linq/Serialization/DefaultDateTimeSerializationFormatProvider.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Couchbase.Core.Serialization;
+using Newtonsoft.Json.Serialization;
+
+namespace Couchbase.Linq.Serialization
+{
+    /// <summary>
+    /// Implementation of <see cref="IDateTimeSerializationFormatProvider"/> used if the Couchbase serializer
+    /// doesn't implement the interface.  Checks to see if the <see cref="JsonConverter"/> for the property
+    /// is <see cref="UnixMillisecondsConverter"/> to determine if the format should be ISO8601 or Unix milliseconds.
+    /// Only works with <see cref="DefaultSerializer"/>, if using a custom serializer please implement
+    /// <see cref="IDateTimeSerializationFormatProvider"/> directly on the serializer.
+    /// </summary>
+    internal class DefaultDateTimeSerializationFormatProvider : IDateTimeSerializationFormatProvider
+    {
+        // Uses a weak table to track a cache for each ITypeSerializer instance
+        // Because it's a weak table, this won't cause memory leaks and will cleanup as GC collects the serializers
+        private static readonly
+            ConditionalWeakTable<ITypeSerializer, ConcurrentDictionary<MemberInfo, DateTimeSerializationFormat>> CacheSet =
+                new ConditionalWeakTable<ITypeSerializer, ConcurrentDictionary<MemberInfo, DateTimeSerializationFormat>>();
+
+        private readonly ITypeSerializer _serializer;
+        private readonly ConcurrentDictionary<MemberInfo, DateTimeSerializationFormat> _cache;
+
+        public DefaultDateTimeSerializationFormatProvider(ITypeSerializer serializer)
+        {
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+
+            _cache = CacheSet.GetOrCreateValue(serializer);
+        }
+
+        public DateTimeSerializationFormat GetDateTimeSerializationFormat(MemberInfo member)
+        {
+            if (member == null)
+            {
+                throw new ArgumentNullException(nameof(member));
+            }
+
+            if (!(_serializer is DefaultSerializer defaultSerializer))
+            {
+                // Default behavior
+                return DateTimeSerializationFormat.Iso8601;
+            }
+
+            return _cache.GetOrAdd(member, p =>
+            {
+                if (defaultSerializer.SerializerSettings.ContractResolver.ResolveContract(member.DeclaringType) is JsonObjectContract contract)
+                {
+                    var property = contract.Properties.FirstOrDefault(
+                        q => q.UnderlyingName == member.Name && !q.Ignored);
+
+                    if (property?.Converter is UnixMillisecondsConverter)
+                    {
+                        return DateTimeSerializationFormat.UnixMilliseconds;
+                    }
+                }
+
+                // Default behavior
+                return DateTimeSerializationFormat.Iso8601;
+            });
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Serialization/IDateTimeSerializationFormatProvider.cs
+++ b/Src/Couchbase.Linq/Serialization/IDateTimeSerializationFormatProvider.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Reflection;
+using Couchbase.Core.Serialization;
+
+namespace Couchbase.Linq.Serialization
+{
+    /// <summary>
+    /// Extension applied to <see cref="ITypeSerializer"/> implementations to provide
+    /// information about how <see cref="DateTime"/> members are serialized.
+    /// </summary>
+    public interface IDateTimeSerializationFormatProvider
+    {
+        /// <summary>
+        /// Provides information about how a <see cref="DateTime"/> member is serialized.
+        /// </summary>
+        /// <param name="member">Member being serialized or deserialized.</param>
+        /// <returns>The member's <see cref="DateTimeSerializationFormat"/>.</returns>
+        /// <remarks>
+        /// Should implement an internal cache for performance, as this method will be
+        /// called repeatedly for the same member.
+        /// </remarks>
+        DateTimeSerializationFormat GetDateTimeSerializationFormat(MemberInfo member);
+    }
+}

--- a/docs/custom-serializers.md
+++ b/docs/custom-serializers.md
@@ -1,5 +1,5 @@
-Custom JSON Serializers
-=======================
+# Custom JSON Serializers
+
 The Couchbase SDK uses Newtonsoft's Json.Net as its default JSON serializer.  If you are using a custom serializer, there are some special requirements which must be met to support Linq2Couchbase.
 
 Custom serializers are used by creating a class which implements the ITypeSerializer interface, and including it in the SDK configuration.  However, to support Linq2Couchbase, instead the serializer should extend IExtendedTypeSerializer.  This interface provides a key additional feature.
@@ -7,3 +7,11 @@ Custom serializers are used by creating a class which implements the ITypeSerial
 The GetMemberName method is used to determine how a particular member property of a POCO will be written as JSON to the document in Couchbase.  This is important, because the N1QL query must reference member names in the way they appear in Couchbase, not the way they appear in your .Net POCOs.
 
 Here is [an example of how this method was implemented for Newtonsoft's Json.Net](https://github.com/couchbase/couchbase-net-client/blob/03d7957226da6f7c3e05220a21e7ebeeb0519b93/Src/Couchbase/Core/Serialization/DefaultSerializer.cs#L192).
+
+## Date/Times
+
+By default, Linq2Couchbase assumes that DateTime properties are serialized as ISO 8601 strings.  When using the default serializer, attributes may be used to indicate that they are stored as milliseconds since the Unix epoch.  See [Date Handling](./date-handling.md) for more information.
+
+For custom serializers that wish to use Unix milliseconds, an extra step is required.  The serializer must implement the IDateTimeSerializationFormatProvider interface (in addition to IExtendedTypeSerializer).  This interface provides the GetDateTimeSerializationFormat, which is used by Linq2Couchbase to determine if a property is serialized as ISO 8601 or Unix milliseconds.
+
+For performance reasons, be sure to use a cache in your internal implementation.  The method is called each time a candidate DateTime property is encountered.  In a system under load this could be many times per second for the same property.

--- a/docs/date-handling.md
+++ b/docs/date-handling.md
@@ -1,42 +1,50 @@
-Date Handling
-=============
+# Date Handling
+
 LINQ works with dates under the assumption that they are stored in the JSON documents as [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted strings.  For more information about N1QL functions and date handling, see [Date functions](http://developer.couchbase.com/documentation/server/4.0/n1ql/n1ql-language-reference/datefun.html) in the N1QL language reference.
 
-##Date Comparisons
+Date/times stored as milliseconds since the Unix epoch are also supported.  Simply add the `[JsonConverter(typeof(UnixMillisecondsConverter)]` attribute to the property if you are using the default Newtonsoft.Json serializer.  For custom serializers, see [Custom JSON Serializers](./custom-serializers.md).
+
+## Date Comparisons
+
 Dates on documents may be compared to each other or to constants using normal .Net comparison operators, so long as the document properties use the DateTime type.
 
-	using (var cluster = new Cluster()) {
-		using (var bucket = cluster.OpenBucket("beer-sample")) {
-			var context = new BucketContext(bucket);
+```cs
+using (var cluster = new Cluster()) {
+    using (var bucket = cluster.OpenBucket("beer-sample")) {
+        var context = new BucketContext(bucket);
 
-			var query = from beer in context.Query<Beer>()
-						where beer.Updated >= new Date(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc)
-						select beer;
+        var query = from beer in context.Query<Beer>()
+                    where beer.Updated >= new Date(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                    select beer;
 
-			foreach (var doc in query) {
-				// do work
-				// query will return beers updated on or after Jan 1, 2015 0:00 UTC
-			}
-		}
-	}
+        foreach (var doc in query) {
+            // do work
+            // query will return beers updated on or after Jan 1, 2015 0:00 UTC
+        }
+    }
+}
+```
 
-##Date Functions
+## Date Functions
+
 A subset of N1QL date/time functions are supported for use in LINQ queries, and are provided as static methods of the N1QlFunctions class.
 
-	using (var cluster = new Cluster()) {
-		using (var bucket = cluster.OpenBucket("beer-sample")) {
-			var context = new BucketContext(bucket);
+```cs
+using (var cluster = new Cluster()) {
+    using (var bucket = cluster.OpenBucket("beer-sample")) {
+        var context = new BucketContext(bucket);
 
-			var query = from beer in context.Query<Beer>()
-						where N1QlFunctions.DateDiff(DateTime.Now, beer.Updated, N1QlDatePart.Day) > 10
-						select beer;
+        var query = from beer in context.Query<Beer>()
+                    where N1QlFunctions.DateDiff(DateTime.Now, beer.Updated, N1QlDatePart.Day) > 10
+                    select beer;
 
-			foreach (var doc in query) {
-				// do work
-				// query will return beers last updated more than 10 days ago
-			}
-		}
-	}
+        foreach (var doc in query) {
+            // do work
+            // query will return beers last updated more than 10 days ago
+        }
+    }
+}
+```
 
 | Function Name               | N1QL Equivalent |
 | --------------------------- | --------------- |
@@ -47,5 +55,6 @@ A subset of N1QL date/time functions are supported for use in LINQ queries, and 
 
 These methods may only be used within queries.  They cannot be called directly in code.  This also means that they cannot be used in unit tests where the query source is being faked.  This may be improved in a future version.
 
-##Time Zones
+## Time Zones
+
 Note that ISO 8601 date/time fields include time and time zone data.  Be sure to take this into account when working with global systems.


### PR DESCRIPTION
Motivation
----------
Support date/time comparisons and functions on values persisted as
milliseconds since the Unix epoch.

Modifications
-------------
Upgrade to Couchbase SDK 2.6.0-beta.

For the default serializer, detect the presence of the
UnixMillisecondsConverter on an attribute to indicate that the attribute
is persisted as milliseconds.  For custom serializers, allow them to
implement IDateTimeSerializationFormatProvider to provide this
information.

When rendering UnixMilliseconds.ToDateTime (used internally for by
DateTimeComparisonExpressionTransformer), skip the STR_TO_MILLIS
conversion step for these attributes.

For DateTime parameters to N1QlFunctions methods, add a MILLIS_TO_STR
conversion for these attributes.

Refactor DocumentProxyDataMapper and BucketQueryExecutor so that they
can share a serializer.

Results
-------
Fields marked with UnixMillisecondsConverter are automatically supported
on queries for comparisons and date/time functions if using the default
serializer.  Custom serializers may implement
IDateTimeSerializationProvider to get the same support.