### PR TITLE
Optional implementation to get the linq2couchbase log

### DIFF
--- a/Src/Couchbase.Linq/BucketContext.cs
+++ b/Src/Couchbase.Linq/BucketContext.cs
@@ -42,6 +42,16 @@ namespace Couchbase.Linq
         }
 
         /// <summary>
+        /// Creates a new BucketContext for a given Couchbase bucket.
+        /// </summary>
+        /// <param name="bucket">Bucket referenced by the new BucketContext.</param>
+        /// <param name="Log">log capture interface</param>
+        public BucketContext(IBucket bucket, ICouchbaseLinqLog Log) : this(bucket)
+        {
+            this.Log = Log;
+        }
+
+        /// <summary>
         /// Gets the bucket the <see cref="IBucketContext"/> was created against.
         /// </summary>
         /// <value>The <see cref="IBucket"/>.</value>
@@ -461,6 +471,8 @@ namespace Couchbase.Linq
         /// This function is only supported on Couchbase Server 4.5 or later.
         /// </remarks>
         public MutationState MutationState { get; private set; }
+
+        public ICouchbaseLinqLog Log { get; set; }
 
         /// <summary>
         /// Resets the <see cref="MutationState"/> to start a new set of mutations.

--- a/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
@@ -1,29 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Couchbase.Configuration.Client;
+﻿using Couchbase.Configuration.Client;
 using Couchbase.Core;
-using Couchbase.Core.Buckets;
 using Couchbase.Core.Serialization;
 using Couchbase.Linq.Operators;
 using Couchbase.Linq.QueryGeneration;
 using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
 using Couchbase.Linq.Utils;
 using Couchbase.Linq.Versioning;
-using Couchbase.Logging;
 using Couchbase.N1QL;
-using Newtonsoft.Json;
 using Remotion.Linq;
-using Remotion.Linq.Clauses.ResultOperators;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Couchbase.Linq.Execution
 {
     internal class BucketQueryExecutor : IBucketQueryExecutor
     {
-        private readonly ILog _log = LogManager.GetLogger<BucketQueryExecutor>();
         private readonly IBucket _bucket;
         private readonly ClientConfiguration _configuration;
         private readonly IBucketContext _bucketContext;
@@ -131,7 +125,7 @@ namespace Couchbase.Linq.Execution
 
             var mainFromClauseType = queryModel.MainFromClause.ItemType;
 
-            return (mainFromClauseType == typeof (T)) || (mainFromClauseType == typeof (ScalarResult<T>));
+            return (mainFromClauseType == typeof(T)) || (mainFromClauseType == typeof(ScalarResult<T>));
         }
 
         private void ApplyQueryRequestSettings(LinqQueryRequest queryRequest, bool generateProxies)
@@ -157,7 +151,7 @@ namespace Couchbase.Linq.Execution
             {
                 if (generateProxies)
                 {
-                    _log.Info("Query result streaming is not supported with change tracking, streaming disabled");
+                    _bucketContext.Log?.Info("Query result streaming is not supported with change tracking, streaming disabled");
                 }
                 else
                 {
@@ -322,7 +316,8 @@ namespace Couchbase.Linq.Execution
             visitor.VisitQueryModel(queryModel);
 
             var query = visitor.GetQuery();
-            _log.Debug("Generated query: {0}", query);
+
+            _bucketContext.Log?.Debug("Generated query: {0}", query);
 
             scalarResultBehavior = visitor.ScalarResultBehavior;
             return query;

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -110,6 +110,9 @@ namespace Couchbase.Linq
 
         #region Log
 
+        /// <summary>
+        /// Optional implementation to get the linq2couchbase log
+        /// </summary>
         ICouchbaseLinqLog Log { get; set; }
 
         #endregion

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -107,5 +107,11 @@ namespace Couchbase.Linq
         void ResetMutationState();
 
         #endregion
+
+        #region Log
+
+        ICouchbaseLinqLog Log { get; set; }
+
+        #endregion
     }
 }

--- a/Src/Couchbase.Linq/ICouchbaseLinqLog.cs
+++ b/Src/Couchbase.Linq/ICouchbaseLinqLog.cs
@@ -1,0 +1,8 @@
+﻿namespace Couchbase.Linq
+{
+    public interface ICouchbaseLinqLog
+    {
+        void Debug(string format, params object[] args);
+        void Info(string message);
+    }
+}


### PR DESCRIPTION
I see Couchbase SDK is going to change the log so i alter way to capture query log after transformation linq to n1ql. If this pull request be aprove, I will change the rest of the code.
The programer need only implemented the interface.