### PR TITLE
Add support for SumAsync

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/SumTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/SumTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.IntegrationTests.Documents;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.IntegrationTests
+{
+    [TestFixture]
+    public class SumTests : N1QlTestBase
+    {
+        [Test]
+        public void Sum_NoSelector()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select beer.Ibu;
+
+            Console.WriteLine(beers.Sum());
+        }
+
+        [Test]
+        public async Task SumAsync_NoSelector()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select beer.Ibu;
+
+            Console.WriteLine(await beers.SumAsync());
+        }
+
+        [Test]
+        public async Task SumAsync_WithSelector()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select beer;
+
+            Console.WriteLine(await beers.SumAsync(p => p.Ibu));
+        }
+    }
+}

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
@@ -235,6 +235,32 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             Assert.AreEqual(expected, n1QlQuery);
         }
 
+        [Test]
+        public async Task Test_SumAsync_NoSelector()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").Select(p => p.Abv).SumAsync();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT SUM(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_SumAsync_WithSelector()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").SumAsync(p => p.Abv);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT SUM(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
         #endregion
 
         #region "Group By"

--- a/Src/Couchbase.Linq/Clauses/SumAsyncExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/SumAsyncExpressionNode.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Operators;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    /// <summary>
+    /// Expression node for SumAsync.
+    /// </summary>
+    internal class SumAsyncExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        /// <summary>
+        /// Methods which are supported by this type of node.
+        /// </summary>
+        public static IEnumerable<MethodInfo> GetSupportedMethods() => new[]
+        {
+            QueryExtensionMethods.SumAsyncNoSelector,
+            QueryExtensionMethods.SumAsyncWithSelector
+        };
+
+        /// <summary>
+        /// Creates a new SumAsyncExpressionNode.
+        /// </summary>
+        /// <param name="parseInfo">Method parse info.</param>
+        /// <param name="optionalSelector">Optional selector for value to be summed.</param>
+        public SumAsyncExpressionNode(MethodCallExpressionParseInfo parseInfo, LambdaExpression optionalSelector)
+            : base(parseInfo, null, optionalSelector)
+        {
+        }
+
+        /// <inheritdoc />
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            throw new NotSupportedException($"Resolve is not supported by {typeof(SumAsyncExpressionNode)}");
+        }
+
+        /// <inheritdoc />
+        protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext) =>
+            new SumAsyncResultOperator();
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
@@ -28,6 +28,9 @@ namespace Couchbase.Linq.Extensions
         public static MethodInfo LongCountAsyncNoPredicate { get; }
         public static MethodInfo LongCountAsyncWithPredicate { get; }
 
+        public static MethodInfo SumAsyncNoSelector { get; }
+        public static MethodInfo SumAsyncWithSelector { get; }
+
         public static MethodInfo Nest { get; }
         public static MethodInfo LeftOuterNest { get; }
         public static MethodInfo Explain { get; }
@@ -78,6 +81,11 @@ namespace Couchbase.Linq.Extensions
                 p.Name == nameof(QueryExtensions.LongCountAsync) && p.GetParameters().Length == 1);
             LongCountAsyncWithPredicate = allMethods.Single(p =>
                 p.Name == nameof(QueryExtensions.LongCountAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
+
+            SumAsyncNoSelector = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.SumAsync) && p.GetParameters().Length == 1);
+            SumAsyncWithSelector = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.SumAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
 
             Nest = allMethods.Single(p => p.Name == nameof(QueryExtensions.Nest));
             LeftOuterNest = allMethods.Single(p => p.Name == nameof(QueryExtensions.LeftOuterNest));

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.Sum.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.Sum.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.Extensions
+{
+    // SumAsync extensions
+
+    public static partial class QueryExtensions
+    {
+        /// <summary>
+        /// Asynchronously sums the items returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <returns>The sum of the items returned by the query.</returns>
+        public static Task<T> SumAsync<T>(this IQueryable<T> source) =>
+            source.SumAsync(default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously sums the items returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The sum of the items returned by the query.</returns>
+        public static Task<T> SumAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return ExecuteAsync<T, Task<T>>(QueryExtensionMethods.SumAsyncNoSelector, source, null,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously sums the items returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <typeparam name="TResult">Type returned by the sum operation.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="selector">Selector for value to be summed.</param>
+        /// <returns>The sum of the items returned by the query.</returns>
+        public static Task<TResult> SumAsync<T, TResult>(this IQueryable<T> source, Expression<Func<T, TResult>> selector) =>
+            source.SumAsync(selector, default);
+
+        /// <summary>
+        /// Asynchronously sums the items returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <typeparam name="TResult">Type returned by the sum operation.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="selector">Selector for value to be summed.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The sum of the items returned by the query.</returns>
+        public static Task<TResult> SumAsync<T, TResult>(this IQueryable<T> source, Expression<Func<T, TResult>> selector, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            return ExecuteAsync<T, Task<TResult>>(QueryExtensionMethods.SumAsyncWithSelector, source, selector,
+                cancellationToken);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Operators/SumAsyncResultOperator.cs
+++ b/Src/Couchbase.Linq/Operators/SumAsyncResultOperator.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Couchbase.Linq.Execution.StreamedData;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Operators
+{
+    /// <summary>
+    /// Result operator for SumAsync.
+    /// </summary>
+    internal class SumAsyncResultOperator : AsyncValueFromSequenceResultOperatorBase
+    {
+        /// <inheritdoc />
+        public override ResultOperatorBase Clone(CloneContext cloneContext) =>
+            new SumAsyncResultOperator();
+
+        /// <inheritdoc />
+        public override AsyncStreamedValue ExecuteInMemory<T>(StreamedSequence input)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            var typedSumMethod = typeof(Enumerable).GetMethod("Sum", new[] {typeof(IEnumerable<T>)});
+            if (typedSumMethod == null)
+            {
+                throw new NotSupportedException($"No in-memory sum method found for type {typeof(T).FullName}.");
+            }
+
+            var sequence = input.GetTypedSequence<T>();
+            var result = typedSumMethod.Invoke(null, new object[] {sequence});
+            return new AsyncStreamedValue(Task.FromResult(result), GetOutputDataInfo(input.DataInfo));
+        }
+
+        /// <inheritdoc />
+        public override IStreamedDataInfo GetOutputDataInfo(IStreamedDataInfo inputInfo)
+        {
+            if (inputInfo == null)
+            {
+                throw new ArgumentNullException(nameof(inputInfo));
+            }
+            if (!(inputInfo is StreamedSequenceInfo streamedSequenceInfo))
+            {
+                throw new ArgumentException($"{nameof(inputInfo)} must be of type {typeof(StreamedSequenceInfo)}");
+            }
+
+            return GetOutputDataInfo(streamedSequenceInfo);
+        }
+
+        protected AsyncStreamedValueInfo GetOutputDataInfo(StreamedSequenceInfo streamedSequenceInfo)
+        {
+            if (streamedSequenceInfo == null)
+            {
+                throw new ArgumentNullException(nameof(streamedSequenceInfo));
+            }
+
+            var resultType = typeof(Task<>).MakeGenericType(streamedSequenceInfo.ResultItemType);
+
+            return new AsyncStreamedScalarValueInfo(resultType);
+        }
+
+        /// <inheritdoc />
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -704,7 +704,7 @@ namespace Couchbase.Linq.QueryGeneration
                 _queryPartsAggregator.AggregateFunction = "MIN";
                 _isAggregated = true;
             }
-            else if (resultOperator is SumResultOperator)
+            else if (resultOperator is SumResultOperator || resultOperator is SumAsyncResultOperator)
             {
                 _queryPartsAggregator.AggregateFunction = "SUM";
                 _isAggregated = true;

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -46,6 +46,7 @@ namespace Couchbase.Linq
             nodeTypeRegistry.Register(AllAsyncExpressionNode.GetSupportedMethods(), typeof(AllAsyncExpressionNode));
             nodeTypeRegistry.Register(CountAsyncExpressionNode.GetSupportedMethods(), typeof(CountAsyncExpressionNode));
             nodeTypeRegistry.Register(LongCountAsyncExpressionNode.GetSupportedMethods(), typeof(LongCountAsyncExpressionNode));
+            nodeTypeRegistry.Register(SumAsyncExpressionNode.GetSupportedMethods(), typeof(SumAsyncExpressionNode));
 
             //This creates all the default node types
             var nodeTypeProvider = ExpressionTreeParser.CreateDefaultNodeTypeProvider();


### PR DESCRIPTION
Motivation
----------
Support asynchronous queries which return sums.

Modifications
-------------
Create extension methods, an expression node, and a result operator to
handle SumAsync.

Update N1QLQueryModelVisitor to recognize the new result operator.

Add tests for the async methods.

Results
-------
SumAsync may be called on IQueryable and will function correctly so long
as the IQueryable is from a CollectionContext.

Relates to #281