### PR TITLE
Cleanup Query Extensions

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/ConsistencyTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/ConsistencyTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.IntegrationTests.Documents;
+using Couchbase.Query;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.IntegrationTests
+{
+    [TestFixture]
+    public class ConsistencyTests : N1QlTestBase
+    {
+        [Test]
+        public async Task ScanConsistency()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from b in context.Query<Beer>().ScanConsistency(QueryScanConsistency.RequestPlus)
+                select b;
+
+            var beer = await beers.FirstAsync();
+            Console.WriteLine(beer.Name);
+        }
+
+        [Test]
+        public async Task ConsistentWith()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var upsertResult = await TestSetup.Collection.UpsertAsync("test-mutation", new {a = "a"});
+            try
+            {
+                var mutationState = MutationState.From(upsertResult);
+
+                var beers = from b in context.Query<Beer>().ConsistentWith(mutationState)
+                    select b;
+
+                var beer = await beers.FirstAsync();
+                Console.WriteLine(beer.Name);
+            }
+            finally
+            {
+                await TestSetup.Collection.RemoveAsync("test-mutation");
+            }
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/ConsistentWithClause.cs
+++ b/Src/Couchbase.Linq/Clauses/ConsistentWithClause.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq.Expressions;
+using Couchbase.Query;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.Linq.Clauses
+{
+    /// <summary>
+    /// Represents a clause on the query setting index consistency using <see cref="MutationState"/>.
+    /// If applied multiple times to the same query, the states should be merged.
+    /// </summary>
+    internal class ConsistentWithClause : IBodyClause
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsistentWithClause" /> class.
+        /// </summary>
+        /// <param name="mutationState">Mutation state for the query.</param>
+        public ConsistentWithClause(MutationState mutationState)
+        {
+            MutationState = mutationState;
+        }
+
+        /// <summary>
+        /// Mutation state for the query.
+        /// </summary>
+        public MutationState MutationState { get; set; }
+
+        /// <inheritdoc />
+        public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
+        {
+            // Do nothing, the ClusterQueryExecutor will find this in QueryModel.BodyClauses to apply behavior
+        }
+
+        /// <inheritdoc />
+        public IBodyClause Clone(CloneContext cloneContext)
+        {
+            return new ConsistentWithClause(MutationState);
+        }
+
+        /// <inheritdoc />
+        public virtual void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+            // Do nothing
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"with mutation state consistency {MutationState}";
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/ConsistentWithExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/ConsistentWithExpressionNode.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Couchbase.Query;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    /// <summary>
+    /// Represents a node on the query setting index consistency using <see cref="MutationState"/>.
+    /// If applied multiple times to the same query, the states should be merged.
+    /// </summary>
+    internal class ConsistentWithExpressionNode : MethodCallExpressionNodeBase
+    {
+        /// <summary>
+        /// Methods which are supported by this type of node.
+        /// </summary>
+        /// <returns></returns>
+        public static IEnumerable<MethodInfo> GetSupportedMethods() =>
+            new[] {QueryExtensionMethods.ConsistentWith};
+
+        /// <summary>
+        /// Creates a new ConsistentWithExpressionNode.
+        /// </summary>
+        /// <param name="parseInfo">Method parse info.</param>
+        /// <param name="mutationState">Mutation state for the query.</param>
+        public ConsistentWithExpressionNode(MethodCallExpressionParseInfo parseInfo, ConstantExpression mutationState)
+            : base(parseInfo)
+        {
+            if (mutationState == null)
+            {
+                throw new ArgumentNullException(nameof(mutationState));
+            }
+            if (mutationState.Type != typeof(MutationState))
+            {
+                throw new ArgumentException($"{nameof(mutationState)} must return a {typeof(MutationState)}", nameof(mutationState));
+            }
+
+            MutationState = mutationState;
+        }
+
+        /// <summary>
+        /// Mutation state for the query.
+        /// </summary>
+        public ConstantExpression MutationState { get; }
+
+        /// <inheritdoc />
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        /// <inheritdoc />
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            queryModel.BodyClauses.Add(new ConsistentWithClause((MutationState) MutationState.Value));
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/ScanConsistencyClause.cs
+++ b/Src/Couchbase.Linq/Clauses/ScanConsistencyClause.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq.Expressions;
+using Couchbase.Query;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.Linq.Clauses
+{
+    /// <summary>
+    /// Represents a clause on the query setting the scan consistency.
+    /// </summary>
+    internal class ScanConsistencyClause : IBodyClause
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScanConsistencyClause" /> class.
+        /// </summary>
+        /// <param name="scanConsistency">Scan consistency for the query.</param>
+        public ScanConsistencyClause(QueryScanConsistency scanConsistency)
+        {
+            ScanConsistency = scanConsistency;
+        }
+
+        /// <summary>
+        /// Scan consistency for the query.
+        /// </summary>
+        public QueryScanConsistency ScanConsistency { get; set; }
+
+        /// <inheritdoc />
+        public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
+        {
+            // Do nothing, the ClusterQueryExecutor will find this in QueryModel.BodyClauses to apply behavior
+        }
+
+        /// <inheritdoc />
+        public IBodyClause Clone(CloneContext cloneContext)
+        {
+            return new ScanConsistencyClause(ScanConsistency);
+        }
+
+        /// <inheritdoc />
+        public virtual void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+            // Do nothing
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"with scan consistency {ScanConsistency}";
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/ScanConsistencyExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/ScanConsistencyExpressionNode.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Couchbase.Query;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    /// <summary>
+    /// Represents a node on the query setting the scan consistency.
+    /// </summary>
+    internal class ScanConsistencyExpressionNode : MethodCallExpressionNodeBase
+    {
+        public static IEnumerable<MethodInfo> GetSupportedMethods() =>
+            new[] {QueryExtensionMethods.ScanConsistency};
+
+        /// <summary>
+        /// Creates a new ScanConsistencyExpressionNode.
+        /// </summary>
+        /// <param name="parseInfo">Method parse info.</param>
+        /// <param name="scanConsistency">Scan consistency for the query.</param>
+        public ScanConsistencyExpressionNode(MethodCallExpressionParseInfo parseInfo, ConstantExpression scanConsistency)
+            : base(parseInfo)
+        {
+            if (scanConsistency == null)
+            {
+                throw new ArgumentNullException(nameof(scanConsistency));
+            }
+            if (scanConsistency.Type != typeof(QueryScanConsistency))
+            {
+                throw new ArgumentException($"{nameof(scanConsistency)} must return a {typeof(QueryScanConsistency)}", nameof(scanConsistency));
+            }
+
+            ScanConsistency = scanConsistency;
+        }
+
+        /// <summary>
+        /// Scan consistency for the query.
+        /// </summary>
+        public ConstantExpression ScanConsistency { get; }
+
+        /// <inheritdoc />
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        /// <inheritdoc />
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            queryModel.BodyClauses.Add(new ScanConsistencyClause((QueryScanConsistency) ScanConsistency.Value));
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Execution/IClusterQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/IClusterQueryExecutor.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Couchbase.Linq.QueryGeneration;
-using Couchbase.Query;
 using Remotion.Linq;
 
 namespace Couchbase.Linq.Execution
@@ -13,29 +12,6 @@ namespace Couchbase.Linq.Execution
     /// </summary>
     internal interface IClusterQueryExecutor : IQueryExecutor
     {
-        /// <summary>
-        /// Specifies the consistency guarantee/constraint for index scanning.
-        /// </summary>
-        QueryScanConsistency? ScanConsistency { get; set; }
-
-        /// <summary>
-        /// Specifies the maximum time the client is willing to wait for an index to catch up to the consistency requirement in the request.
-        /// If an index has to catch up, and the time is exceed doing so, an error is returned.
-        /// </summary>
-        TimeSpan? ScanWait { get; set; }
-
-        /// <summary>
-        /// Specifies the maximum time the server should wait for the QueryRequest to execute.
-        /// </summary>
-        TimeSpan? Timeout { get; set; }
-
-        /// <summary>
-        /// Requires that the indexes but up to date with a <see cref="MutationState"/> before the query is executed.
-        /// </summary>
-        /// <param name="state"><see cref="MutationState"/> used for consistency controls.</param>
-        /// <remarks>If called multiple times, the states from the calls are combined.</remarks>
-        void ConsistentWith(MutationState state);
-
         IAsyncEnumerable<T> ExecuteCollectionAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default);
 
         Task<T> ExecuteSingleAsync<T>(QueryModel queryModel, bool returnDefaultWhenEmpty, CancellationToken cancellationToken = default);

--- a/Src/Couchbase.Linq/Extensions/EnumerableExtensionMethods.cs
+++ b/Src/Couchbase.Linq/Extensions/EnumerableExtensionMethods.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Couchbase.Linq.Extensions
+{
+    /// <summary>
+    /// Static helper to store reflection method info for various <see cref="IEnumerable{T}"/> extensions.
+    /// </summary>
+    internal static class EnumerableExtensionMethods
+    {
+        public static MethodInfo Nest { get; }
+        public static MethodInfo LeftOuterNest { get; }
+
+        public static MethodInfo UseKeys { get; }
+
+        static EnumerableExtensionMethods()
+        {
+            var allMethods = typeof(EnumerableExtensions)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .ToList();
+
+            Nest = allMethods.Single(p => p.Name == nameof(QueryExtensions.Nest));
+            LeftOuterNest = allMethods.Single(p => p.Name == nameof(QueryExtensions.LeftOuterNest));
+
+            UseKeys = allMethods.Single(p => p.Name == nameof(QueryExtensions.UseKeys));
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
@@ -5,7 +5,7 @@ using System.Threading;
 namespace Couchbase.Linq.Extensions
 {
     /// <summary>
-    /// Static helper to store reflection method info for various <see cref="IQueryable"/> extensions.
+    /// Static helper to store reflection method info for various <see cref="IQueryable{T}"/> extensions.
     /// </summary>
     internal static class QueryExtensionMethods
     {
@@ -13,6 +13,17 @@ namespace Couchbase.Linq.Extensions
         public static MethodInfo FirstAsyncWithPredicate { get; }
         public static MethodInfo FirstOrDefaultAsyncNoPredicate { get; }
         public static MethodInfo FirstOrDefaultAsyncWithPredicate { get; }
+
+        public static MethodInfo Nest { get; }
+        public static MethodInfo LeftOuterNest { get; }
+        public static MethodInfo Explain { get; }
+
+        public static MethodInfo UseKeys { get; }
+        public static MethodInfo UseIndexWithType { get; }
+        public static MethodInfo UseHash { get; }
+
+        public static MethodInfo ScanConsistency { get; }
+        public static MethodInfo ConsistentWith { get; }
 
         static QueryExtensionMethods()
         {
@@ -28,6 +39,17 @@ namespace Couchbase.Linq.Extensions
                 p.Name == nameof(QueryExtensions.FirstOrDefaultAsync) && p.GetParameters().Length == 1);
             FirstOrDefaultAsyncWithPredicate = allMethods.Single(p =>
                 p.Name == nameof(QueryExtensions.FirstOrDefaultAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
+
+            Nest = allMethods.Single(p => p.Name == nameof(QueryExtensions.Nest));
+            LeftOuterNest = allMethods.Single(p => p.Name == nameof(QueryExtensions.LeftOuterNest));
+            Explain = allMethods.Single(p => p.Name == nameof(QueryExtensions.Explain));
+
+            UseKeys = allMethods.Single(p => p.Name == nameof(QueryExtensions.UseKeys));
+            UseIndexWithType = allMethods.Single(p => p.Name == nameof(QueryExtensions.UseIndex) && p.GetParameters().Length == 3);
+            UseHash = allMethods.Single(p => p.Name == nameof(QueryExtensions.UseHash));
+
+            ScanConsistency = allMethods.Single(p => p.Name == nameof(QueryExtensions.ScanConsistency));
+            ConsistentWith = allMethods.Single(p => p.Name == nameof(QueryExtensions.ConsistentWith));
         }
     }
 }

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.Consistency.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.Consistency.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Couchbase.Query;
+
+namespace Couchbase.Linq.Extensions
+{
+    public static partial class QueryExtensions
+    {
+        /// <summary>
+        /// Specifies the consistency guarantee/constraint for index scanning.
+        /// </summary>
+        /// <param name="source">Sets scan consistency for this query.  Must be a Couchbase LINQ query.</param>
+        /// <param name="scanConsistency">Specify the consistency guarantee/constraint for index scanning.</param>
+        /// <remarks>The default is <see cref="QueryScanConsistency.NotBounded"/>.</remarks>
+        public static IQueryable<T> ScanConsistency<T>(this IQueryable<T> source, QueryScanConsistency scanConsistency)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return source.Provider.CreateQuery<T>(
+                Expression.Call(
+                    QueryExtensionMethods.ScanConsistency.MakeGenericMethod(typeof(T)),
+                    source.Expression,
+                    Expression.Constant(scanConsistency)));
+        }
+
+        /// <summary>
+        /// Requires that the indexes but up to date with a <see cref="MutationState"/> before the query is executed.
+        /// </summary>
+        /// <param name="source">Sets consistency requirement for this query.  Must be a Couchbase LINQ query.</param>
+        /// <param name="state"><see cref="MutationState"/> used for conistency controls.</param>
+        /// <remarks>If called multiple times, the states from the calls are combined.</remarks>
+        public static IQueryable<T> ConsistentWith<T>(this IQueryable<T> source, MutationState state)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return source.Provider.CreateQuery<T>(
+                Expression.Call(
+                    QueryExtensionMethods.ConsistentWith.MakeGenericMethod(typeof(T)),
+                    source.Expression,
+                    Expression.Constant(state)));
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.Explain.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.Explain.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Couchbase.Linq.Extensions
+{
+    public static partial class QueryExtensions
+    {
+        /// <summary>
+        /// Returns the query execution plan for the query.
+        /// </summary>
+        /// <typeparam name="T">The target type.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <returns>Explanation of the query</returns>
+        public static dynamic Explain<T>(this IQueryable<T> source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var newExpression = Expression.Call(null,
+                QueryExtensionMethods.Explain.MakeGenericMethod(typeof (T)),
+                source.Expression);
+
+            return source.Provider.Execute<dynamic>(newExpression);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.First.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.First.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Couchbase.Linq.Execution;
 
 namespace Couchbase.Linq.Extensions
 {
@@ -134,35 +132,6 @@ namespace Couchbase.Linq.Extensions
 
             return ExecuteAsync<T, Task<T>>(QueryExtensionMethods.FirstOrDefaultAsyncWithPredicate, source, predicate,
                 cancellationToken);
-        }
-
-        private static TResult ExecuteAsync<TSource, TResult>(
-            MethodInfo operatorMethodInfo,
-            IQueryable<TSource> source,
-            Expression expression,
-            CancellationToken cancellationToken = default)
-        {
-            if (source.Provider is IAsyncQueryProvider provider)
-            {
-                if (operatorMethodInfo.IsGenericMethod)
-                {
-                    operatorMethodInfo
-                        = operatorMethodInfo.GetGenericArguments().Length == 2
-                            ? operatorMethodInfo.MakeGenericMethod(typeof(TSource), typeof(TResult).GetGenericArguments().Single())
-                            : operatorMethodInfo.MakeGenericMethod(typeof(TSource));
-                }
-
-                var updatedExpression = Expression.Call(
-                    instance: null,
-                    method: operatorMethodInfo,
-                    arguments: expression == null
-                        ? new[] {source.Expression}
-                        : new[] {source.Expression, expression});
-
-                return provider.ExecuteAsync<TResult>(updatedExpression, cancellationToken);
-            }
-
-            throw new InvalidOperationException("The provided IQueryable is not backed by an IAsyncQueryProvider.");
         }
     }
 }

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.Nest.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.Nest.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Couchbase.Linq.Metadata;
+
+namespace Couchbase.Linq.Extensions
+{
+    public static partial class QueryExtensions
+    {
+        /// <summary>
+        ///     Nest for N1QL. (outer.Nest(inner, keySelector, resultSelector) translates to NEST inner ON KEYS outer.keySelector)
+        /// </summary>
+        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
+        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
+        /// <typeparam name="TResult">Type of the result sequence</typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner">Sequence to be nested</param>
+        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
+        /// <param name="resultSelector">Expression that returns the result</param>
+        /// <remarks>Returns a result for values in the outer sequence only if matching values in the inner sequence are found</remarks>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<TResult> Nest<TOuter, TInner, TResult>(
+            this IQueryable<TOuter> outer,
+            IEnumerable<TInner> inner,
+            Expression<Func<TOuter, IEnumerable<string>>> keySelector,
+            Expression<Func<TOuter, IEnumerable<TInner>, TResult>> resultSelector)
+        {
+            if (inner == null)
+            {
+                throw new ArgumentNullException(nameof(inner));
+            }
+            if (outer == null)
+            {
+                throw new ArgumentNullException(nameof(outer));
+            }
+            if (keySelector == null)
+            {
+                throw new ArgumentNullException(nameof(keySelector));
+            }
+            if (resultSelector == null)
+            {
+                throw new ArgumentNullException(nameof(resultSelector));
+            }
+
+            if (outer is EnumerableQuery<TOuter>)
+            {
+                // If outer is an IEnumerable converted to IQueryable via AsQueryable
+                // Then we need to just call the IEnumerable implementation
+
+                if (!typeof (IDocumentMetadataProvider).IsAssignableFrom(typeof (TInner)))
+                {
+                    throw new NotSupportedException("Inner Sequence Items Must Implement IDocumentMetadataProvider To Function With EnumerableQuery<T>");
+                }
+
+                var methodCall =
+                    Expression.Call(
+                        EnumerableExtensionMethods.Nest.MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
+                        Expression.Constant(outer, typeof(IEnumerable<TOuter>)),
+                        Expression.Constant(inner, typeof(IEnumerable<TInner>)),
+                        keySelector,
+                        resultSelector);
+
+                return outer.Provider.CreateQuery<TResult>(
+                    Expression.Call(
+                        typeof(Queryable).GetMethods().First(p => p.Name == "AsQueryable" && p.GetGenericArguments().Length == 1)
+                            .MakeGenericMethod(typeof(TResult)),
+                        methodCall));
+            }
+            else
+            {
+                return outer.Provider.CreateQuery<TResult>(
+                    Expression.Call(
+                        QueryExtensionMethods.Nest.MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
+                        outer.Expression,
+                        GetSourceExpression(inner),
+                        Expression.Quote(keySelector),
+                        Expression.Quote(resultSelector)));
+            }
+        }
+
+        /// <summary>
+        ///     Nest for N1QL. (outer.LeftNest(inner, keySelector, resultSelector) translates to LEFT OUTER NEST inner ON KEYS outer.keySelector)
+        /// </summary>
+        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
+        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
+        /// <typeparam name="TResult">Type of the result sequence</typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner">Sequence to be nested</param>
+        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
+        /// <param name="resultSelector">Expression that returns the result</param>
+        /// <remarks>Returns a result for all values in the outer sequence</remarks>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<TResult> LeftOuterNest<TOuter, TInner, TResult>(
+            this IQueryable<TOuter> outer,
+            IEnumerable<TInner> inner,
+            Expression<Func<TOuter, IEnumerable<string>>> keySelector,
+            Expression<Func<TOuter, IEnumerable<TInner>, TResult>> resultSelector)
+        {
+            if (inner == null)
+            {
+                throw new ArgumentNullException(nameof(inner));
+            }
+            if (outer == null)
+            {
+                throw new ArgumentNullException(nameof(outer));
+            }
+            if (keySelector == null)
+            {
+                throw new ArgumentNullException(nameof(keySelector));
+            }
+            if (resultSelector == null)
+            {
+                throw new ArgumentNullException(nameof(resultSelector));
+            }
+
+            if (outer is EnumerableQuery<TOuter>)
+            {
+                // If outer is an IEnumerable converted to IQueryable via AsQueryable
+                // Then we need to just call the IEnumerable implementation
+
+                if (!typeof(IDocumentMetadataProvider).IsAssignableFrom(typeof(TInner)))
+                {
+                    throw new NotSupportedException("Inner Sequence Items Must Implement IDocumentMetadataProvider To Function With EnumerableQuery<T>");
+                }
+
+                var methodCall =
+                    Expression.Call(
+                        EnumerableExtensionMethods.LeftOuterNest.MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
+                        Expression.Constant(outer, typeof(IEnumerable<TOuter>)),
+                        Expression.Constant(inner, typeof(IEnumerable<TInner>)),
+                        keySelector,
+                        resultSelector);
+
+                return outer.Provider.CreateQuery<TResult>(
+                    Expression.Call(
+                        typeof(Queryable).GetMethods().First(p => p.Name == "AsQueryable" && p.GetGenericArguments().Length == 1)
+                            .MakeGenericMethod(typeof(TResult)),
+                        methodCall));
+            }
+            else
+            {
+                return outer.Provider.CreateQuery<TResult>(
+                    Expression.Call(
+                        QueryExtensionMethods.LeftOuterNest.MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
+                        outer.Expression,
+                        GetSourceExpression(inner),
+                        Expression.Quote(keySelector),
+                        Expression.Quote(resultSelector)));
+            }
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.Use.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.Use.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Couchbase.Linq.Metadata;
+
+namespace Couchbase.Linq.Extensions
+{
+    // UseXXX extensions
+
+    public static partial class QueryExtensions
+    {
+        #region UseKeys
+
+        /// <summary>
+        ///     Filters documents based on a list of keys
+        /// </summary>
+        /// <typeparam name="T">Type of the items being filtered</typeparam>
+        /// <param name="items">Items being filtered</param>
+        /// <param name="keys">Keys to be selected</param>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<T> UseKeys<T>(
+            this IQueryable<T> items,
+            IEnumerable<string> keys)
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+            if (keys == null)
+            {
+                throw new ArgumentNullException(nameof(keys));
+            }
+
+            if (items is EnumerableQuery<T>)
+            {
+                // If outer is an IEnumerable converted to IQueryable via AsQueryable
+                // Then we need to just call the IEnumerable implementation
+
+                if (!typeof(IDocumentMetadataProvider).IsAssignableFrom(typeof(T)))
+                {
+                    throw new NotSupportedException("Items Sequence Must Implement IDocumentMetadataProvider To Function With EnumerableQuery<T>");
+                }
+
+                var methodCall =
+                    Expression.Call(
+                        EnumerableExtensionMethods.UseKeys.MakeGenericMethod(typeof(T)),
+                        Expression.Constant(items, typeof(IEnumerable<T>)),
+                        Expression.Constant(keys, typeof(IEnumerable<string>)));
+
+                return items.Provider.CreateQuery<T>(
+                    Expression.Call(
+                        typeof(Queryable).GetMethods().First(p => p.Name == "AsQueryable" && p.GetGenericArguments().Length == 1)
+                            .MakeGenericMethod(typeof(T)),
+                        methodCall));
+            }
+            else
+            {
+                return items.Provider.CreateQuery<T>(
+                    Expression.Call(
+                        QueryExtensionMethods.UseKeys.MakeGenericMethod(typeof(T)),
+                        items.Expression,
+                        GetSourceExpression(keys)));
+            }
+        }
+
+        #endregion
+
+        #region UseIndex
+
+        /// <summary>
+        /// Provides an index hint to the query engine.
+        /// </summary>
+        /// <typeparam name="T">Type of items being queried.</typeparam>
+        /// <param name="source">Items being queried.</param>
+        /// <param name="indexName">Name of the index to use.</param>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<T> UseIndex<T>(this IQueryable<T> source, string indexName) =>
+            source.UseIndex(indexName, N1QlIndexType.Gsi);
+
+        /// <summary>
+        /// Provides an index hint to the query engine.
+        /// </summary>
+        /// <typeparam name="T">Type of items being queried.</typeparam>
+        /// <param name="source">Items being queried.</param>
+        /// <param name="indexName">Name of the index to use.</param>
+        /// <param name="indexType">Type of the index to use.</param>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<T> UseIndex<T>(this IQueryable<T> source, string indexName, N1QlIndexType indexType)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (indexType < N1QlIndexType.Gsi || indexType > N1QlIndexType.View)
+            {
+                throw new ArgumentOutOfRangeException(nameof(indexType));
+            }
+
+            return source.Provider.CreateQuery<T>(
+                Expression.Call(
+                    QueryExtensionMethods.UseIndexWithType.MakeGenericMethod(typeof(T)),
+                    source.Expression,
+                    Expression.Constant(indexName),
+                    Expression.Constant(indexType)));
+        }
+
+        #endregion
+
+        #region Use Hash
+
+        /// <summary>
+        /// Provides an hash join hint to the query engine.
+        /// </summary>
+        /// <typeparam name="T">Type of items being queried.</typeparam>
+        /// <param name="source">Items being queried.</param>
+        /// <param name="type">Type of hash hint to provide.</param>
+        /// <returns>Modified IQueryable</returns>
+        /// <remarks>Only valid when using Couchbase Server 5.5 Enterprise Edition (or later).  Not supported by Community Edition.</remarks>
+        public static IQueryable<T> UseHash<T>(this IQueryable<T> source, HashHintType type)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (type < HashHintType.Build || type > HashHintType.Probe)
+            {
+                throw new ArgumentOutOfRangeException(nameof(type));
+            }
+
+            return source.Provider.CreateQuery<T>(
+                Expression.Call(
+                    QueryExtensionMethods.UseHash.MakeGenericMethod(typeof(T)),
+                    source.Expression,
+                    Expression.Constant(type)));
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
@@ -3,10 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 using Couchbase.Linq.Execution;
-using Couchbase.Linq.Metadata;
-using Couchbase.Query;
-using Remotion.Linq.Parsing.ExpressionVisitors;
 
 namespace Couchbase.Linq.Extensions
 {
@@ -15,424 +13,42 @@ namespace Couchbase.Linq.Extensions
     /// </summary>
     public static partial class QueryExtensions
     {
-        #region Nest
-
-        /// <summary>
-        ///     Nest for N1QL. (outer.Nest(inner, keySelector, resultSelector) translates to NEST inner ON KEYS outer.keySelector)
-        /// </summary>
-        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
-        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
-        /// <typeparam name="TResult">Type of the result sequence</typeparam>
-        /// <param name="outer"></param>
-        /// <param name="inner">Sequence to be nested</param>
-        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
-        /// <param name="resultSelector">Expression that returns the result</param>
-        /// <remarks>Returns a result for values in the outer sequence only if matching values in the inner sequence are found</remarks>
-        /// <returns>Modified IQueryable</returns>
-        public static IQueryable<TResult> Nest<TOuter, TInner, TResult>(
-            this IQueryable<TOuter> outer,
-            IEnumerable<TInner> inner,
-            Expression<Func<TOuter, IEnumerable<string>>> keySelector,
-            Expression<Func<TOuter, IEnumerable<TInner>, TResult>> resultSelector)
+        private static TResult ExecuteAsync<TSource, TResult>(
+            MethodInfo operatorMethodInfo,
+            IQueryable<TSource> source,
+            Expression expression,
+            CancellationToken cancellationToken = default)
         {
-            if (inner == null)
+            if (source.Provider is IAsyncQueryProvider provider)
             {
-                throw new ArgumentNullException("inner");
-            }
-            if (outer == null)
-            {
-                throw new ArgumentNullException("outer");
-            }
-            if (keySelector == null)
-            {
-                throw new ArgumentNullException("keySelector");
-            }
-            if (resultSelector == null)
-            {
-                throw new ArgumentNullException("resultSelector");
-            }
-
-            if (outer is EnumerableQuery<TOuter>)
-            {
-                // If outer is an IEnumerable converted to IQueryable via AsQueryable
-                // Then we need to just call the IEnumerable implementation
-
-                if (!typeof (IDocumentMetadataProvider).IsAssignableFrom(typeof (TInner)))
+                if (operatorMethodInfo.IsGenericMethod)
                 {
-                    throw new NotSupportedException("Inner Sequence Items Must Implement IDocumentMetadataProvider To Function With EnumerableQuery<T>");
+                    operatorMethodInfo
+                        = operatorMethodInfo.GetGenericArguments().Length == 2
+                            ? operatorMethodInfo.MakeGenericMethod(typeof(TSource), typeof(TResult).GetGenericArguments().Single())
+                            : operatorMethodInfo.MakeGenericMethod(typeof(TSource));
                 }
 
-                var methodCall =
-                    Expression.Call(
-                        typeof(EnumerableExtensions).GetMethod("Nest")
-                            .MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
-                        Expression.Constant(outer, typeof(IEnumerable<TOuter>)),
-                        Expression.Constant(inner, typeof(IEnumerable<TInner>)),
-                        keySelector,
-                        resultSelector);
+                var updatedExpression = Expression.Call(
+                    instance: null,
+                    method: operatorMethodInfo,
+                    arguments: expression == null
+                        ? new[] {source.Expression}
+                        : new[] {source.Expression, expression});
 
-                return outer.Provider.CreateQuery<TResult>(
-                    Expression.Call(
-                        typeof(Queryable).GetMethods().First(p => p.Name == "AsQueryable" && p.GetGenericArguments().Length == 1)
-                            .MakeGenericMethod(typeof(TResult)),
-                        methodCall));
-            }
-            else
-            {
-                return outer.Provider.CreateQuery<TResult>(
-                    Expression.Call(
-                        typeof(QueryExtensions).GetMethod("Nest")
-                            .MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
-                        outer.Expression,
-                        GetSourceExpression(inner),
-                        Expression.Quote(keySelector),
-                        Expression.Quote(resultSelector)));
-            }
-        }
-
-        /// <summary>
-        ///     Nest for N1QL. (outer.LeftNest(inner, keySelector, resultSelector) translates to LEFT OUTER NEST inner ON KEYS outer.keySelector)
-        /// </summary>
-        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
-        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
-        /// <typeparam name="TResult">Type of the result sequence</typeparam>
-        /// <param name="outer"></param>
-        /// <param name="inner">Sequence to be nested</param>
-        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
-        /// <param name="resultSelector">Expression that returns the result</param>
-        /// <remarks>Returns a result for all values in the outer sequence</remarks>
-        /// <returns>Modified IQueryable</returns>
-        public static IQueryable<TResult> LeftOuterNest<TOuter, TInner, TResult>(
-            this IQueryable<TOuter> outer,
-            IEnumerable<TInner> inner,
-            Expression<Func<TOuter, IEnumerable<string>>> keySelector,
-            Expression<Func<TOuter, IEnumerable<TInner>, TResult>> resultSelector)
-        {
-            if (inner == null)
-            {
-                throw new ArgumentNullException("inner");
-            }
-            if (outer == null)
-            {
-                throw new ArgumentNullException("outer");
-            }
-            if (keySelector == null)
-            {
-                throw new ArgumentNullException("keySelector");
-            }
-            if (resultSelector == null)
-            {
-                throw new ArgumentNullException("resultSelector");
+                return provider.ExecuteAsync<TResult>(updatedExpression, cancellationToken);
             }
 
-            if (outer is EnumerableQuery<TOuter>)
-            {
-                // If outer is an IEnumerable converted to IQueryable via AsQueryable
-                // Then we need to just call the IEnumerable implementation
-
-                if (!typeof(IDocumentMetadataProvider).IsAssignableFrom(typeof(TInner)))
-                {
-                    throw new NotSupportedException("Inner Sequence Items Must Implement IDocumentMetadataProvider To Function With EnumerableQuery<T>");
-                }
-
-                var methodCall =
-                    Expression.Call(
-                        typeof(EnumerableExtensions).GetMethod("LeftOuterNest")
-                            .MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
-                        Expression.Constant(outer, typeof(IEnumerable<TOuter>)),
-                        Expression.Constant(inner, typeof(IEnumerable<TInner>)),
-                        keySelector,
-                        resultSelector);
-
-                return outer.Provider.CreateQuery<TResult>(
-                    Expression.Call(
-                        typeof(Queryable).GetMethods().First(p => p.Name == "AsQueryable" && p.GetGenericArguments().Length == 1)
-                            .MakeGenericMethod(typeof(TResult)),
-                        methodCall));
-            }
-            else
-            {
-                return outer.Provider.CreateQuery<TResult>(
-                    Expression.Call(
-                        typeof(QueryExtensions).GetMethod("LeftOuterNest")
-                            .MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
-                        outer.Expression,
-                        GetSourceExpression(inner),
-                        Expression.Quote(keySelector),
-                        Expression.Quote(resultSelector)));
-            }
-        }
-
-        #endregion
-
-        #region UseKeys
-
-        /// <summary>
-        ///     Filters documents based on a list of keys
-        /// </summary>
-        /// <typeparam name="T">Type of the items being filtered</typeparam>
-        /// <param name="items">Items being filtered</param>
-        /// <param name="keys">Keys to be selected</param>
-        /// <returns>Modified IQueryable</returns>
-        public static IQueryable<T> UseKeys<T>(
-            this IQueryable<T> items,
-            IEnumerable<string> keys)
-        {
-            if (items == null)
-            {
-                throw new ArgumentNullException("items");
-            }
-            if (keys == null)
-            {
-                throw new ArgumentNullException("keys");
-            }
-
-            if (items is EnumerableQuery<T>)
-            {
-                // If outer is an IEnumerable converted to IQueryable via AsQueryable
-                // Then we need to just call the IEnumerable implementation
-
-                if (!typeof(IDocumentMetadataProvider).IsAssignableFrom(typeof(T)))
-                {
-                    throw new NotSupportedException("Items Sequence Must Implement IDocumentMetadataProvider To Function With EnumerableQuery<T>");
-                }
-
-                var methodCall =
-                    Expression.Call(
-                        typeof(EnumerableExtensions).GetMethod("UseKeys")
-                            .MakeGenericMethod(typeof(T)),
-                        Expression.Constant(items, typeof(IEnumerable<T>)),
-                        Expression.Constant(keys, typeof(IEnumerable<string>)));
-
-                return items.Provider.CreateQuery<T>(
-                    Expression.Call(
-                        typeof(Queryable).GetMethods().First(p => p.Name == "AsQueryable" && p.GetGenericArguments().Length == 1)
-                            .MakeGenericMethod(typeof(T)),
-                        methodCall));
-            }
-            else
-            {
-                return items.Provider.CreateQuery<T>(
-                    Expression.Call(
-                        typeof(QueryExtensions).GetMethod("UseKeys")
-                            .MakeGenericMethod(typeof(T)),
-                        items.Expression,
-                        GetSourceExpression(keys)));
-            }
-        }
-
-        #endregion
-
-        /// <summary>
-        /// The EXPLAIN statement is used before any N1QL statement to obtain information about how the statement operates.
-        /// </summary>
-        /// <typeparam name="T">The target type.</typeparam>
-        /// <param name="source">The source.</param>
-        /// <returns>Explanation of the query</returns>
-        public static dynamic Explain<T>(this IQueryable<T> source)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException("source");
-            }
-
-            var newExpression = Expression.Call(null,
-                typeof(QueryExtensions).GetMethod("Explain")
-                    .MakeGenericMethod(typeof (T)),
-                source.Expression);
-
-            return source.Provider.Execute<dynamic>(newExpression);
-        }
-
-        #region Use Index
-
-        private static readonly MethodInfo UseIndexMethod =
-            typeof(QueryExtensions).GetMethods()
-            .First(p => p.Name == "UseIndex" && p.GetParameters().Length == 3);
-
-        /// <summary>
-        /// Provides an index hint to the query engine.
-        /// </summary>
-        /// <typeparam name="T">Type of items being queried.</typeparam>
-        /// <param name="source">Items being queried.</param>
-        /// <param name="indexName">Name of the index to use.</param>
-        /// <returns>Modified IQueryable</returns>
-        public static IQueryable<T> UseIndex<T>(this IQueryable<T> source, string indexName)
-        {
-            return source.UseIndex(indexName, N1QlIndexType.Gsi);
-        }
-
-        /// <summary>
-        /// Provides an index hint to the query engine.
-        /// </summary>
-        /// <typeparam name="T">Type of items being queried.</typeparam>
-        /// <param name="source">Items being queried.</param>
-        /// <param name="indexName">Name of the index to use.</param>
-        /// <param name="indexType">Type of the index to use.</param>
-        /// <returns>Modified IQueryable</returns>
-        public static IQueryable<T> UseIndex<T>(this IQueryable<T> source, string indexName, N1QlIndexType indexType)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException("source");
-            }
-            if (!Enum.IsDefined(typeof(N1QlIndexType), indexType))
-            {
-                throw new ArgumentOutOfRangeException("indexType");
-            }
-
-            return source.Provider.CreateQuery<T>(
-                    Expression.Call(
-                        UseIndexMethod
-                            .MakeGenericMethod(typeof(T)),
-                        source.Expression,
-                        Expression.Constant(indexName),
-                        Expression.Constant(indexType)));
-        }
-
-        #endregion
-
-        #region Use Hash
-
-        private static readonly MethodInfo UseHashMethod =
-            typeof(QueryExtensions).GetMethod("UseHash");
-
-        /// <summary>
-        /// Provides an hash join hint to the query engine.
-        /// </summary>
-        /// <typeparam name="T">Type of items being queried.</typeparam>
-        /// <param name="source">Items being queried.</param>
-        /// <param name="type">Type of hash hint to provide.</param>
-        /// <returns>Modified IQueryable</returns>
-        /// <remarks>Only valid when using Couchbase Server 5.5 Enterprise Edition (or later).  Not supported by Community Edition.</remarks>
-        public static IQueryable<T> UseHash<T>(this IQueryable<T> source, HashHintType type)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-            if (!Enum.IsDefined(typeof(HashHintType), type))
-            {
-                throw new ArgumentOutOfRangeException(nameof(type));
-            }
-
-            return source.Provider.CreateQuery<T>(
-                    Expression.Call(
-                        UseHashMethod
-                            .MakeGenericMethod(typeof(T)),
-                        source.Expression,
-                        Expression.Constant(type)));
-        }
-
-        #endregion
-
-        #region Query Request Settings
-
-        /// <summary>
-        /// Specifies the consistency guarantee/constraint for index scanning.
-        /// </summary>
-        /// <param name="source">Sets scan consistency for this query.  Must be a Couchbase LINQ query.</param>
-        /// <param name="scanConsistency">Specify the consistency guarantee/constraint for index scanning.</param>
-        /// <remarks>The default is <see cref="QueryScanConsistency.NotBounded"/>.</remarks>
-        public static IQueryable<T> ScanConsistency<T>(this IQueryable<T> source, QueryScanConsistency scanConsistency)
-        {
-            EnsureBucketQueryable(source, "ScanConsistency", "source");
-
-            ((IClusterQueryExecutorProvider) source).ClusterQueryExecutor.ScanConsistency = scanConsistency;
-
-            return source;
-        }
-
-        /// <summary>
-        /// Specifies the maximum time the client is willing to wait for an index to catch up to the consistency requirement in the request.
-        /// If an index has to catch up, and the time is exceed doing so, an error is returned.
-        /// </summary>
-        /// <param name="source">Sets scan wait for this query.  Must be a Couchbase LINQ query.</param>
-        /// <param name="scanWait">The maximum time the client is willing to wait for index to catch up to the vector timestamp.</param>
-        public static IQueryable<T> ScanWait<T>(this IQueryable<T> source, TimeSpan scanWait)
-        {
-            EnsureBucketQueryable(source, "ScanWait", "source");
-
-            ((IClusterQueryExecutorProvider)source).ClusterQueryExecutor.ScanWait = scanWait;
-
-            return source;
-        }
-
-        /// <summary>
-        /// Specifies the maximum time the server should wait for the QueryRequest to execute.
-        /// </summary>
-        /// <param name="source">Sets scan wait for this query.  Must be a Couchbase LINQ query.</param>
-        /// <param name="timeout">The maximum time the server should wait for the QueryRequest to execute.</param>
-        public static IQueryable<T> Timeout<T>(this IQueryable<T> source, TimeSpan timeout)
-        {
-            EnsureBucketQueryable(source, "Timeout", "source");
-
-            ((IClusterQueryExecutorProvider)source).ClusterQueryExecutor.Timeout = timeout;
-
-            return source;
-        }
-
-        /// <summary>
-        /// Requires that the indexes but up to date with a <see cref="MutationState"/> before the query is executed.
-        /// </summary>
-        /// <param name="source">Sets consistency requirement for this query.  Must be a Couchbase LINQ query.</param>
-        /// <param name="state"><see cref="MutationState"/> used for conistency controls.</param>
-        /// <remarks>If called multiple times, the states from the calls are combined.</remarks>
-        public static IQueryable<T> ConsistentWith<T>(this IQueryable<T> source, MutationState state)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException("source");
-            }
-            if (!(source is IClusterQueryExecutorProvider))
-            {
-                // do nothing if this isn't a Couchbase LINQ query
-                return source;
-            }
-
-            ((IClusterQueryExecutorProvider) source).ClusterQueryExecutor.ConsistentWith(state);
-
-            return source;
-        }
-
-        #endregion
-
-        private static void EnsureBucketQueryable<T>(IQueryable<T> source, string methodName, string paramName)
-        {
-            if (source == null)
-            {
-                throw new ArgumentNullException(paramName);
-            }
-            if (!(source is ICollectionQueryable) || !(source is IClusterQueryExecutorProvider))
-            {
-                throw new ArgumentException(string.Format("{0} is only supported on Couchbase LINQ queries.", methodName), paramName);
-            }
-        }
-
-        /// <summary>
-        /// An expression generation helper for adding additional methods to a Linq provider.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <typeparam name="TR">The type of the return value.</typeparam>
-        /// <param name="source">The <see cref="IQueryable"/> source.</param>
-        /// <param name="expression">The expression.</param>
-        /// <remarks>Original work from: https://www.re-motion.org/blogs/mix/2010/10/28/re-linq-extensibility-custom-query-operators.</remarks>
-        /// <returns></returns>
-        private static IQueryable<T> CreateQuery<T, TR>(
-            this IQueryable<T> source, Expression<Func<IQueryable<T>, TR> > expression)
-        {
-            var queryExpression = ReplacingExpressionVisitor.Replace(
-                expression.Parameters[0],
-                source.Expression,
-                expression.Body);
-
-            return source.Provider.CreateQuery<T>(queryExpression);
+            throw new InvalidOperationException("The provided IQueryable is not backed by an IAsyncQueryProvider.");
         }
 
         private static Expression GetSourceExpression<TSource>(IEnumerable<TSource> source)
         {
-            IQueryable<TSource> q = source as IQueryable<TSource>;
-            if (q != null) return q.Expression;
+            if (source is IQueryable<TSource> q)
+            {
+                return q.Expression;
+            }
+
             return Expression.Constant(source, typeof(IEnumerable<TSource>));
         }
     }

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -29,29 +29,15 @@ namespace Couchbase.Linq
             //Create Custom node registry
             var nodeTypeRegistry = new MethodInfoBasedNodeTypeRegistry();
 
-            //register the "Nest" clause type
-            nodeTypeRegistry.Register(NestExpressionNode.SupportedMethods,
-                typeof(NestExpressionNode));
-
-            //register the "Explain" expression node parser
-            nodeTypeRegistry.Register(ExplainExpressionNode.SupportedMethods,
-                typeof(ExplainExpressionNode));
-
-            //register the "UseKeys" expression node parser
-            nodeTypeRegistry.Register(UseKeysExpressionNode.SupportedMethods,
-                typeof(UseKeysExpressionNode));
-
-            //register the "UseIndex" expression node parser
-            nodeTypeRegistry.Register(UseIndexExpressionNode.SupportedMethods,
-                typeof(UseIndexExpressionNode));
-
-            //register the "UseHash" expression node parser
-            nodeTypeRegistry.Register(UseHashExpressionNode.SupportedMethods,
-                typeof(UseHashExpressionNode));
-
-            //register the "ExtentName" expression node parser
-            nodeTypeRegistry.Register(ExtentNameExpressionNode.SupportedMethods,
-                typeof(ExtentNameExpressionNode));
+            //register the nodes for special Couchbase clauses
+            nodeTypeRegistry.Register(NestExpressionNode.SupportedMethods, typeof(NestExpressionNode));
+            nodeTypeRegistry.Register(ExplainExpressionNode.SupportedMethods, typeof(ExplainExpressionNode));
+            nodeTypeRegistry.Register(UseKeysExpressionNode.SupportedMethods, typeof(UseKeysExpressionNode));
+            nodeTypeRegistry.Register(UseIndexExpressionNode.SupportedMethods, typeof(UseIndexExpressionNode));
+            nodeTypeRegistry.Register(UseHashExpressionNode.SupportedMethods, typeof(UseHashExpressionNode));
+            nodeTypeRegistry.Register(ExtentNameExpressionNode.SupportedMethods, typeof(ExtentNameExpressionNode));
+            nodeTypeRegistry.Register(ScanConsistencyExpressionNode.GetSupportedMethods(), typeof(ScanConsistencyExpressionNode));
+            nodeTypeRegistry.Register(ConsistentWithExpressionNode.GetSupportedMethods(), typeof(ConsistentWithExpressionNode));
 
             //register the various asynchronous expression nodes
             nodeTypeRegistry.Register(FirstAsyncExpressionNode.GetSupportedMethods(), typeof(FirstAsyncExpressionNode));


### PR DESCRIPTION
Motivation
----------
Make the QueryExtensions cleaner, better organized, and a touch more
efficient.

Modifications
-------------
Separate QueryExtensions into partial class files.

Switch to static MethodInfo for special expression nodes rather than
reloading them via reflection on each method call.

Rework ConsistentWith and ScanConsistency to work via expression nodes
and clauses instead of directly setting IClusterQueryExecutor
properties.

Drop ScanWait and Timeout (for now), I think we're going to approach
them differently.

Results
-------
Cleaner and better organized code base, with less spaghetti.

Closes #302