### PR TITLE
Add support for CountAsync and LongCountAsync

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/CountQueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/CountQueryTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.IntegrationTests.Documents;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.IntegrationTests
+{
+    [TestFixture]
+    public class CountQueryTests : N1QlTestBase
+    {
+        [Test]
+        public void Count_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            Console.WriteLine(beers.Count());
+        }
+
+        [Test]
+        public async Task CountAsync_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            Console.WriteLine(await beers.CountAsync());
+        }
+
+        [Test]
+        public async Task CountAsync_WithPredicate_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            var result = await beers.CountAsync(p => p.Name == "21A IPA");
+
+            Console.WriteLine(result);
+        }
+
+        [Test]
+        public void LongCount_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            Console.WriteLine(beers.LongCount());
+        }
+
+        [Test]
+        public async Task LongCountAsync_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            Console.WriteLine(await beers.LongCountAsync());
+        }
+
+        [Test]
+        public async Task LongCountAsync_WithPredicate_HasResult()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name};
+
+            var result = await beers.LongCountAsync(p => p.Name == "21A IPA");
+
+            Console.WriteLine(result);
+        }
+    }
+}

--- a/Src/Couchbase.Linq.UnitTests/ClusterQueryExecutorEmulator.cs
+++ b/Src/Couchbase.Linq.UnitTests/ClusterQueryExecutorEmulator.cs
@@ -78,5 +78,12 @@ namespace Couchbase.Linq.UnitTests
 
             return Task.FromResult(default(T));
         }
+
+        public Task<T> ExecuteScalarAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default)
+        {
+            ExecuteCollection<T>(queryModel);
+
+            return Task.FromResult(default(T));
+        }
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 using System.Threading.Tasks;
-using Couchbase.Core;
+using Couchbase.Linq.Extensions;
 using Couchbase.Linq.UnitTests.Documents;
 using Couchbase.Linq.Versioning;
 using Moq;
@@ -24,7 +21,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         public void Test_Avg()
         {
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default").Average(p => p.Abv);
+            _ = CreateQueryable<Beer>("default").Average(p => p.Abv);
             var n1QlQuery = QueryExecutor.Query;
 
             const string expected =
@@ -39,7 +36,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var queryExecutor = new ClusterQueryExecutorEmulator(this, FeatureVersions.SelectRaw);
 
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default", queryExecutor).Average(p => p.Abv);
+            _ = CreateQueryable<Beer>("default", queryExecutor).Average(p => p.Abv);
             var n1QlQuery = queryExecutor.Query;
 
             const string expected =
@@ -52,11 +49,37 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         public void Test_Count()
         {
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default").Count();
+            _ = CreateQueryable<Beer>("default").Count();
             var n1QlQuery = QueryExecutor.Query;
 
             const string expected =
                 "SELECT COUNT(*) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_CountAsync()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").CountAsync();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT COUNT(*) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_CountAsync_WithPredicate()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").CountAsync(p => p.Abv == 1);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT COUNT(*) as `result` FROM `default` as `Extent1` WHERE (`Extent1`.`abv` = 1)";
 
             Assert.AreEqual(expected, n1QlQuery);
         }
@@ -67,7 +90,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var queryExecutor = new ClusterQueryExecutorEmulator(this, FeatureVersions.SelectRaw);
 
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default", queryExecutor).Count();
+            _ = CreateQueryable<Beer>("default", queryExecutor).Count();
             var n1QlQuery = queryExecutor.Query;
 
             const string expected =
@@ -80,7 +103,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         public void Test_CountAfterSelectProjection()
         {
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default")
+            _ = CreateQueryable<Beer>("default")
                 .Select(p => new { p.Name, p.Description})
                 .Count();
             var n1QlQuery = QueryExecutor.Query;
@@ -97,7 +120,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var queryExecutor = new ClusterQueryExecutorEmulator(this, FeatureVersions.SelectRaw);
 
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default", queryExecutor)
+            _ = CreateQueryable<Beer>("default", queryExecutor)
                 .Select(p => new { p.Name, p.Description })
                 .Count();
             var n1QlQuery = queryExecutor.Query;
@@ -112,7 +135,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         public void Test_CountProperty()
         {
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default").Select(p => p.Name).Count();
+            _ = CreateQueryable<Beer>("default").Select(p => p.Name).Count();
             var n1QlQuery = QueryExecutor.Query;
 
             const string expected =
@@ -125,7 +148,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         public void Test_CountDistinct()
         {
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default").Select(p => p.Name).Distinct().Count();
+            _ = CreateQueryable<Beer>("default").Select(p => p.Name).Distinct().Count();
             var n1QlQuery = QueryExecutor.Query;
 
             const string expected =
@@ -138,7 +161,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         public void Test_LongCount()
         {
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default").LongCount();
+            _ = CreateQueryable<Beer>("default").LongCount();
             var n1QlQuery = QueryExecutor.Query;
 
             const string expected =
@@ -148,10 +171,36 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         }
 
         [Test]
+        public async Task Test_LongCountAsync()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").LongCountAsync();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT COUNT(*) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_LongCountAsync_WithPredicate()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").LongCountAsync(p => p.Abv == 1);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT COUNT(*) as `result` FROM `default` as `Extent1` WHERE (`Extent1`.`abv` = 1)";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
         public void Test_Min()
         {
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default").Min(p => p.Abv);
+            _ = CreateQueryable<Beer>("default").Min(p => p.Abv);
             var n1QlQuery = QueryExecutor.Query;
 
             const string expected =
@@ -164,7 +213,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         public void Test_Max()
         {
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default").Max(p => p.Abv);
+            _ = CreateQueryable<Beer>("default").Max(p => p.Abv);
             var n1QlQuery = QueryExecutor.Query;
 
             const string expected =
@@ -177,7 +226,7 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         public void Test_Sum()
         {
             // ReSharper disable once UnusedVariable
-            var temp = CreateQueryable<Beer>("default").Sum(p => p.Abv);
+            _ = CreateQueryable<Beer>("default").Sum(p => p.Abv);
             var n1QlQuery = QueryExecutor.Query;
 
             const string expected =

--- a/Src/Couchbase.Linq/Clauses/CountAsyncExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/CountAsyncExpressionNode.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Operators;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    /// <summary>
+    /// Expression node for CountAsync.
+    /// </summary>
+    internal class CountAsyncExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        /// <summary>
+        /// Methods which are supported by this type of node.
+        /// </summary>
+        public static IEnumerable<MethodInfo> GetSupportedMethods() => new[]
+        {
+            QueryExtensionMethods.CountAsyncNoPredicate,
+            QueryExtensionMethods.CountAsyncWithPredicate
+        };
+
+        /// <summary>
+        /// Creates a new CountAsyncExpressionNode.
+        /// </summary>
+        /// <param name="parseInfo">Method parse info.</param>
+        /// <param name="optionalPredicate">Optional predicate which filters the results.</param>
+        public CountAsyncExpressionNode(MethodCallExpressionParseInfo parseInfo, LambdaExpression optionalPredicate)
+            : base(parseInfo, optionalPredicate, null)
+        {
+        }
+
+        /// <inheritdoc />
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            throw new NotSupportedException($"Resolve is not supported by {typeof(CountAsyncExpressionNode)}");
+        }
+
+        /// <inheritdoc />
+        protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext) =>
+            new CountAsyncResultOperator();
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/LongCountAsyncExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/LongCountAsyncExpressionNode.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Operators;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    /// <summary>
+    /// Expression node for LongCountAsync.
+    /// </summary>
+    internal class LongCountAsyncExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        /// <summary>
+        /// Methods which are supported by this type of node.
+        /// </summary>
+        public static IEnumerable<MethodInfo> GetSupportedMethods() => new[]
+        {
+            QueryExtensionMethods.LongCountAsyncNoPredicate,
+            QueryExtensionMethods.LongCountAsyncWithPredicate
+        };
+
+        /// <summary>
+        /// Creates a new LongCountAsyncExpressionNode.
+        /// </summary>
+        /// <param name="parseInfo">Method parse info.</param>
+        /// <param name="optionalPredicate">Optional predicate which filters the results.</param>
+        public LongCountAsyncExpressionNode(MethodCallExpressionParseInfo parseInfo, LambdaExpression optionalPredicate)
+            : base(parseInfo, optionalPredicate, null)
+        {
+        }
+
+        /// <inheritdoc />
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            throw new NotSupportedException($"Resolve is not supported by {typeof(LongCountAsyncExpressionNode)}");
+        }
+
+        /// <inheritdoc />
+        protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext) =>
+            new LongCountAsyncResultOperator();
+    }
+}

--- a/Src/Couchbase.Linq/Execution/ClusterQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/ClusterQueryExecutor.cs
@@ -130,19 +130,16 @@ namespace Couchbase.Linq.Execution
             }
         }
 
-        public T ExecuteScalar<T>(QueryModel queryModel)
-        {
-            return ExecuteSingle<T>(queryModel, false);
-        }
+        public T ExecuteScalar<T>(QueryModel queryModel)=>
+            ExecuteSingle<T>(queryModel, false);
 
-        public T ExecuteSingle<T>(QueryModel queryModel, bool returnDefaultWhenEmpty)
-        {
-            var result = returnDefaultWhenEmpty
+        public T ExecuteSingle<T>(QueryModel queryModel, bool returnDefaultWhenEmpty) =>
+            returnDefaultWhenEmpty
                 ? ExecuteCollection<T>(queryModel).SingleOrDefault()
                 : ExecuteCollection<T>(queryModel).Single();
 
-            return result;
-        }
+        public Task<T> ExecuteScalarAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default) =>
+            ExecuteSingleAsync<T>(queryModel, false, cancellationToken);
 
         public Task<T> ExecuteSingleAsync<T>(QueryModel queryModel, bool returnDefaultWhenEmpty, CancellationToken cancellationToken = default)
         {

--- a/Src/Couchbase.Linq/Execution/IAsyncQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/IAsyncQueryExecutor.cs
@@ -13,5 +13,7 @@ namespace Couchbase.Linq.Execution
         IAsyncEnumerable<T> ExecuteCollectionAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default);
 
         Task<T> ExecuteSingleAsync<T>(QueryModel queryModel, bool returnDefaultWhenEmpty, CancellationToken cancellationToken = default);
+
+        Task<T> ExecuteScalarAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default);
     }
 }

--- a/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedScalarValueInfo.cs
+++ b/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedScalarValueInfo.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Remotion.Linq;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Execution.StreamedData
+{
+    /// <summary>
+    /// Version of <see cref="AsyncStreamedValueInfo"/> intended for scalar result objects, for example
+    /// from CountAsync.
+    /// </summary>
+    internal class AsyncStreamedScalarValueInfo : AsyncStreamedValueInfo
+    {
+        /// <summary>
+        /// Creates a new AsyncStreamedScalarValueInfo.
+        /// </summary>
+        /// <param name="dataType">Data type returned by the <see cref="IStreamedData"/>. Must be of type <see cref="Task{T}"/>.</param>
+        public AsyncStreamedScalarValueInfo(Type dataType)
+            : base(dataType)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override AsyncStreamedValueInfo CloneWithNewDataType(Type dataType) =>
+            new AsyncStreamedScalarValueInfo(dataType);
+
+        /// <inheritdoc />
+        public override Task<T> ExecuteQueryModelAsync<T>(QueryModel queryModel, IAsyncQueryExecutor executor,
+            CancellationToken cancellationToken = default)
+        {
+            if (queryModel == null)
+            {
+                throw new ArgumentNullException(nameof(queryModel));
+            }
+
+            if (executor == null)
+            {
+                throw new ArgumentNullException(nameof(executor));
+            }
+
+            return executor.ExecuteScalarAsync<T>(queryModel, cancellationToken);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
@@ -19,6 +19,11 @@ namespace Couchbase.Linq.Extensions
         public static MethodInfo SingleOrDefaultAsyncNoPredicate { get; }
         public static MethodInfo SingleOrDefaultAsyncWithPredicate { get; }
 
+        public static MethodInfo CountAsyncNoPredicate { get; }
+        public static MethodInfo CountAsyncWithPredicate { get; }
+        public static MethodInfo LongCountAsyncNoPredicate { get; }
+        public static MethodInfo LongCountAsyncWithPredicate { get; }
+
         public static MethodInfo Nest { get; }
         public static MethodInfo LeftOuterNest { get; }
         public static MethodInfo Explain { get; }
@@ -53,6 +58,15 @@ namespace Couchbase.Linq.Extensions
                 p.Name == nameof(QueryExtensions.SingleOrDefaultAsync) && p.GetParameters().Length == 1);
             SingleOrDefaultAsyncWithPredicate = allMethods.Single(p =>
                 p.Name == nameof(QueryExtensions.SingleOrDefaultAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
+
+            CountAsyncNoPredicate = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.CountAsync) && p.GetParameters().Length == 1);
+            CountAsyncWithPredicate = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.CountAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
+            LongCountAsyncNoPredicate = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.LongCountAsync) && p.GetParameters().Length == 1);
+            LongCountAsyncWithPredicate = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.LongCountAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
 
             Nest = allMethods.Single(p => p.Name == nameof(QueryExtensions.Nest));
             LeftOuterNest = allMethods.Single(p => p.Name == nameof(QueryExtensions.LeftOuterNest));

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.Count.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.Count.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.Extensions
+{
+    // CountAsync and LongCountAsync extensions
+
+    public static partial class QueryExtensions
+    {
+        /// <summary>
+        /// Asynchronously retrieves the number of items returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <returns>The number of items returned by the query.</returns>
+        public static Task<int> CountAsync<T>(this IQueryable<T> source) =>
+            source.CountAsync(default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously retrieves the number of items returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The number of items returned by the query.</returns>
+        public static Task<int> CountAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return ExecuteAsync<T, Task<int>>(QueryExtensionMethods.CountAsyncNoPredicate, source, null,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves the number of items returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="predicate">Predicate to filter query results.</param>
+        /// <returns>The number of items returned by the query.</returns>
+        public static Task<int> CountAsync<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate) =>
+            source.CountAsync(predicate, default);
+
+        /// <summary>
+        /// Asynchronously retrieves the number of items returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="predicate">Predicate to filter query results.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The number of items returned by the query.</returns>
+        public static Task<int> CountAsync<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            return ExecuteAsync<T, Task<int>>(QueryExtensionMethods.CountAsyncWithPredicate, source, predicate,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves the number of items returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <returns>The number of items returned by the query.</returns>
+        public static Task<long> LongCountAsync<T>(this IQueryable<T> source) =>
+            source.LongCountAsync(default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously retrieves the number of items returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The number of items returned by the query.</returns>
+        public static Task<long> LongCountAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return ExecuteAsync<T, Task<long>>(QueryExtensionMethods.LongCountAsyncNoPredicate, source, null,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves the number of items returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="predicate">Predicate to filter query results.</param>
+        /// <returns>The number of items returned by the query.</returns>
+        public static Task<long> LongCountAsync<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate) =>
+            source.LongCountAsync(predicate, default);
+
+        /// <summary>
+        /// Asynchronously retrieves the number of items returned by the query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="predicate">Predicate to filter query results.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The number of items returned by the query.</returns>
+        public static Task<long> LongCountAsync<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            return ExecuteAsync<T, Task<long>>(QueryExtensionMethods.LongCountAsyncWithPredicate, source, predicate,
+                cancellationToken);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Operators/CountAsyncResultOperator.cs
+++ b/Src/Couchbase.Linq/Operators/CountAsyncResultOperator.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Couchbase.Linq.Execution.StreamedData;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Operators
+{
+    /// <summary>
+    /// Result operator for CountAsync.
+    /// </summary>
+    internal class CountAsyncResultOperator : AsyncValueFromSequenceResultOperatorBase
+    {
+        /// <inheritdoc />
+        public override ResultOperatorBase Clone(CloneContext cloneContext) =>
+            new CountAsyncResultOperator();
+
+        /// <inheritdoc />
+        public override AsyncStreamedValue ExecuteInMemory<T>(StreamedSequence input)
+        {
+            var sequence = input.GetTypedSequence<T>();
+            var result = sequence.Count();
+            return new AsyncStreamedValue(Task.FromResult(result), GetOutputDataInfo(input.DataInfo));
+        }
+
+        /// <inheritdoc />
+        public override IStreamedDataInfo GetOutputDataInfo(IStreamedDataInfo inputInfo)
+        {
+            if (inputInfo == null)
+            {
+                throw new ArgumentNullException(nameof(inputInfo));
+            }
+            if (!(inputInfo is StreamedSequenceInfo streamedSequenceInfo))
+            {
+                throw new ArgumentException($"{nameof(inputInfo)} must be of type {typeof(StreamedSequenceInfo)}");
+            }
+
+            return GetOutputDataInfo(streamedSequenceInfo);
+        }
+
+        protected AsyncStreamedValueInfo GetOutputDataInfo(StreamedSequenceInfo streamedSequenceInfo)
+        {
+            if (streamedSequenceInfo == null)
+            {
+                throw new ArgumentNullException(nameof(streamedSequenceInfo));
+            }
+
+            return new AsyncStreamedScalarValueInfo(typeof(Task<int>));
+        }
+
+        /// <inheritdoc />
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Operators/LongCountAsyncResultOperator.cs
+++ b/Src/Couchbase.Linq/Operators/LongCountAsyncResultOperator.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Couchbase.Linq.Execution.StreamedData;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Operators
+{
+    /// <summary>
+    /// Result operator for LongCountAsync.
+    /// </summary>
+    internal class LongCountAsyncResultOperator : AsyncValueFromSequenceResultOperatorBase
+    {
+        /// <inheritdoc />
+        public override ResultOperatorBase Clone(CloneContext cloneContext) =>
+            new LongCountAsyncResultOperator();
+
+        /// <inheritdoc />
+        public override AsyncStreamedValue ExecuteInMemory<T>(StreamedSequence input)
+        {
+            var sequence = input.GetTypedSequence<T>();
+            var result = sequence.LongCount();
+            return new AsyncStreamedValue(Task.FromResult(result), GetOutputDataInfo(input.DataInfo));
+        }
+
+        /// <inheritdoc />
+        public override IStreamedDataInfo GetOutputDataInfo(IStreamedDataInfo inputInfo)
+        {
+            if (inputInfo == null)
+            {
+                throw new ArgumentNullException(nameof(inputInfo));
+            }
+            if (!(inputInfo is StreamedSequenceInfo streamedSequenceInfo))
+            {
+                throw new ArgumentException($"{nameof(inputInfo)} must be of type {typeof(StreamedSequenceInfo)}");
+            }
+
+            return GetOutputDataInfo(streamedSequenceInfo);
+        }
+
+        protected AsyncStreamedValueInfo GetOutputDataInfo(StreamedSequenceInfo streamedSequenceInfo)
+        {
+            if (streamedSequenceInfo == null)
+            {
+                throw new ArgumentNullException(nameof(streamedSequenceInfo));
+            }
+
+            return new AsyncStreamedScalarValueInfo(typeof(Task<long>));
+        }
+
+        /// <inheritdoc />
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -675,7 +675,8 @@ namespace Couchbase.Linq.QueryGeneration
                 _queryPartsAggregator.AggregateFunction = "AVG";
                 _isAggregated = true;
             }
-            else if ((resultOperator is CountResultOperator) || (resultOperator is LongCountResultOperator))
+            else if ((resultOperator is CountResultOperator) || (resultOperator is LongCountResultOperator) ||
+                     (resultOperator is CountAsyncResultOperator) || (resultOperator is LongCountAsyncResultOperator))
             {
                 if (_queryPartsAggregator.IsArraySubquery)
                 {

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -42,6 +42,8 @@ namespace Couchbase.Linq
             //register the various asynchronous expression nodes
             nodeTypeRegistry.Register(FirstAsyncExpressionNode.GetSupportedMethods(), typeof(FirstAsyncExpressionNode));
             nodeTypeRegistry.Register(SingleAsyncExpressionNode.GetSupportedMethods(), typeof(SingleAsyncExpressionNode));
+            nodeTypeRegistry.Register(CountAsyncExpressionNode.GetSupportedMethods(), typeof(CountAsyncExpressionNode));
+            nodeTypeRegistry.Register(LongCountAsyncExpressionNode.GetSupportedMethods(), typeof(LongCountAsyncExpressionNode));
 
             //This creates all the default node types
             var nodeTypeProvider = ExpressionTreeParser.CreateDefaultNodeTypeProvider();


### PR DESCRIPTION
Motivation
----------
Support asynchronous queries which return counts.

Modifications
-------------
Create extension methods, an expression node, a result operator, and
streamed data classes to handle CountAsync and LongCountAsync.

Update N1QLQueryModelVisitor to recognize the new result operator.

Add tests for the async methods.

Results
-------
CountAsync or LongCountAsync may be called on IQueryable and they
function correctly so long as the IQueryable is from a
CollectionContext.

Relates to #281