### PR TITLE
Add support for AverageAsync

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/AverageTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/AverageTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.IntegrationTests.Documents;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.IntegrationTests
+{
+    [TestFixture]
+    public class AverageTests : N1QlTestBase
+    {
+        [Test]
+        public void Average_WithSelector()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var avg = context.Query<Beer>()
+                .Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv))
+                .Average(p => p.Abv);
+
+            Assert.Greater(avg, 0);
+            Console.WriteLine("Average ABV of all beers is {0}", avg);
+        }
+
+        [Test]
+        public async Task AverageAsync_NoSelector()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var avg = await context.Query<Beer>()
+                .Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv))
+                .Select(p => p.Abv)
+                .AverageAsync();
+
+            Assert.Greater(avg, 0);
+            Console.WriteLine("Average ABV of all beers is {0}", avg);
+        }
+
+        [Test]
+        public async Task AverageAsync_WithSelector()
+        {
+            var context = new CollectionContext(TestSetup.Collection);
+
+            var avg = await context.Query<Beer>()
+                .Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv))
+                .AverageAsync(p => p.Abv);
+
+            Assert.Greater(avg, 0);
+            Console.WriteLine("Average ABV of all beers is {0}", avg);
+        }
+    }
+}

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -1182,17 +1182,6 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
-        public void AggregateTests_SimpleAverage()
-        {
-            var context = new CollectionContext(TestSetup.Collection);
-
-            var avg =
-                context.Query<Beer>().Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv)).Average(p => p.Abv);
-            Assert.Greater(avg, 0);
-            Console.WriteLine("Average ABV of all beers is {0}", avg);
-        }
-
-        [Test]
         public void AggregateTests_SimpleCount()
         {
             var context = new CollectionContext(TestSetup.Collection);

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
@@ -46,6 +46,47 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         }
 
         [Test]
+        public async Task Test_AvgAsync()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").AverageAsync(p => p.Abv);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT AVG(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_AvgAsync_NoSelector()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").Select(p => p.Abv).AverageAsync();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT AVG(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_AvgAsync_Raw()
+        {
+            var queryExecutor = new ClusterQueryExecutorEmulator(this, FeatureVersions.SelectRaw);
+
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default", queryExecutor).AverageAsync(p => p.Abv);
+            var n1QlQuery = queryExecutor.Query;
+
+            const string expected =
+                "SELECT RAW AVG(`Extent1`.`abv`) FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
         public void Test_Count()
         {
             // ReSharper disable once UnusedVariable

--- a/Src/Couchbase.Linq/Clauses/AverageAsyncExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/AverageAsyncExpressionNode.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Operators;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    /// <summary>
+    /// Expression node for AverageAsync.
+    /// </summary>
+    internal class AverageAsyncExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        /// <summary>
+        /// Methods which are supported by this type of node.
+        /// </summary>
+        public static IEnumerable<MethodInfo> GetSupportedMethods() => new[]
+        {
+            QueryExtensionMethods.AverageAsyncNoSelector,
+            QueryExtensionMethods.AverageAsyncWithSelector
+        };
+
+        /// <summary>
+        /// Creates a new AverageAsyncExpressionNode.
+        /// </summary>
+        /// <param name="parseInfo">Method parse info.</param>
+        /// <param name="optionalSelector">Optional selector for value to be summed.</param>
+        public AverageAsyncExpressionNode(MethodCallExpressionParseInfo parseInfo, LambdaExpression optionalSelector)
+            : base(parseInfo, null, optionalSelector)
+        {
+        }
+
+        /// <inheritdoc />
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            throw new NotSupportedException($"Resolve is not supported by {typeof(AverageAsyncExpressionNode)}");
+        }
+
+        /// <inheritdoc />
+        protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext) =>
+            new AverageAsyncResultOperator();
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
@@ -30,6 +30,8 @@ namespace Couchbase.Linq.Extensions
 
         public static MethodInfo SumAsyncNoSelector { get; }
         public static MethodInfo SumAsyncWithSelector { get; }
+        public static MethodInfo AverageAsyncNoSelector { get; }
+        public static MethodInfo AverageAsyncWithSelector { get; }
 
         public static MethodInfo Nest { get; }
         public static MethodInfo LeftOuterNest { get; }
@@ -86,6 +88,10 @@ namespace Couchbase.Linq.Extensions
                 p.Name == nameof(QueryExtensions.SumAsync) && p.GetParameters().Length == 1);
             SumAsyncWithSelector = allMethods.Single(p =>
                 p.Name == nameof(QueryExtensions.SumAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
+            AverageAsyncNoSelector = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.AverageAsync) && p.GetParameters().Length == 1);
+            AverageAsyncWithSelector = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.AverageAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
 
             Nest = allMethods.Single(p => p.Name == nameof(QueryExtensions.Nest));
             LeftOuterNest = allMethods.Single(p => p.Name == nameof(QueryExtensions.LeftOuterNest));

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.Average.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.Average.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.Extensions
+{
+    // AverageAsync extensions
+
+    public static partial class QueryExtensions
+    {
+        /// <summary>
+        /// Asynchronously averages the items returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <returns>The average of the items returned by the query.</returns>
+        public static Task<T> AverageAsync<T>(this IQueryable<T> source) =>
+            source.AverageAsync(default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously averages the items returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The average of the items returned by the query.</returns>
+        public static Task<T> AverageAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return ExecuteAsync<T, Task<T>>(QueryExtensionMethods.AverageAsyncNoSelector, source, null,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously averages the items returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <typeparam name="TResult">Type returned by the sum operation.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="selector">Selector for value to be summed.</param>
+        /// <returns>The average of the items returned by the query.</returns>
+        public static Task<TResult> AverageAsync<T, TResult>(this IQueryable<T> source, Expression<Func<T, TResult>> selector) =>
+            source.AverageAsync(selector, default);
+
+        /// <summary>
+        /// Asynchronously averages the items returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <typeparam name="TResult">Type returned by the sum operation.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="selector">Selector for value to be summed.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The average of the items returned by the query.</returns>
+        public static Task<TResult> AverageAsync<T, TResult>(this IQueryable<T> source, Expression<Func<T, TResult>> selector, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            return ExecuteAsync<T, Task<TResult>>(QueryExtensionMethods.AverageAsyncWithSelector, source, selector,
+                cancellationToken);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Operators/AverageAsyncResultOperator.cs
+++ b/Src/Couchbase.Linq/Operators/AverageAsyncResultOperator.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Couchbase.Linq.Execution.StreamedData;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Operators
+{
+    /// <summary>
+    /// Result operator for AverageAsync.
+    /// </summary>
+    internal class AverageAsyncResultOperator : AsyncValueFromSequenceResultOperatorBase
+    {
+        /// <inheritdoc />
+        public override ResultOperatorBase Clone(CloneContext cloneContext) =>
+            new AverageAsyncResultOperator();
+
+        /// <inheritdoc />
+        public override AsyncStreamedValue ExecuteInMemory<T>(StreamedSequence input)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            var typedAverageMethod = typeof(Enumerable).GetMethod(nameof(Enumerable.Average), new[] {typeof(IEnumerable<T>)});
+            if (typedAverageMethod == null)
+            {
+                throw new NotSupportedException($"No in-memory sum method found for type {typeof(T).FullName}.");
+            }
+
+            var sequence = input.GetTypedSequence<T>();
+            var result = typedAverageMethod.Invoke(null, new object[] {sequence});
+            return new AsyncStreamedValue(Task.FromResult(result), GetOutputDataInfo(input.DataInfo));
+        }
+
+        /// <inheritdoc />
+        public override IStreamedDataInfo GetOutputDataInfo(IStreamedDataInfo inputInfo)
+        {
+            if (inputInfo == null)
+            {
+                throw new ArgumentNullException(nameof(inputInfo));
+            }
+            if (!(inputInfo is StreamedSequenceInfo streamedSequenceInfo))
+            {
+                throw new ArgumentException($"{nameof(inputInfo)} must be of type {typeof(StreamedSequenceInfo)}");
+            }
+
+            return GetOutputDataInfo(streamedSequenceInfo);
+        }
+
+        protected AsyncStreamedValueInfo GetOutputDataInfo(StreamedSequenceInfo streamedSequenceInfo)
+        {
+            if (streamedSequenceInfo == null)
+            {
+                throw new ArgumentNullException(nameof(streamedSequenceInfo));
+            }
+
+            var resultType = typeof(Task<>).MakeGenericType(streamedSequenceInfo.ResultItemType);
+
+            return new AsyncStreamedScalarValueInfo(resultType);
+        }
+
+        /// <inheritdoc />
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -675,7 +675,7 @@ namespace Couchbase.Linq.QueryGeneration
             {
                 VisitGroupResultOperator((GroupResultOperator)resultOperator, queryModel);
             }
-            else if (resultOperator is AverageResultOperator)
+            else if (resultOperator is AverageResultOperator || resultOperator is AverageAsyncResultOperator)
             {
                 _queryPartsAggregator.AggregateFunction = "AVG";
                 _isAggregated = true;

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -47,6 +47,7 @@ namespace Couchbase.Linq
             nodeTypeRegistry.Register(CountAsyncExpressionNode.GetSupportedMethods(), typeof(CountAsyncExpressionNode));
             nodeTypeRegistry.Register(LongCountAsyncExpressionNode.GetSupportedMethods(), typeof(LongCountAsyncExpressionNode));
             nodeTypeRegistry.Register(SumAsyncExpressionNode.GetSupportedMethods(), typeof(SumAsyncExpressionNode));
+            nodeTypeRegistry.Register(AverageAsyncExpressionNode.GetSupportedMethods(), typeof(AverageAsyncExpressionNode));
 
             //This creates all the default node types
             var nodeTypeProvider = ExpressionTreeParser.CreateDefaultNodeTypeProvider();


### PR DESCRIPTION
Motivation
----------
Support asynchronous queries which return averages.

Modifications
-------------
Create extension methods, an expression node, and a result operator to
handle AverageAsync.

Update N1QLQueryModelVisitor to recognize the new result operator.

Add tests for the async methods.

Results
-------
AverageAsync may be called on IQueryable and will function correctly so
long as the IQueryable is from a CollectionContext.

Relates to #281