### PR TITLE
Switch to Couchbase SDK 3.0.2

### DIFF
--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -21,24 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CouchbaseNetClient" Version="3.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
-  </ItemGroup>
-
-  <!-- Hack to import Couchbase SDK 3 until next package is published -->
-  <ItemGroup>
-    <Reference Include="Couchbase.NetClient">
-      <HintPath>..\..\..\couchbase-net-client\src\Couchbase\bin\Debug\$(TargetFramework)\Couchbase.NetClient.dll</HintPath>
-    </Reference>
-    <PackageReference Include="DnsClient" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Memory" Version="4.5.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Motivation
----------
We had hacked in local paths to the Couchbase SDK to use unreleased
features, but those features are now released.

Modifications
-------------
Switch to using the SDK 3.0.2 NuGet packages.

Results
-------
We're closer to a releasable package.

Closes #306