### PR TITLE
Issue #268: Count aggregate on an array

### DIFF
--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -364,7 +364,15 @@ namespace Couchbase.Linq.QueryGeneration
                     _queryPartsAggregator.RawSelection = true;
                 }
 
-                return "*";
+                if (_queryPartsAggregator.IsArraySubquery)
+                {
+                    // Can't use * in an array subquery
+                    return GetN1QlExpression(selectClause.Selector);
+                }
+                else
+                {
+                    return "*";
+                }
             }
 
             if (_queryPartsAggregator.IsArraySubquery)
@@ -689,7 +697,15 @@ namespace Couchbase.Linq.QueryGeneration
             }
             else if ((resultOperator is CountResultOperator) || (resultOperator is LongCountResultOperator))
             {
-                _queryPartsAggregator.AggregateFunction = "COUNT";
+                if (_queryPartsAggregator.IsArraySubquery)
+                {
+                    _queryPartsAggregator.AddWrappingFunction("ARRAY_LENGTH");
+                }
+                else
+                {
+                    _queryPartsAggregator.AggregateFunction = "COUNT";
+                }
+
                 _isAggregated = true;
             }
             else if (resultOperator is MaxResultOperator)


### PR DESCRIPTION
Motivation
----------
Queries involving a count aggregate on an array are currently failing
to generate valid N1QL.

Modifications
-------------
Ensure that the array subquery doesn't use "*", which isn't valid, in
its select projection.

Add logic to wrap the query in ARRAY_LENGTH instead of trying to use
COUNT(*).

Results
-------
Calling .Count or .CountLong on a nested array should function
correctly. Other forms of aggregation are still not supported.