### PR TITLE
Implement a very basic async query for sdk 3

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -50,6 +50,23 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public async Task Map2PocoTestsAsync()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from b in context.Query<Beer>()
+                select b;
+
+            var results = await ((IAsyncEnumerable<Beer>) beers.Take(1)).ToListAsync();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var beer in results)
+            {
+                Console.WriteLine(beer.Name);
+            }
+        }
+
+        [Test]
         public void Map2PocoTests_Simple_Projections()
         {
             var context = new CollectionContext(TestSetup.Collection);

--- a/Src/Couchbase.Linq.UnitTests/ClusterQueryExecutorEmulator.cs
+++ b/Src/Couchbase.Linq.UnitTests/ClusterQueryExecutorEmulator.cs
@@ -83,7 +83,7 @@ namespace Couchbase.Linq.UnitTests
             return visitor.GetQuery();
         }
 
-        public Task<IAsyncEnumerable<T>> ExecuteCollectionAsync<T>(string statement, LinqQueryOptions queryResult)
+        public IAsyncEnumerable<T> ExecuteCollectionAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/Src/Couchbase.Linq/Execution/ClusterQueryProvider.cs
+++ b/Src/Couchbase.Linq/Execution/ClusterQueryProvider.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using Remotion.Linq;
+using Remotion.Linq.Clauses.StreamedData;
+using Remotion.Linq.Parsing.Structure;
+
+namespace Couchbase.Linq.Execution
+{
+    internal class ClusterQueryProvider : QueryProviderBase, IAsyncQueryProvider
+    {
+        public static readonly MethodInfo ExecuteAsyncMethod =
+            typeof(IClusterQueryExecutor).GetMethod("ExecuteCollectionAsync",
+                new[] {typeof(QueryModel), typeof(CancellationToken)});
+
+        public ClusterQueryProvider(IQueryParser queryParser, IQueryExecutor executor)
+            : base(queryParser, executor)
+        {
+        }
+
+        public override IQueryable<T> CreateQuery<T>(Expression expression)
+        {
+            return (IQueryable<T>) Activator.CreateInstance(
+                typeof(CollectionQueryable<>).MakeGenericType(typeof(T)),
+                this, expression);
+        }
+
+        public T ExecuteAsync<T>(Expression expression, CancellationToken cancellationToken = default)
+        {
+            var queryModel = GenerateQueryModel(expression);
+
+            var streamedDataInfo = queryModel.GetOutputDataInfo();
+
+            if (streamedDataInfo is StreamedSequenceInfo sequence)
+            {
+                var executeAsyncMethod = ExecuteAsyncMethod.MakeGenericMethod(sequence.ResultItemType);
+
+                return (T) executeAsyncMethod.Invoke(Executor, new object[] {queryModel, cancellationToken});
+            }
+            else
+            {
+                throw new NotImplementedException("Currently only supporting async streams, no aggregates or first/single.");
+            }
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Execution/IAsyncQueryProvider.cs
+++ b/Src/Couchbase.Linq/Execution/IAsyncQueryProvider.cs
@@ -1,0 +1,11 @@
+﻿using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+
+namespace Couchbase.Linq.Execution
+{
+    internal interface IAsyncQueryProvider : IQueryProvider
+    {
+        T ExecuteAsync<T>(Expression expression, CancellationToken cancellationToken = default);
+    }
+}

--- a/Src/Couchbase.Linq/Execution/IClusterQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/IClusterQueryExecutor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Couchbase.Linq.QueryGeneration;
 using Couchbase.Query;
@@ -35,12 +36,6 @@ namespace Couchbase.Linq.Execution
         /// <remarks>If called multiple times, the states from the calls are combined.</remarks>
         void ConsistentWith(MutationState state);
 
-        /// <summary>
-        /// Asynchronously execute a <see cref="LinqQueryOptions"/>.
-        /// </summary>
-        /// <typeparam name="T">Type returned by the query.</typeparam>
-        /// <param name="queryRequest">Request to execute.</param>
-        /// <returns>Task which contains a list of objects returned by the request when complete.</returns>
-        Task<IAsyncEnumerable<T>> ExecuteCollectionAsync<T>(string statement, LinqQueryOptions queryRequest);
+        IAsyncEnumerable<T> ExecuteCollectionAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default);
     }
 }

--- a/Src/Couchbase.Linq/ICollectionQueryable.cs
+++ b/Src/Couchbase.Linq/ICollectionQueryable.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Couchbase.Linq
 {
@@ -26,7 +27,7 @@ namespace Couchbase.Linq
     /// <summary>
     /// IQueryable sourced from a Couchbase collection.  Used to provide the collection name to the query generator.
     /// </summary>
-    public interface ICollectionQueryable<out T> : IQueryable<T>, ICollectionQueryable
+    public interface ICollectionQueryable<out T> : IQueryable<T>, ICollectionQueryable, IAsyncEnumerable<T>
     {
     }
 }


### PR DESCRIPTION
Motivation
----------
Create some basic infrastructure around using IAsyncEnumerable to
run asynchronous queries with sdk 3.

Modifications
-------------
Switch from the DefaultQueryProvider to a custom ClusterQueryProvider
which implements IAsyncQueryProvider.

Rework ClusterQueryExecutor to accept a QueryModel for async execution.

Results
-------
You can execute an async query by typecasting the IQueryable to
IAsyncEnumerable. We'll need to add extension methods to make this
easier, much like EF. Also, it doesn't support scalar (i.e. Sum) or
single result (i.e. First or Single) approaches yet, these will require
extension methods and custom ResultOperator implementations.

Also needs further cleanup and optimization.

Relates to #281 