### PR TITLE
Remove PackageTargetFallback from Couchbase.Linq.UnitTests

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net46;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">


### PR DESCRIPTION
Motivation
----------
PackageTargetFallback is a legacy csproj attribute for Core 1.X and its no
longer needed and causes a build failure.

Modification
------------
 - Remove PackageTargetFallback element from Couchbase.Linq.UnitTests

Result
------
Successfully builds using internal build framework.