### PR TITLE
Re-enable UnixMillisecondsConverter

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/Documents/Beer.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/Documents/Beer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Couchbase.Core.IO.Serializers;
 using Newtonsoft.Json;
 
 namespace Couchbase.Linq.IntegrationTests.Documents
@@ -38,11 +39,10 @@ namespace Couchbase.Linq.IntegrationTests.Documents
         [JsonProperty("updated")]
         public virtual DateTime Updated { get; set; }
 
-        // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
         // This property isn't normally on beers in the beer-sample bucket
         // But we need it for some integration tests so we'll add it
-        //[JsonProperty("updatedUnixMillis")]
-        //[JsonConverter(typeof(UnixMillisecondsConverter))]
-        //public virtual DateTime? UpdatedUnixMillis { get; set; }
+        [JsonProperty("updatedUnixMillis")]
+        [JsonConverter(typeof(UnixMillisecondsConverter))]
+        public virtual DateTime? UpdatedUnixMillis { get; set; }
     }
 }

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -1580,24 +1580,23 @@ namespace Couchbase.Linq.IntegrationTests
             }
         }
 
-        // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
-        //[Test]
-        //public void DateTime_DateAdd_UnixMillis()
-        //{
-        //    var context = new CollectionContext(TestSetup.Collection);
+        [Test]
+        public void DateTime_DateAdd_UnixMillis()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
 
-        //    var beers = from beer in context.Query<Beer>()
-        //        where beer.Type == "beer" && N1QlFunctions.IsValued(beer.UpdatedUnixMillis)
-        //        select new {beer.Name, Updated = N1QlFunctions.DateAdd(beer.UpdatedUnixMillis.Value, -10, N1QlDatePart.Day)};
+            var beers = from beer in context.Query<Beer>()
+                        where beer.Type == "beer" && N1QlFunctions.IsValued(beer.UpdatedUnixMillis)
+                        select new { beer.Name, Updated = N1QlFunctions.DateAdd(beer.UpdatedUnixMillis.Value, -10, N1QlDatePart.Day) };
 
-        //    var results = beers.Take(1).ToList();
-        //    Assert.AreEqual(1, results.Count());
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
 
-        //    foreach (var b in results)
-        //    {
-        //        Console.WriteLine("Beer {0} was updated 10 days after {1:g}", b.Name, b.Updated);
-        //    }
-        //}
+            foreach (var b in results)
+            {
+                Console.WriteLine("Beer {0} was updated 10 days after {1:g}", b.Name, b.Updated);
+            }
+        }
 
         [Test]
         public void DateTime_DateDiff()
@@ -1617,24 +1616,23 @@ namespace Couchbase.Linq.IntegrationTests
             }
         }
 
-        // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
-        //[Test]
-        //public void DateTime_DateDiff_UnixMillis()
-        //{
-        //    var context = new CollectionContext(TestSetup.Collection);
+        [Test]
+        public void DateTime_DateDiff_UnixMillis()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
 
-        //    var beers = from beer in context.Query<Beer>()
-        //        where beer.Type == "beer"
-        //        select new {beer.Name, DaysOld = N1QlFunctions.DateDiff(DateTime.Now, beer.UpdatedUnixMillis.Value, N1QlDatePart.Day)};
+            var beers = from beer in context.Query<Beer>()
+                        where beer.Type == "beer"
+                        select new { beer.Name, DaysOld = N1QlFunctions.DateDiff(DateTime.Now, beer.UpdatedUnixMillis.Value, N1QlDatePart.Day) };
 
-        //    var results = beers.Take(1).ToList();
-        //    Assert.AreEqual(1, results.Count());
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
 
-        //    foreach (var b in results)
-        //    {
-        //        Console.WriteLine("Beer {0} is {1} days old", b.Name, b.DaysOld);
-        //    }
-        //}
+            foreach (var b in results)
+            {
+                Console.WriteLine("Beer {0} is {1} days old", b.Name, b.DaysOld);
+            }
+        }
 
         [Test]
         public void DateTime_DatePart()
@@ -1654,24 +1652,23 @@ namespace Couchbase.Linq.IntegrationTests
             }
         }
 
-        // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
-        //[Test]
-        //public void DateTime_DatePart_UnixMillis()
-        //{
-        //    var context = new CollectionContext(TestSetup.Collection);
+        [Test]
+        public void DateTime_DatePart_UnixMillis()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
 
-        //    var beers = from beer in context.Query<Beer>()
-        //        where beer.Type == "beer"
-        //        select new {beer.Name, Year = N1QlFunctions.DatePart(beer.UpdatedUnixMillis.Value, N1QlDatePart.Year)};
+            var beers = from beer in context.Query<Beer>()
+                        where beer.Type == "beer"
+                        select new { beer.Name, Year = N1QlFunctions.DatePart(beer.UpdatedUnixMillis.Value, N1QlDatePart.Year) };
 
-        //    var results = beers.Take(1).ToList();
-        //    Assert.AreEqual(1, results.Count());
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
 
-        //    foreach (var b in results)
-        //    {
-        //        Console.WriteLine("Beer {0} was updated in {1:0000}", b.Name, b.Year);
-        //    }
-        //}
+            foreach (var b in results)
+            {
+                Console.WriteLine("Beer {0} was updated in {1:0000}", b.Name, b.Year);
+            }
+        }
 
         [Test]
         public void DateTime_DateTrunc()
@@ -1688,28 +1685,27 @@ namespace Couchbase.Linq.IntegrationTests
             }
         }
 
-        // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
-        //[Test]
-        //public async Task DateTime_DateTrunc_UnixMillis()
-        //{
-        //    var context = new CollectionContext(TestSetup.Collection);
+        [Test]
+        public async Task DateTime_DateTrunc_UnixMillis()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
 
-        //    var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
-        //    var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
-        //    if (clusterVersion.Version == new Version(5, 5, 0))
-        //    {
-        //        Assert.Ignore("Skipping temporarily due to bug in 5.5 Beta https://issues.couchbase.com/browse/MB-29357");
-        //    }
+            var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
+            var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
+            if (clusterVersion.Version == new Version(5, 5, 0))
+            {
+                Assert.Ignore("Skipping temporarily due to bug in 5.5 Beta https://issues.couchbase.com/browse/MB-29357");
+            }
 
-        //    var beers = from beer in context.Query<Beer>()
-        //        where beer.Type == "beer" && N1QlFunctions.IsValued(beer.UpdatedUnixMillis)
-        //        select new {beer.Name, Updated = N1QlFunctions.DateTrunc(beer.UpdatedUnixMillis.Value, N1QlDatePart.Month)};
+            var beers = from beer in context.Query<Beer>()
+                        where beer.Type == "beer" && N1QlFunctions.IsValued(beer.UpdatedUnixMillis)
+                        select new { beer.Name, Updated = N1QlFunctions.DateTrunc(beer.UpdatedUnixMillis.Value, N1QlDatePart.Month) };
 
-        //    foreach (var b in beers.Take(1))
-        //    {
-        //        Console.WriteLine("Beer {0} is in {1:MMMM yyyy}", b.Name, b.Updated);
-        //    }
-        //}
+            foreach (var b in beers.Take(1))
+            {
+                Console.WriteLine("Beer {0} is in {1:MMMM yyyy}", b.Name, b.Updated);
+            }
+        }
 
         private async Task PrepareBeerDocuments()
         {

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/NullHandlingTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/NullHandlingTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
+using Couchbase.Core.IO.Serializers;
 using Moq;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace Couchbase.Linq.UnitTests.QueryGeneration
@@ -67,64 +69,63 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             Assert.AreEqual(expected, n1QlQuery);
         }
 
-        // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
-        //[Test]
-        //public void Test_UnixDateTime_HasValue()
-        //{
-        //    var mockBucket = new Mock<IBucket>();
-        //    mockBucket.SetupGet(e => e.Name).Returns("default");
+        [Test]
+        public void Test_UnixDateTime_HasValue()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
 
-        //    var query =
-        //        QueryFactory.Queryable<Class2>(mockBucket.Object)
-        //            .Where(e => e.Updated.HasValue)
-        //            .Select(e => new { e.Updated });
+            var query =
+                QueryFactory.Queryable<Class2>(mockBucket.Object)
+                    .Where(e => e.Updated.HasValue)
+                    .Select(e => new { e.Updated });
 
-        //    const string expected =
-        //        "SELECT MILLIS_TO_STR(`Extent1`.`Updated`) as `Updated` FROM `default` as `Extent1` WHERE (`Extent1`.`Updated` IS NOT NULL)";
+            const string expected =
+                "SELECT MILLIS_TO_STR(`Extent1`.`Updated`) as `Updated` FROM `default` as `Extent1` WHERE (`Extent1`.`Updated` IS NOT NULL)";
 
-        //    var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
-        //    Assert.AreEqual(expected, n1QlQuery);
-        //}
+            Assert.AreEqual(expected, n1QlQuery);
+        }
 
-        //[Test]
-        //public void Test_UnixDateTime_NotHasValue()
-        //{
-        //    var mockBucket = new Mock<IBucket>();
-        //    mockBucket.SetupGet(e => e.Name).Returns("default");
+        [Test]
+        public void Test_UnixDateTime_NotHasValue()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
 
-        //    var query =
-        //        QueryFactory.Queryable<Class2>(mockBucket.Object)
-        //            .Where(e => !e.Updated.HasValue)
-        //            .Select(e => new { e.Updated });
+            var query =
+                QueryFactory.Queryable<Class2>(mockBucket.Object)
+                    .Where(e => !e.Updated.HasValue)
+                    .Select(e => new { e.Updated });
 
-        //    const string expected =
-        //        "SELECT MILLIS_TO_STR(`Extent1`.`Updated`) as `Updated` FROM `default` as `Extent1` WHERE NOT (`Extent1`.`Updated` IS NOT NULL)";
+            const string expected =
+                "SELECT MILLIS_TO_STR(`Extent1`.`Updated`) as `Updated` FROM `default` as `Extent1` WHERE NOT (`Extent1`.`Updated` IS NOT NULL)";
 
-        //    var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
-        //    Assert.AreEqual(expected, n1QlQuery);
-        //}
+            Assert.AreEqual(expected, n1QlQuery);
+        }
 
-        //[Test]
-        //public void Test_UnixDateTime_Value()
-        //{
-        //    var mockBucket = new Mock<IBucket>();
-        //    mockBucket.SetupGet(e => e.Name).Returns("default");
+        [Test]
+        public void Test_UnixDateTime_Value()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
 
-        //    var query =
-        //        QueryFactory.Queryable<Class2>(mockBucket.Object)
-        //            .Where(e => e.Updated.Value < new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc))
-        //            .Select(e => new { e.Updated });
+            var query =
+                QueryFactory.Queryable<Class2>(mockBucket.Object)
+                    .Where(e => e.Updated.Value < new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+                    .Select(e => new { e.Updated });
 
-        //    const string expected =
-        //        "SELECT MILLIS_TO_STR(`Extent1`.`Updated`) as `Updated` FROM `default` as `Extent1` " +
-        //        "WHERE (`Extent1`.`Updated` < 946684800000)";
+            const string expected =
+                "SELECT MILLIS_TO_STR(`Extent1`.`Updated`) as `Updated` FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`Updated` < 946684800000)";
 
-        //    var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
-        //    Assert.AreEqual(expected, n1QlQuery);
-        //}
+            Assert.AreEqual(expected, n1QlQuery);
+        }
 
         #region Helpers
 
@@ -134,13 +135,12 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             public DateTime? Updated { get; set; }
         }
 
-        // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
-        //private class Class2
-        //{
-        //    // ReSharper disable once UnusedAutoPropertyAccessor.Local
-        //    [JsonConverter(typeof(UnixMillisecondsConverter))]
-        //    public DateTime? Updated { get; set; }
-        //}
+        private class Class2
+        {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            [JsonConverter(typeof(UnixMillisecondsConverter))]
+            public DateTime? Updated { get; set; }
+        }
 
         #endregion
 

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Linq;
+using Couchbase.Core.IO.Serializers;
 using Couchbase.Linq.Extensions;
 using Couchbase.Linq.UnitTests.Documents;
 using Couchbase.Linq.Versioning;
 using Moq;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace Couchbase.Linq.UnitTests.QueryGeneration
@@ -45,58 +47,57 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             Assert.AreEqual(expected, n1QlQuery);
         }
 
-        // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
-        //[Test]
-        //public void Test_Select_WithUnixMillisecondsProjection()
-        //{
-        //    var mockBucket = new Mock<IBucket>();
-        //    mockBucket.SetupGet(e => e.Name).Returns("default");
+        [Test]
+        public void Test_Select_WithUnixMillisecondsProjection()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
 
-        //    var query =
-        //        QueryFactory.Queryable<UnixMillisecondsDocument>(mockBucket.Object)
-        //            .Select(e => new UnixMillisecondsDocument { DateTime = e.DateTime });
+            var query =
+                QueryFactory.Queryable<UnixMillisecondsDocument>(mockBucket.Object)
+                    .Select(e => new UnixMillisecondsDocument { DateTime = e.DateTime });
 
-        //    // Since the source and dest are both using UnixMillisecondsConverter, no functions should be applied
-        //    const string expected = "SELECT `Extent1`.`DateTime` as `DateTime` FROM `default` as `Extent1`";
+            // Since the source and dest are both using UnixMillisecondsConverter, no functions should be applied
+            const string expected = "SELECT `Extent1`.`DateTime` as `DateTime` FROM `default` as `Extent1`";
 
-        //    var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
-        //    Assert.AreEqual(expected, n1QlQuery);
-        //}
+            Assert.AreEqual(expected, n1QlQuery);
+        }
 
-        //[Test]
-        //public void Test_Select_WithUnixMillisecondsToIsoProjection()
-        //{
-        //    var mockBucket = new Mock<IBucket>();
-        //    mockBucket.SetupGet(e => e.Name).Returns("default");
+        [Test]
+        public void Test_Select_WithUnixMillisecondsToIsoProjection()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
 
-        //    var query =
-        //        QueryFactory.Queryable<UnixMillisecondsDocument>(mockBucket.Object)
-        //            .Select(e => new IsoDocument { DateTime = e.DateTime });
+            var query =
+                QueryFactory.Queryable<UnixMillisecondsDocument>(mockBucket.Object)
+                    .Select(e => new IsoDocument { DateTime = e.DateTime });
 
-        //    const string expected = "SELECT MILLIS_TO_STR(`Extent1`.`DateTime`) as `DateTime` FROM `default` as `Extent1`";
+            const string expected = "SELECT MILLIS_TO_STR(`Extent1`.`DateTime`) as `DateTime` FROM `default` as `Extent1`";
 
-        //    var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
-        //    Assert.AreEqual(expected, n1QlQuery);
-        //}
+            Assert.AreEqual(expected, n1QlQuery);
+        }
 
-        //[Test]
-        //public void Test_Select_WithIsoToUnixMillisecondsProjection()
-        //{
-        //    var mockBucket = new Mock<IBucket>();
-        //    mockBucket.SetupGet(e => e.Name).Returns("default");
+        [Test]
+        public void Test_Select_WithIsoToUnixMillisecondsProjection()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
 
-        //    var query =
-        //        QueryFactory.Queryable<IsoDocument>(mockBucket.Object)
-        //            .Select(e => new UnixMillisecondsDocument { DateTime = e.DateTime });
+            var query =
+                QueryFactory.Queryable<IsoDocument>(mockBucket.Object)
+                    .Select(e => new UnixMillisecondsDocument { DateTime = e.DateTime });
 
-        //    const string expected = "SELECT STR_TO_MILLIS(`Extent1`.`DateTime`) as `DateTime` FROM `default` as `Extent1`";
+            const string expected = "SELECT STR_TO_MILLIS(`Extent1`.`DateTime`) as `DateTime` FROM `default` as `Extent1`";
 
-        //    var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
-        //    Assert.AreEqual(expected, n1QlQuery);
-        //}
+            Assert.AreEqual(expected, n1QlQuery);
+        }
 
         [Test]
         public void Test_Select_All_Properties()
@@ -191,12 +192,11 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             public DateTime DateTime { get; set; }
         }
 
-        // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
-        //public class UnixMillisecondsDocument
-        //{
-        //    [JsonConverter(typeof(UnixMillisecondsConverter))]
-        //    public DateTime DateTime { get; set; }
-        //}
+        public class UnixMillisecondsDocument
+        {
+            [JsonConverter(typeof(UnixMillisecondsConverter))]
+            public DateTime DateTime { get; set; }
+        }
 
         #endregion
     }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/WhereClauseTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/WhereClauseTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Couchbase.Core.IO.Serializers;
 using Couchbase.Linq.UnitTests.Documents;
 using Moq;
 using Newtonsoft.Json;
@@ -269,26 +270,25 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             Assert.AreEqual(expected, n1QlQuery);
         }
 
-        // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
-        //[Test]
-        //public void Test_Where_With_UnixMillisecondsDateComparison()
-        //{
-        //    var mockBucket = new Mock<IBucket>();
-        //    mockBucket.SetupGet(e => e.Name).Returns("default");
+        [Test]
+        public void Test_Where_With_UnixMillisecondsDateComparison()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
 
-        //    var query =
-        //        QueryFactory.Queryable<UnixMillisecondsDocument>(mockBucket.Object)
-        //            .Where(e => e.DateTime >= new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            var query =
+                QueryFactory.Queryable<UnixMillisecondsDocument>(mockBucket.Object)
+                    .Where(e => e.DateTime >= new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc));
 
 
-        //    const string expected =
-        //        "SELECT `Extent1`.* FROM `default` as `Extent1` " +
-        //        "WHERE (`Extent1`.`DateTime` >= 1262304000000)";
+            const string expected =
+                "SELECT `Extent1`.* FROM `default` as `Extent1` " +
+                "WHERE (`Extent1`.`DateTime` >= 1262304000000)";
 
-        //    var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
 
-        //    Assert.AreEqual(expected, n1QlQuery);
-        //}
+            Assert.AreEqual(expected, n1QlQuery);
+        }
 
         [Test]
         public void Test_Where_With_DateTimeOffsetComparison()
@@ -334,12 +334,11 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
         #region Helpers
 
-        // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
-        //public class UnixMillisecondsDocument
-        //{
-        //    [JsonConverter(typeof(UnixMillisecondsConverter))]
-        //    public DateTime DateTime { get; set; }
-        //}
+        public class UnixMillisecondsDocument
+        {
+            [JsonConverter(typeof(UnixMillisecondsConverter))]
+            public DateTime DateTime { get; set; }
+        }
 
         #endregion
     }

--- a/Src/Couchbase.Linq/Serialization/TypeBasedSerializationConverterRegistry.cs
+++ b/Src/Couchbase.Linq/Serialization/TypeBasedSerializationConverterRegistry.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using Couchbase.Core.IO.Serializers;
 using Couchbase.Linq.Serialization.Converters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -29,8 +30,7 @@ namespace Couchbase.Linq.Serialization
         /// <returns></returns>
         public static TypeBasedSerializationConverterRegistry CreateDefaultRegistry() => new TypeBasedSerializationConverterRegistry
         {
-            // TODO: Enabled UnixMillisecondsConverter once available https://issues.couchbase.com/browse/NCBC-2539
-            // { typeof(UnixMillisecondsConverter), typeof(UnixMillisecondsSerializationConverter) },
+            { typeof(UnixMillisecondsConverter), typeof(UnixMillisecondsSerializationConverter) },
             { typeof(StringEnumConverter), typeof(StringEnumSerializationConverter<>)}
         };
 


### PR DESCRIPTION
Motivation
----------
It has now been ported to sdk3.

Modifications
-------------
Remove commented code and correct namespaces.

Results
-------
UnixMillisecondsConverter is working again with LINQ queries.

Closes #299