### PR TITLE
Add support for FirstAsync and FirstOrDefaultAsync

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/FirstQueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/FirstQueryTests.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.IntegrationTests.Documents;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.IntegrationTests
+{
+    [TestFixture]
+    public class FirstQueryTests : N1QlTestBase
+    {
+        [Test]
+        public void First_Empty()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "abcdefg"
+                select new {beer.Name};
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                // ReSharper disable once UnusedVariable
+                var temp = beers.First();
+            });
+        }
+
+        [Test]
+        public void FirstAsync_Empty()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "abcdefg"
+                select new {beer.Name};
+
+            Assert.ThrowsAsync<InvalidOperationException>(beers.FirstAsync);
+        }
+
+        [Test]
+        public void First_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            Console.WriteLine(beers.First().Name);
+        }
+
+        [Test]
+        public async Task FirstAsync_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            Console.WriteLine((await beers.FirstAsync()).Name);
+        }
+
+        [Test]
+        public async Task FirstAsync_WithPredicate_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            var result = await beers.FirstAsync(p => p.Name != "21A IPA");
+
+            Console.WriteLine(result.Name);
+        }
+
+        [Test]
+        public void FirstOrDefault_Empty()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "abcdefg"
+                select new {beer.Name};
+
+            var aBeer = beers.FirstOrDefault();
+            Assert.IsNull(aBeer);
+        }
+
+        [Test]
+        public async Task FirstOrDefaultAsync_Empty()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "abcdefg"
+                select new {beer.Name};
+
+            var aBeer = await beers.FirstOrDefaultAsync();
+            Assert.IsNull(aBeer);
+        }
+
+        [Test]
+        public void FirstOrDefault_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            var aBeer = beers.FirstOrDefault();
+            Assert.IsNotNull(aBeer);
+            Console.WriteLine(aBeer.Name);
+        }
+
+        [Test]
+        public async Task FirstOrDefaultAsync_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            var aBeer = await beers.FirstOrDefaultAsync();
+            Assert.IsNotNull(aBeer);
+            Console.WriteLine(aBeer.Name);
+        }
+
+        [Test]
+        public async Task FirstOrDefaultAsync_WithPredicate_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            var aBeer = await beers.FirstOrDefaultAsync(p => p.Name != "21A IPA");
+            Assert.IsNotNull(aBeer);
+            Console.WriteLine(aBeer.Name);
+        }
+    }
+}

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -1436,61 +1436,6 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
-        public void First_Empty()
-        {
-            var context = new CollectionContext(TestSetup.Collection);
-
-            var beers = from beer in context.Query<Beer>()
-                where beer.Type == "abcdefg"
-                select new {beer.Name};
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                // ReSharper disable once UnusedVariable
-                var temp = beers.First();
-            });
-        }
-
-        [Test]
-        public void First_HasResult()
-        {
-            var context = new CollectionContext(TestSetup.Collection);
-
-            var beers = from beer in context.Query<Beer>()
-                where beer.Type == "beer"
-                select new {beer.Name};
-
-            Console.WriteLine(beers.First().Name);
-        }
-
-        [Test]
-        public void FirstOrDefault_Empty()
-        {
-            var context = new CollectionContext(TestSetup.Collection);
-
-            var beers = from beer in context.Query<Beer>()
-                where beer.Type == "abcdefg"
-                select new {beer.Name};
-
-            var aBeer = beers.FirstOrDefault();
-            Assert.IsNull(aBeer);
-        }
-
-        [Test]
-        public void FirstOrDefault_HasResult()
-        {
-            var context = new CollectionContext(TestSetup.Collection);
-
-            var beers = from beer in context.Query<Beer>()
-                where beer.Type == "beer"
-                select new {beer.Name};
-
-            var aBeer = beers.FirstOrDefault();
-            Assert.IsNotNull(aBeer);
-            Console.WriteLine(aBeer.Name);
-        }
-
-        [Test]
         public void Single_Empty()
         {
             var context = new CollectionContext(TestSetup.Collection);

--- a/Src/Couchbase.Linq.UnitTests/ClusterQueryExecutorEmulator.cs
+++ b/Src/Couchbase.Linq.UnitTests/ClusterQueryExecutorEmulator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Couchbase.Core.Version;
@@ -85,7 +86,17 @@ namespace Couchbase.Linq.UnitTests
 
         public IAsyncEnumerable<T> ExecuteCollectionAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            ExecuteCollection<T>(queryModel);
+
+            return AsyncEnumerable.Empty<T>();
+        }
+
+        public Task<T> ExecuteSingleAsync<T>(QueryModel queryModel, bool returnDefaultWhenEmpty,
+            CancellationToken cancellationToken = default)
+        {
+            ExecuteCollection<T>(queryModel);
+
+            return Task.FromResult(default(T));
         }
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/FirstTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/FirstTests.cs
@@ -1,0 +1,100 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.UnitTests.Documents;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.QueryGeneration
+{
+    [TestFixture]
+    public class FirstTests : N1QLTestBase
+    {
+        [Test]
+        public void Test_First()
+        {
+            var temp = CreateQueryable<Contact>("default").First();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_FirstOrDefault()
+        {
+            var temp = CreateQueryable<Contact>("default").FirstOrDefault();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_FirstWithSkip()
+        {
+            var temp = CreateQueryable<Contact>("default").Skip(10).First();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1 OFFSET 10";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_FirstAsync()
+        {
+            var temp = await CreateQueryable<Contact>("default").FirstAsync();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_FirstAsyncWithPredicate()
+        {
+            var temp = await CreateQueryable<Contact>("default").FirstAsync(p => p.Age > 5);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`age` > 5) LIMIT 1";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_FirstOrDefaultAsync()
+        {
+            var temp = await CreateQueryable<Contact>("default").FirstOrDefaultAsync();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_FirstOrDefaultAsyncWithPredicate()
+        {
+            var temp = await CreateQueryable<Contact>("default").FirstOrDefaultAsync(p => p.Age > 5);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` WHERE (`Extent1`.`age` > 5) LIMIT 1";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_FirstAsyncWithSkip()
+        {
+            var temp = await CreateQueryable<Contact>("default").Skip(10).FirstAsync();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1 OFFSET 10";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+    }
+}

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/TakeAndSkipTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/TakeAndSkipTests.cs
@@ -65,39 +65,6 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         }
 
         [Test]
-        public void Test_First()
-        {
-            var temp = CreateQueryable<Contact>("default").First();
-            var n1QlQuery = QueryExecutor.Query;
-
-            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1";
-
-            Assert.AreEqual(expected, n1QlQuery);
-        }
-
-        [Test]
-        public void Test_FirstOrDefault()
-        {
-            var temp = CreateQueryable<Contact>("default").FirstOrDefault();
-            var n1QlQuery = QueryExecutor.Query;
-
-            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1";
-
-            Assert.AreEqual(expected, n1QlQuery);
-        }
-
-        [Test]
-        public void Test_FirstWithSkip()
-        {
-            var temp = CreateQueryable<Contact>("default").Skip(10).First();
-            var n1QlQuery = QueryExecutor.Query;
-
-            const string expected = "SELECT `Extent1`.* FROM `default` as `Extent1` LIMIT 1 OFFSET 10";
-
-            Assert.AreEqual(expected, n1QlQuery);
-        }
-
-        [Test]
         public void Test_Single()
         {
             var temp = CreateQueryable<Contact>("default").Single();

--- a/Src/Couchbase.Linq/Clauses/FirstAsyncExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/FirstAsyncExpressionNode.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Operators;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    /// <summary>
+    /// Expression node for FirstAsync and FirstOrDefaultAsync.
+    /// </summary>
+    internal class FirstAsyncExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        public static IEnumerable<MethodInfo> GetSupportedMethods() => new[]
+        {
+            QueryExtensionMethods.FirstAsyncNoPredicate,
+            QueryExtensionMethods.FirstAsyncWithPredicate,
+            QueryExtensionMethods.FirstOrDefaultAsyncNoPredicate,
+            QueryExtensionMethods.FirstOrDefaultAsyncWithPredicate
+        };
+
+        public FirstAsyncExpressionNode(MethodCallExpressionParseInfo parseInfo, LambdaExpression optionalPredicate)
+            : base(parseInfo, optionalPredicate, null)
+        {
+        }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            throw new NotSupportedException($"Resolve is not supported by {typeof(FirstAsyncExpressionNode)}");
+        }
+
+        protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext) =>
+            new FirstAsyncResultOperator(ParsedExpression.Method.Name.EndsWith("OrDefaultAsync"));
+    }
+}

--- a/Src/Couchbase.Linq/Execution/ClusterQueryProvider.cs
+++ b/Src/Couchbase.Linq/Execution/ClusterQueryProvider.cs
@@ -43,7 +43,7 @@ namespace Couchbase.Linq.Execution
             }
             else
             {
-                throw new NotImplementedException("Currently only supporting async streams, no aggregates or first/single.");
+                return (T) streamedDataInfo.ExecuteQueryModel(queryModel, Executor).Value;
             }
         }
     }

--- a/Src/Couchbase.Linq/Execution/IClusterQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/IClusterQueryExecutor.cs
@@ -37,5 +37,7 @@ namespace Couchbase.Linq.Execution
         void ConsistentWith(MutationState state);
 
         IAsyncEnumerable<T> ExecuteCollectionAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default);
+
+        Task<T> ExecuteSingleAsync<T>(QueryModel queryModel, bool returnDefaultWhenEmpty, CancellationToken cancellationToken = default);
     }
 }

--- a/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedSingleValueInfo.cs
+++ b/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedSingleValueInfo.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Reflection;
+using Remotion.Linq;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Execution.StreamedData
+{
+    /// <summary>
+    /// Version of <see cref="AsyncStreamedValueInfo"/> intended for single result objects, for example
+    /// from FirstAsync or SingleAsync.
+    /// </summary>
+    internal class AsyncStreamedSingleValueInfo : AsyncStreamedValueInfo
+    {
+        private static readonly MethodInfo ExecuteMethod =
+            typeof(AsyncStreamedSingleValueInfo).GetMethod(nameof(ExecuteSingleQueryModel),
+                new[] {typeof(QueryModel), typeof(IClusterQueryExecutor)});
+
+        public bool ReturnDefaultWhenEmpty { get; }
+
+        public AsyncStreamedSingleValueInfo(Type dataType, bool returnDefaultWhenEmpty)
+            : base(dataType)
+        {
+            ReturnDefaultWhenEmpty = returnDefaultWhenEmpty;
+        }
+
+        public override IStreamedData ExecuteQueryModel(QueryModel queryModel, IQueryExecutor executor)
+        {
+            if (queryModel == null)
+            {
+                throw new ArgumentNullException(nameof(queryModel));
+            }
+            if (executor == null)
+            {
+                throw new ArgumentNullException(nameof(executor));
+            }
+            if (!(executor is IClusterQueryExecutor asyncExecutor))
+            {
+                throw new ArgumentException($"{nameof(executor)} must implement {typeof(IClusterQueryExecutor)} for asynchronous queries.");
+            }
+
+            var executeMethod = ExecuteMethod.MakeGenericMethod(InternalType);
+
+            // wrap executeMethod into a delegate instead of calling Invoke in order to allow for exceptions that are bubbled up correctly
+            var func = (Func<QueryModel, IClusterQueryExecutor, object>) executeMethod.CreateDelegate (typeof (Func<QueryModel, IClusterQueryExecutor, object>), this);
+            var result = func(queryModel, asyncExecutor);
+
+            return new AsyncStreamedValue(result, this);
+        }
+
+        protected override AsyncStreamedValueInfo CloneWithNewDataType(Type dataType) =>
+            new AsyncStreamedSingleValueInfo (dataType, ReturnDefaultWhenEmpty);
+
+        public object ExecuteSingleQueryModel<T>(QueryModel queryModel, IClusterQueryExecutor executor)
+        {
+            if (queryModel == null)
+            {
+                throw new ArgumentNullException(nameof(queryModel));
+            }
+            if (executor == null)
+            {
+                throw new ArgumentNullException(nameof(executor));
+            }
+
+            return executor.ExecuteSingleAsync<T>(queryModel, ReturnDefaultWhenEmpty);
+        }
+
+        // ReSharper disable PossibleNullReferenceException
+        public override bool Equals(IStreamedDataInfo obj) =>
+            base.Equals(obj) &&
+            ((AsyncStreamedSingleValueInfo) obj).ReturnDefaultWhenEmpty == ReturnDefaultWhenEmpty;
+        // ReSharper restore PossibleNullReferenceException
+
+        public override int GetHashCode() =>
+            base.GetHashCode() ^ ReturnDefaultWhenEmpty.GetHashCode();
+    }
+}

--- a/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedValue.cs
+++ b/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedValue.cs
@@ -1,0 +1,23 @@
+﻿using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Execution.StreamedData
+{
+    /// <summary>
+    /// Implementation of <see cref="IStreamedData"/> intended for single value results
+    /// being returned asynchronously.
+    /// </summary>
+    internal class AsyncStreamedValue : IStreamedData
+    {
+        public object Value { get; }
+
+        public AsyncStreamedValueInfo DataInfo { get; }
+
+        IStreamedDataInfo IStreamedData.DataInfo => DataInfo;
+
+        public AsyncStreamedValue(object value, AsyncStreamedValueInfo asyncStreamedValueInfo)
+        {
+            Value = value;
+            DataInfo = asyncStreamedValueInfo;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedValueInfo.cs
+++ b/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedValueInfo.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Threading.Tasks;
+using Remotion.Linq;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Execution.StreamedData
+{
+    /// <summary>
+    /// Provides <see cref="IStreamedDataInfo"/> for <see cref="AsyncStreamedValue"/>, which is returning
+    /// a single value asynchronously.
+    /// </summary>
+    internal abstract class AsyncStreamedValueInfo : IStreamedDataInfo
+    {
+        /// <inheritdoc />
+        /// <remarks>
+        /// This will always be a Task&lt;T&gt;, where T is <see cref="InternalType"/>.
+        /// </remarks>
+        public Type DataType { get; }
+
+        /// <summary>
+        /// Type being wrapped by the Task.
+        /// </summary>
+        public Type InternalType { get; }
+
+        protected AsyncStreamedValueInfo(Type dataType)
+        {
+            DataType = dataType ?? throw new ArgumentNullException(nameof(dataType));
+
+            if (!dataType.IsGenericType || dataType.GetGenericTypeDefinition() != typeof(Task<>))
+            {
+                throw new ArgumentException($"{nameof(dataType)} must be a Task<T>");
+            }
+
+            InternalType = dataType.GetGenericArguments()[0];
+        }
+
+        /// <inheritdoc />
+        public abstract IStreamedData ExecuteQueryModel(QueryModel queryModel, IQueryExecutor executor);
+
+        protected abstract AsyncStreamedValueInfo CloneWithNewDataType (Type dataType);
+
+        /// <inheritdoc />
+        public virtual IStreamedDataInfo AdjustDataType (Type dataType)
+        {
+            if (dataType == null)
+            {
+                throw new ArgumentNullException(nameof(dataType));
+            }
+
+            if (!dataType.IsAssignableFrom(DataType))
+            {
+                throw new ArgumentException(
+                    $"'{dataType}' cannot be used as the new data type for a value of type '{DataType}'.",
+                    nameof(dataType));
+            }
+
+            return CloneWithNewDataType(dataType);
+        }
+
+        public sealed override bool Equals(object obj)
+        {
+            return Equals(obj as IStreamedDataInfo);
+        }
+
+        public virtual bool Equals(IStreamedDataInfo obj)
+        {
+            if (obj == null)
+                return false;
+
+            if (GetType () != obj.GetType ())
+                return false;
+
+            var other = (StreamedValueInfo) obj;
+            return DataType == other.DataType;
+        }
+
+        public override int GetHashCode()
+        {
+            return DataType.GetHashCode();
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using System.Reflection;
+using System.Threading;
+
+namespace Couchbase.Linq.Extensions
+{
+    /// <summary>
+    /// Static helper to store reflection method info for various <see cref="IQueryable"/> extensions.
+    /// </summary>
+    internal static class QueryExtensionMethods
+    {
+        public static MethodInfo FirstAsyncNoPredicate { get; }
+        public static MethodInfo FirstAsyncWithPredicate { get; }
+        public static MethodInfo FirstOrDefaultAsyncNoPredicate { get; }
+        public static MethodInfo FirstOrDefaultAsyncWithPredicate { get; }
+
+        static QueryExtensionMethods()
+        {
+            var allMethods = typeof(QueryExtensions)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .ToList();
+
+            FirstAsyncNoPredicate = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.FirstAsync) && p.GetParameters().Length == 1);
+            FirstAsyncWithPredicate = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.FirstAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
+            FirstOrDefaultAsyncNoPredicate = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.FirstOrDefaultAsync) && p.GetParameters().Length == 1);
+            FirstOrDefaultAsyncWithPredicate = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.FirstOrDefaultAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.First.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.First.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Linq.Execution;
+
+namespace Couchbase.Linq.Extensions
+{
+    // FirstAsync and FirstOrDefaultAsync extensions
+
+    public static partial class QueryExtensions
+    {
+        /// <summary>
+        /// Asynchronously retrieves the first item returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <returns>The first item returned by the query.</returns>
+        /// <exception cref="InvalidOperationException">The query returns no results.</exception>
+        public static Task<T> FirstAsync<T>(this IQueryable<T> source) =>
+            source.FirstAsync<T>(default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously retrieves the first item returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The first item returned by the query.</returns>
+        /// <exception cref="InvalidOperationException">The query returns no results.</exception>
+        public static Task<T> FirstAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return ExecuteAsync<T, Task<T>>(QueryExtensionMethods.FirstAsyncNoPredicate, source, null,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves the first item returned by the query, filtered by a predicate.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="predicate">Predicate to filter query results.</param>
+        /// <returns>The first item returned by the query.</returns>
+        /// <exception cref="InvalidOperationException">The query returns no results.</exception>
+        public static Task<T> FirstAsync<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate) =>
+            source.FirstAsync<T>(predicate, default);
+
+        /// <summary>
+        /// Asynchronously retrieves the first item returned by the query, filtered by a predicate.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="predicate">Predicate to filter query results.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The first item returned by the query.</returns>
+        /// <exception cref="InvalidOperationException">The query returns no results.</exception>
+        public static Task<T> FirstAsync<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            return ExecuteAsync<T, Task<T>>(QueryExtensionMethods.FirstAsyncWithPredicate, source, predicate,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves the first item returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <returns>The first item returned by the query, or the default value of <typeparamref name="T"/> if empty.</returns>
+        public static Task<T> FirstOrDefaultAsync<T>(this IQueryable<T> source) =>
+            source.FirstOrDefaultAsync<T>(default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously retrieves the first item returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The first item returned by the query, or the default value of <typeparamref name="T"/> if empty.</returns>
+        public static Task<T> FirstOrDefaultAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return ExecuteAsync<T, Task<T>>(QueryExtensionMethods.FirstOrDefaultAsyncNoPredicate, source, null,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves the first item returned by the query, filtered by a predicate.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="predicate">Predicate to filter query results.</param>
+        /// <returns>The first item returned by the query, or the default value of <typeparamref name="T"/> if empty.</returns>
+        public static Task<T> FirstOrDefaultAsync<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate) =>
+            source.FirstOrDefaultAsync<T>(predicate, default);
+
+        /// <summary>
+        /// Asynchronously retrieves the first item returned by the query, filtered by a predicate.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="predicate">Predicate to filter query results.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The first item returned by the query, or the default value of <typeparamref name="T"/> if empty.</returns>
+        public static Task<T> FirstOrDefaultAsync<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            return ExecuteAsync<T, Task<T>>(QueryExtensionMethods.FirstOrDefaultAsyncWithPredicate, source, predicate,
+                cancellationToken);
+        }
+
+        private static TResult ExecuteAsync<TSource, TResult>(
+            MethodInfo operatorMethodInfo,
+            IQueryable<TSource> source,
+            Expression expression,
+            CancellationToken cancellationToken = default)
+        {
+            if (source.Provider is IAsyncQueryProvider provider)
+            {
+                if (operatorMethodInfo.IsGenericMethod)
+                {
+                    operatorMethodInfo
+                        = operatorMethodInfo.GetGenericArguments().Length == 2
+                            ? operatorMethodInfo.MakeGenericMethod(typeof(TSource), typeof(TResult).GetGenericArguments().Single())
+                            : operatorMethodInfo.MakeGenericMethod(typeof(TSource));
+                }
+
+                var updatedExpression = Expression.Call(
+                    instance: null,
+                    method: operatorMethodInfo,
+                    arguments: expression == null
+                        ? new[] {source.Expression}
+                        : new[] {source.Expression, expression});
+
+                return provider.ExecuteAsync<TResult>(updatedExpression, cancellationToken);
+            }
+
+            throw new InvalidOperationException("The provided IQueryable is not backed by an IAsyncQueryProvider.");
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
@@ -11,9 +11,9 @@ using Remotion.Linq.Parsing.ExpressionVisitors;
 namespace Couchbase.Linq.Extensions
 {
     /// <summary>
-    /// Extentions to <see cref="IQueryable{T}" /> for use in queries against a <see cref="CollectionContext"/>.
+    /// Extensions to <see cref="IQueryable{T}" /> for use in queries against a <see cref="CollectionContext"/>.
     /// </summary>
-    public static class QueryExtensions
+    public static partial class QueryExtensions
     {
         #region Nest
 

--- a/Src/Couchbase.Linq/Operators/AsyncValueFromSequenceResultOperatorBase.cs
+++ b/Src/Couchbase.Linq/Operators/AsyncValueFromSequenceResultOperatorBase.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Reflection;
+using Couchbase.Linq.Execution.StreamedData;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Operators
+{
+    /// <summary>
+    /// Abstract base for result operators which return their result asynchronously.
+    /// </summary>
+    internal abstract class AsyncValueFromSequenceResultOperatorBase : ResultOperatorBase
+    {
+        private static readonly MethodInfo ExecuteMethod = typeof(AsyncValueFromSequenceResultOperatorBase)
+            .GetMethod(nameof(ExecuteInMemory), new[] {typeof(StreamedSequence)});
+
+        public abstract AsyncStreamedValue ExecuteInMemory<T>(StreamedSequence sequence);
+
+        /// <inheritdoc />
+        public sealed override IStreamedData ExecuteInMemory(IStreamedData input)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+            if (!(input is StreamedSequence streamedSequence))
+            {
+                throw new ArgumentException($"{nameof(input)} must be of type {typeof(StreamedSequence)}");
+            }
+
+            var executeMethod = ExecuteMethod.MakeGenericMethod(streamedSequence.DataInfo.ResultItemType);
+            return (AsyncStreamedValue) InvokeExecuteMethod(executeMethod, streamedSequence);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Operators/ChoiceAsyncResultOperatorBase.cs
+++ b/Src/Couchbase.Linq/Operators/ChoiceAsyncResultOperatorBase.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading.Tasks;
+using Couchbase.Linq.Execution.StreamedData;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Operators
+{
+    /// <summary>
+    /// Abstract base for result operators which return a single result asynchronously, such as <see cref="FirstAsyncResultOperator"/>.
+    /// </summary>
+    internal abstract class ChoiceAsyncResultOperatorBase : AsyncValueFromSequenceResultOperatorBase
+    {
+        /// <summary>
+        /// If true, an empty collection should return the default value.
+        /// </summary>
+        public bool ReturnDefaultWhenEmpty { get; set; }
+
+        protected ChoiceAsyncResultOperatorBase(bool returnDefaultWhenEmpty)
+        {
+            ReturnDefaultWhenEmpty = returnDefaultWhenEmpty;
+        }
+
+        public sealed override IStreamedDataInfo GetOutputDataInfo(IStreamedDataInfo inputInfo)
+        {
+            if (inputInfo == null)
+            {
+                throw new ArgumentNullException(nameof(inputInfo));
+            }
+            if (!(inputInfo is StreamedSequenceInfo streamedSequenceInfo))
+            {
+                throw new ArgumentException($"{nameof(inputInfo)} must be of type {typeof(StreamedSequenceInfo)}");
+            }
+
+            return GetOutputDataInfo(streamedSequenceInfo);
+        }
+
+        protected AsyncStreamedValueInfo GetOutputDataInfo(StreamedSequenceInfo streamedSequenceInfo)
+        {
+            if (streamedSequenceInfo == null)
+            {
+                throw new ArgumentNullException(nameof(streamedSequenceInfo));
+            }
+
+            var taskType = typeof(Task<>).MakeGenericType(streamedSequenceInfo.ResultItemType);
+
+            return new AsyncStreamedSingleValueInfo(taskType, ReturnDefaultWhenEmpty);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Operators/FirstAsyncResultOperator.cs
+++ b/Src/Couchbase.Linq/Operators/FirstAsyncResultOperator.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Couchbase.Linq.Execution.StreamedData;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Operators
+{
+    /// <summary>
+    /// Result operator for FirstAsync and FirstOrDefaultAsync.
+    /// </summary>
+    internal class FirstAsyncResultOperator : ChoiceAsyncResultOperatorBase
+    {
+        public FirstAsyncResultOperator (bool returnDefaultWhenEmpty)
+            : base (returnDefaultWhenEmpty)
+        {
+        }
+
+        public override ResultOperatorBase Clone(CloneContext cloneContext) =>
+            new FirstAsyncResultOperator(ReturnDefaultWhenEmpty);
+
+        public override AsyncStreamedValue ExecuteInMemory<T>(StreamedSequence input)
+        {
+            var sequence = input.GetTypedSequence<T>();
+            T result = ReturnDefaultWhenEmpty ? sequence.FirstOrDefault() : sequence.First();
+            return new AsyncStreamedValue (Task.FromResult(result), GetOutputDataInfo (input.DataInfo));
+        }
+
+        /// <inheritdoc />
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+        }
+
+        public override string ToString() =>
+            ReturnDefaultWhenEmpty
+                ? "FirstOrDefaultAsync()"
+                : "FirstAsync()";
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -562,7 +562,7 @@ namespace Couchbase.Linq.QueryGeneration
                 _queryPartsAggregator.AddOffsetPart(" OFFSET {0}",
                     Convert.ToInt32(GetN1QlExpression(skipResultOperator.Count)));
             }
-            else if (resultOperator is FirstResultOperator)
+            else if (resultOperator is FirstResultOperator || resultOperator is FirstAsyncResultOperator)
             {
                 // We can save query execution time with a short circuit for .First()
 

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Couchbase.Linq.Clauses;
+using Couchbase.Linq.Extensions;
 using Couchbase.Linq.Operators;
 using Couchbase.Linq.QueryGeneration.ExpressionTransformers;
 using Couchbase.Linq.Serialization;
@@ -51,6 +52,9 @@ namespace Couchbase.Linq
             //register the "ExtentName" expression node parser
             nodeTypeRegistry.Register(ExtentNameExpressionNode.SupportedMethods,
                 typeof(ExtentNameExpressionNode));
+
+            //register the various asynchronous expression nodes
+            nodeTypeRegistry.Register(FirstAsyncExpressionNode.GetSupportedMethods(), typeof(FirstAsyncExpressionNode));
 
             //This creates all the default node types
             var nodeTypeProvider = ExpressionTreeParser.CreateDefaultNodeTypeProvider();


### PR DESCRIPTION
Motivation
----------
Support asynchronous queries which select only the first row.

Modifications
-------------
Create extension methods, an expression node, a result operator, and
streamed data classes to handle FirstAsync and FirstOrDefaultAsync.

Update N1QLQueryModelVisitor to recognize the new result operator.

Add ExecuteScalarAsync to IClusterQueryExecutor to support running
asynchronously.

Refactor First and FirstOrDefault tests into separate files and add
tests for the async methods.

Results
-------
FirstAsync or FirstOrDefaultAsync may be called on IQueryable and they
function correctly so long as the IQueryable is from a
CollectionContext.

Relates to #281