### PR TITLE
Remove streaming support for SDK 3

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -63,24 +63,6 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
-        public void Map2PocoTests_Simple_Projections_Streamed()
-        {
-            var bucket = ClusterHelper.GetBucket("beer-sample");
-            var context = new BucketContext(bucket);
-
-            var beers = from b in context.Query<Beer>().UseStreaming(true)
-                        select new { name = b.Name, abv = b.Abv };
-
-            var results = beers.Take(10).ToList();
-            Assert.AreEqual(10, results.Count());
-
-            foreach (var b in results)
-            {
-                Console.WriteLine("{0} has {1} ABV", b.name, b.abv);
-            }
-        }
-
-        [Test]
         public void Map2PocoTests_StronglyTyped_Projections()
         {
             var bucket = ClusterHelper.GetBucket("beer-sample");

--- a/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/BucketQueryExecutor.cs
@@ -52,9 +52,6 @@ namespace Couchbase.Linq.Execution
 
         public MutationState MutationState { get; private set; }
 
-        /// <inheritdoc cref="IBucketQueryExecutor.UseStreaming"/>
-        public bool UseStreaming { get; set; }
-
         private ITypeSerializer Serializer
         {
             get
@@ -120,11 +117,6 @@ namespace Couchbase.Linq.Execution
             if (MutationState != null)
             {
                 queryRequest.ConsistentWith(MutationState);
-            }
-
-            if (UseStreaming)
-            {
-                queryRequest.UseStreaming(true);
             }
         }
 

--- a/Src/Couchbase.Linq/Execution/IBucketQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/IBucketQueryExecutor.cs
@@ -32,12 +32,6 @@ namespace Couchbase.Linq.Execution
         TimeSpan? Timeout { get; set; }
 
         /// <summary>
-        /// Specifies if the query results should be streamed, reducing memory utilzation for large result sets.
-        /// </summary>
-        /// <remarks>The default is false.</remarks>
-        bool UseStreaming { get; set; }
-
-        /// <summary>
         /// Requires that the indexes but up to date with a <see cref="MutationState"/> before the query is executed.
         /// </summary>
         /// <param name="state"><see cref="MutationState"/> used for conistency controls.</param>

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
@@ -526,32 +526,6 @@ namespace Couchbase.Linq.Extensions
             return source;
         }
 
-        /// <summary>
-        /// Specifies if the query results should be streamed, reducing memory utilzation for large result sets.
-        /// </summary>
-        /// <param name="source">Sets scan consistency for this query.  Must be a Couchbase LINQ query.</param>
-        /// <param name="useStreaming">Specifies if query results should be streamed.</param>
-        /// <remarks>
-        /// Streaming is not supported in combination with change tracking.  If change tracking is enabled,
-        /// this setting will be ignored.  Streaming is disabled by default.
-        /// </remarks>
-        public static IQueryable<T> UseStreaming<T>(this IQueryable<T> source, bool useStreaming)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException("source");
-            }
-            if (!(source is IBucketQueryExecutorProvider))
-            {
-                // do nothing if this isn't a Couchbase LINQ query
-                return source;
-            }
-
-            ((IBucketQueryExecutorProvider)source).BucketQueryExecutor.UseStreaming = useStreaming;
-
-            return source;
-        }
-
         #endregion
 
         private static void EnsureBucketQueryable<T>(IQueryable<T> source, string methodName, string paramName)


### PR DESCRIPTION
Motivation
----------
In SDK 3 queries always transparently stream (if supported by the type
serializer), so having options to control it makes no sense.

Modifications
-------------
Remove the IQueryable extension and support on the BucketQueryExecutor.

Results
-------
One step closer to moving to SDK 3.

Closes #292