### PR TITLE
Add AsAsyncEnumerable and ToListAsync

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -57,7 +57,7 @@ namespace Couchbase.Linq.IntegrationTests
             var beers = from b in context.Query<Beer>()
                 select b;
 
-            var results = await ((IAsyncEnumerable<Beer>) beers.Take(1)).ToListAsync();
+            var results = await beers.Take(1).ToListAsync();
             Assert.AreEqual(1, results.Count());
 
             foreach (var beer in results)

--- a/Src/Couchbase.Linq.UnitTests/Extensions/QueryExtensionTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Extensions/QueryExtensionTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.UnitTests.Documents;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.Extensions
+{
+    [TestFixture]
+    public class QueryExtensionTests
+    {
+        #region AsAsyncEnumerable
+
+        [Test]
+        public void AsAsyncEnumerable_Implements_Returns()
+        {
+            // Arrange
+
+            var mock = new Mock<IQueryable<Beer>>();
+            mock.As<IAsyncEnumerable<Beer>>();
+
+            // Act
+
+            var result = mock.Object.AsAsyncEnumerable();
+
+            // Assert
+
+            Assert.NotNull(result);
+        }
+
+        [Test]
+        public void AsAsyncEnumerable_DoesNotImplement_InvalidOperationException()
+        {
+            // Arrange
+
+            var mock = new Mock<IQueryable<Beer>>();
+
+            // Act/Assert
+
+            Assert.Throws<InvalidOperationException>(() => mock.Object.AsAsyncEnumerable());
+        }
+
+        #endregion
+
+        #region AsAsyncEnumerable
+
+        private async IAsyncEnumerable<Beer> TestEnumerable([EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.Yield();
+            yield return new Beer {Name = "A"};
+            yield return new Beer {Name = "B"};
+        }
+
+        [Test]
+        public async Task ToListAsync_Implements_Returns()
+        {
+            // Arrange
+
+            var mock = new Mock<IQueryable<Beer>>();
+            var asyncMock = mock.As<IAsyncEnumerable<Beer>>();
+            asyncMock
+                .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+                .Returns((CancellationToken ct) => TestEnumerable().GetAsyncEnumerator(ct));
+
+            // Act
+
+            var result = await mock.Object.ToListAsync();
+
+            // Assert
+
+            Assert.IsNotEmpty(result);
+        }
+
+        [Test]
+        public void ToListAsync_DoesNotImplement_InvalidOperationException()
+        {
+            // Arrange
+
+            var mock = new Mock<IQueryable<Beer>>();
+
+            // Act/Assert
+
+            Assert.Throws<InvalidOperationException>(() => mock.Object.ToListAsync());
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using Couchbase.Linq.Execution;
 
 namespace Couchbase.Linq.Extensions
@@ -13,6 +14,33 @@ namespace Couchbase.Linq.Extensions
     /// </summary>
     public static partial class QueryExtensions
     {
+        /// <summary>
+        /// Returns an <see cref="IAsyncEnumerable{T}"/> for an <see cref="IQueryable{T}"/> to allow async enumeration.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <returns>An <see cref="IAsyncEnumerable{T}"/> which can be enumerated asynchronously.</returns>
+        /// <remarks>
+        /// This method stops subsequent methods in the chain from being applied to any generated query.
+        /// For example, a subsequent call to Queryable.Where to apply a predicate would be applied in-memory
+        /// to the query results rather than adding the predicate to the generated query.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The implementation of <see cref="IQueryable{T}"/> does not also implement <see cref="IAsyncEnumerable{T}"/>.</exception>
+        public static IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IQueryable<T> source) =>
+            source as IAsyncEnumerable<T> ?? throw new InvalidOperationException("The implementation of IQueryable<T> does not also implement IAsyncEnumerable<T>.");
+
+        /// <summary>
+        /// Executes an <see cref="IQueryable{T}"/> asynchronously and returns a list of results.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/>.</param>
+        /// <returns>A list of results.</returns>
+        /// <exception cref="InvalidOperationException">The implementation of <see cref="IQueryable{T}"/> does not also implement <see cref="IAsyncEnumerable{T}"/>.</exception>
+        public static ValueTask<List<T>> ToListAsync<T>(this IQueryable<T> source,
+            CancellationToken cancellationToken = default) =>
+            source.AsAsyncEnumerable().ToListAsync(cancellationToken);
+
         private static TResult ExecuteAsync<TSource, TResult>(
             MethodInfo operatorMethodInfo,
             IQueryable<TSource> source,


### PR DESCRIPTION
Motivation
----------
Make it easier for consumers to work with IQueryable asynchronously.

Modifications
-------------
Implement IQueryable extension methods which work around casting the
IQueryable to an IAsyncEnumerable.

Results
-------
Easy usage!

Relates to #281