### PR TITLE
Improve query generation performance

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/QueryFactory.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryFactory.cs
@@ -2,7 +2,7 @@
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
 
-namespace Couchbase.Linq
+namespace Couchbase.Linq.UnitTests
 {
     internal class QueryFactory
     {


### PR DESCRIPTION
Motivation
----------
Reduce redundant initialization and heap allocations during the query
generation process to improve performance.

Modifications
-------------
Cache certain readonly parts of the QueryParser statically and reuse for
each query.

Move unnecessary QueryFactory to the unit test project.

Results
-------
In rough testing of generating 100,000 N1Ql queries from a basic LINQ
query, run time was reduced by approximately 73%.  This number is only
for the query generation step, moving from an already built LINQ query
to a N1QL string, and does not account for query runtime.