### PR TITLE
Issue #268: Allow selecting single fields with a Distint operator

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/DistinctTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/DistinctTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Core;
+using Couchbase.Core.Version;
 using Couchbase.Linq.UnitTests.Documents;
 using Moq;
 using NUnit.Framework;
@@ -26,6 +27,24 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             const string expected = "SELECT DISTINCT `Extent1`.`age` as `age` FROM `default` as `Extent1`";
 
             var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_DistinctRaw_CorrectOrdering()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query = QueryFactory.Queryable<Contact>(mockBucket.Object)
+                .Select(c => c.Age)
+                .Distinct();
+
+            const string expected = "SELECT DISTINCT RAW `Extent1`.`age` FROM `default` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression,
+                new ClusterVersion(new Version(5, 5)));
 
             Assert.AreEqual(expected, n1QlQuery);
         }

--- a/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/QueryPartsAggregator.cs
@@ -223,22 +223,20 @@ namespace Couchbase.Linq.QueryGeneration
             }
 
             sb.Append("SELECT ");
-            if (RawSelection)
-            {
-                sb.Append("RAW ");
-            }
 
             if (!string.IsNullOrEmpty(AggregateFunction))
             {
-                sb.AppendFormat("{0}({1}{2})",
+                sb.AppendFormat("{0}{1}({2}{3})",
+                    RawSelection ? "RAW " : string.Empty,
                     AggregateFunction,
                     !string.IsNullOrWhiteSpace(DistinctPart) ? DistinctPart : string.Empty,
                     SelectPart);
             }
             else
             {
-                sb.AppendFormat("{0}{1}",
+                sb.AppendFormat("{0}{1}{2}",
                     !string.IsNullOrWhiteSpace(DistinctPart) ? DistinctPart : string.Empty,
+                    RawSelection ? "RAW " : string.Empty,
                     SelectPart);
                 //TODO support multiple select parts: http://localhost:8093/tutorial/content/#5
             }


### PR DESCRIPTION
Motivation
----------
The currently generated query when selecting a single field with a
Distinct operator is invalid.

Modifications
-------------
Switch the order of the DISTINCT and RAW clauses on the generated query.

Results
-------
The query works with this combination of operators.