### PR TITLE
Issue #232: ANSI INNER NEST clauses

### DIFF
--- a/Src/Couchbase.Linq/QueryGeneration/FromParts/AnsiJoinPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/FromParts/AnsiJoinPart.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.QueryGeneration.FromParts
 {
@@ -27,6 +28,10 @@ namespace Couchbase.Linq.QueryGeneration.FromParts
         /// Additional predicates to apply to the inner sequence.
         /// </summary>
         public string AdditionalInnerPredicates { get; set; }
+
+        public AnsiJoinPart(IQuerySource querySource) : base(querySource)
+        {
+        }
 
         public override void AppendToStringBuilder(StringBuilder sb)
         {

--- a/Src/Couchbase.Linq/QueryGeneration/FromParts/ExtentPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/FromParts/ExtentPart.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Couchbase.Linq.Clauses;
+using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.QueryGeneration.FromParts
 {
@@ -10,6 +12,17 @@ namespace Couchbase.Linq.QueryGeneration.FromParts
     /// </summary>
     internal abstract class ExtentPart
     {
+        private IQuerySource _querySource;
+
+        /// <summary>
+        /// Clause which is the source of the query data, such as a MainFromClause.
+        /// </summary>
+        public IQuerySource QuerySource
+        {
+            get => _querySource;
+            set => _querySource = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
         /// <summary>
         /// Source of the query data, such as a bucket name.  Should already be escaped.
         /// </summary>
@@ -21,6 +34,11 @@ namespace Couchbase.Linq.QueryGeneration.FromParts
         public string ItemName { get; set; }
 
         public List<HintClause> Hints { get; set; }
+
+        protected ExtentPart(IQuerySource querySource)
+        {
+            QuerySource = querySource ?? throw new ArgumentNullException(nameof(querySource));
+        }
 
         public virtual void AppendToStringBuilder(StringBuilder sb)
         {

--- a/Src/Couchbase.Linq/QueryGeneration/FromParts/FromPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/FromParts/FromPart.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
+using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.QueryGeneration.FromParts
 {
@@ -7,6 +9,10 @@ namespace Couchbase.Linq.QueryGeneration.FromParts
     /// </summary>
     internal class FromPart : ExtentPart
     {
+        public FromPart(IQuerySource querySource) : base(querySource)
+        {
+        }
+
         public override void AppendToStringBuilder(StringBuilder sb)
         {
             sb.Append(" FROM");

--- a/Src/Couchbase.Linq/QueryGeneration/FromParts/IndexJoinPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/FromParts/IndexJoinPart.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.QueryGeneration.FromParts
 {
@@ -17,6 +18,10 @@ namespace Couchbase.Linq.QueryGeneration.FromParts
         /// For index joins, the name of the extent on the left side of the join.  Should already be escaped.
         /// </summary>
         public string IndexJoinExtentName { get; set; }
+
+        public IndexJoinPart(IQuerySource querySource) : base(querySource)
+        {
+        }
 
         public override void AppendToStringBuilder(StringBuilder sb)
         {

--- a/Src/Couchbase.Linq/QueryGeneration/FromParts/JoinPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/FromParts/JoinPart.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.QueryGeneration.FromParts
 {
@@ -11,6 +12,10 @@ namespace Couchbase.Linq.QueryGeneration.FromParts
         /// Type of join to perform
         /// </summary>
         public string JoinType { get; set; }
+
+        public JoinPart(IQuerySource querySource) : base(querySource)
+        {
+        }
 
         public override void AppendToStringBuilder(StringBuilder sb)
         {

--- a/Src/Couchbase.Linq/QueryGeneration/FromParts/OnKeysJoinPart.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/FromParts/OnKeysJoinPart.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using Remotion.Linq.Clauses;
 
 namespace Couchbase.Linq.QueryGeneration.FromParts
 {
@@ -11,6 +12,10 @@ namespace Couchbase.Linq.QueryGeneration.FromParts
         /// For joins, the expression for the key value to join
         /// </summary>
         public string OnKeys { get; set; }
+
+        public OnKeysJoinPart(IQuerySource querySource) : base(querySource)
+        {
+        }
 
         public override void AppendToStringBuilder(StringBuilder sb)
         {

--- a/Src/Couchbase.Linq/QueryGeneration/InnerNestDetectingExpressionVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/InnerNestDetectingExpressionVisitor.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Couchbase.Linq.QueryGeneration.FromParts;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Parsing;
+
+namespace Couchbase.Linq.QueryGeneration
+{
+    /// <summary>
+    /// Processes the predicate of a <see cref="WhereClause"/> to find .Any() subqueries
+    /// against group join (NEST) extents.  If found, converts the group join from a
+    /// LEFT NEST to an INNER NEST and drops the subquery from the predicate.
+    /// </summary>
+    internal class InnerNestDetectingExpressionVisitor : RelinqExpressionVisitor
+    {
+        private readonly QueryPartsAggregator _queyPartsAggregator;
+
+        /// <summary>
+        /// Creates a new InnerNestDetectingExpressionVisitor.
+        /// </summary>
+        /// <param name="queyPartsAggregator"><see cref="QueryPartsAggregator"/> for the current query.</param>
+        public InnerNestDetectingExpressionVisitor(QueryPartsAggregator queyPartsAggregator)
+        {
+            _queyPartsAggregator = queyPartsAggregator ?? throw new ArgumentNullException(nameof(queyPartsAggregator));
+        }
+
+        protected override Expression VisitBinary(BinaryExpression node)
+        {
+            if (node.NodeType == ExpressionType.AndAlso)
+            {
+                var left = Visit(node.Left);
+                var right = Visit(node.Right);
+
+                if (left != null && right != null)
+                {
+                    if (left.Equals(node.Left) && right.Equals(node.Right))
+                    {
+                        // Was not modified
+                        return node;
+                    }
+                    else
+                    {
+                        // One of the sides was modified, so build a replacement binary expression
+                        return Expression.MakeBinary(node.NodeType, left, right, node.IsLiftedToNull,
+                            node.Method, node.Conversion);
+                    }
+                }
+                else if (left != null)
+                {
+                    // Right side was dropped
+                    return left;
+                }
+                else
+                {
+                    // Left side or both sides were dropped
+                    return right;
+                }
+            }
+            else
+            {
+                // Don't recurse into anything other than &&
+                return node;
+            }
+        }
+
+        protected override Expression VisitSubQuery(SubQueryExpression expression)
+        {
+            var queryModel = expression.QueryModel;
+
+            if (!IsSimpleAnySubqueryAgainstGroupJoin(queryModel, out var groupJoinClause))
+            {
+                // We don't care about subqueries with any body clauses
+                return expression;
+            }
+
+            // See if this group join is a LEFT OUTER NEST
+            var ansiJoinPart = _queyPartsAggregator.Extents.OfType<AnsiJoinPart>()
+                .FirstOrDefault(p => p.QuerySource == groupJoinClause);
+
+            if (ansiJoinPart != null && ansiJoinPart.JoinType == JoinTypes.LeftNest)
+            {
+                // Convert from a LEFT OUTER NEST to an INNER NEST
+                ansiJoinPart.JoinType = JoinTypes.InnerNest;
+
+                // And drop the expression from the WHERE clause
+                return null;
+            }
+            else
+            {
+                return expression;
+            }
+        }
+
+        private static bool IsSimpleAnySubqueryAgainstGroupJoin(QueryModel queryModel, out GroupJoinClause groupJoinClause)
+        {
+            groupJoinClause = null;
+
+            if (queryModel.BodyClauses.Count > 0)
+            {
+                return false;
+            }
+
+            if (queryModel.ResultOperators.Count != 1)
+            {
+                return false;
+            }
+
+            if (!(queryModel.ResultOperators[0] is AnyResultOperator))
+            {
+                return false;
+            }
+
+            if (queryModel.MainFromClause.FromExpression is QuerySourceReferenceExpression referenceExpression)
+            {
+                groupJoinClause = referenceExpression.ReferencedQuerySource as GroupJoinClause;
+
+                return groupJoinClause != null;
+            }
+
+            return false;
+        }
+    }
+}

--- a/docs/nest.md
+++ b/docs/nest.md
@@ -171,3 +171,24 @@ foreach (var doc in query) {
     // may return airlines with no routes
 }
 ```
+
+To perform an INNER NEST instead of a LEFT OUTER NEST, simply add a .Any() predicate to your where clause.
+
+```cs
+var context = new BucketContext(bucket);
+
+var query = from airline in context.Query<Airline>()
+            join route in context.Query<Route>().Where(route.SourceAirport == "SFO")
+                on airline.Iata equals route.Airline into routes
+            where airline.Type == "airline" && airline.Country == "United States" && routes.Any()
+            select new { airline, routes };
+
+foreach (var doc in query) {
+    // do work
+
+    // each returned "document" has a airline property which is the airline
+    // and a routes property that is an array of routes the airline flies from SFO
+
+    // will not return airlines with no routes
+}
+```


### PR DESCRIPTION
Motivation
----------
Optimize queries with ANSI NEST clauses by performing an INNER NEST if
the where clause is excluding results where the NEST returns an empty
list.

Modifications
-------------
Add QuerySource to ExtentPart to keep track of the query source clause
being referenced by the ExtentPart.

Change ANSI NEST handling to occur up front during VisitBodyClauses
instead of between VisitBodyClauses and VisitResultOperators so that the
ExtentParts are available when we reach the where clause.  Legacy NEST
handling remains unchanged.

During where clause processing, visit the predicate expression tree
looking for .Any() subqueries against NEST clauses.  When found, exclude
the subquery and convert the NEST clause to an INNER NEST.

Results
-------
ANSI INNER NEST operations are generated by simply including a .Any()
clause against the nest extent as part of the query predicates.  Only
applies to simple .Any() subqueries and must be in the top level of the
where clause using &&.