### PR TITLE
Switch back to BucketContext

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/AnyAllTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/AnyAllTests.cs
@@ -15,7 +15,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AnyNestedArrayWithFilter()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var breweries = (from b in context.Query<Brewery>()
                 where b.Type == "brewery" && b.Address.Any(p => p == "563 Second Street")
@@ -30,7 +30,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task AnyNestedArrayWithFilter_UsesArrayIndex()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -60,7 +60,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AnyOnMainDocument_ReturnsTrue()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var hasBreweries = (from b in context.Query<Brewery>()
                 where b.Type == "brewery"
@@ -73,7 +73,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AnyOnMainDocument_ReturnsFalse()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var hasFaketype = (from b in context.Query<Brewery>()
                 where b.Type == "faketype"
@@ -87,7 +87,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task AnyAsyncOnMainDocument_ReturnsTrue()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var hasBreweries = await (from b in context.Query<Brewery>()
                     where b.Type == "brewery"
@@ -100,7 +100,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task AnyAsyncOnMainDocument_ReturnsFalse()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var hasFaketype = await (from b in context.Query<Brewery>()
                     where b.Type == "faketype"
@@ -113,7 +113,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AllNestedArray()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var breweries = (from b in context.Query<Brewery>()
                 where b.Type == "brewery" && b.Address.All(p => p == "563 Second Street")
@@ -128,7 +128,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AllNestedArrayPrefiltered()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             // Note: This query isn't very useful in the real world
             // However, it does demonstrate how to prefilter the collection before all is run
@@ -151,7 +151,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AllOnMainDocument_ReturnsFalse()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var isAllBreweries = context.Query<Brewery>().All(p => p.Type == "brewery");
 
@@ -161,7 +161,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AllOnMainDocument_ReturnsTrue()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var allBreweriesHaveAddress = (from b in context.Query<Brewery>()
                 where b.Type == "brewery"
@@ -174,7 +174,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task AllAsyncOnMainDocument_ReturnsFalse()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var isAllBreweries = await context.Query<Brewery>().AllAsync(p => p.Type == "brewery");
 
@@ -184,7 +184,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task AllAsyncOnMainDocument_ReturnsTrue()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var allBreweriesHaveAddress = await (from b in context.Query<Brewery>()
                     where b.Type == "brewery"

--- a/Src/Couchbase.Linq.IntegrationTests/BeerSample.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/BeerSample.cs
@@ -9,14 +9,14 @@ namespace Couchbase.Linq.IntegrationTests
     /// <summary>
     /// A concrete DbContext for the beer-sample example bucket.
     /// </summary>
-    public class BeerSample : CollectionContext
+    public class BeerSample : BucketContext
     {
         public BeerSample()
-            : this(TestSetup.Collection)
+            : this(TestSetup.Bucket)
         {
         }
 
-        public BeerSample(ICouchbaseCollection collection) : base(collection)
+        public BeerSample(IBucket bucket) : base(bucket)
         {
             //Two ways of applying a filter are included in this example.
             //This is by implementing IDocumentFilter and then adding explicitly.

--- a/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/BucketContextTests.cs
@@ -15,7 +15,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Test_Basic_Query()
         {
-            var db = new CollectionContext(TestSetup.Collection);
+            var db = new BucketContext(TestSetup.Bucket);
             var query = from x in db.Query<Beer>()
                 where x.Type == "beer"
                 select x;

--- a/Src/Couchbase.Linq.IntegrationTests/ConsistencyTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/ConsistencyTests.cs
@@ -16,7 +16,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task ScanConsistency()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from b in context.Query<Beer>().ScanConsistency(QueryScanConsistency.RequestPlus)
                 select b;
@@ -28,9 +28,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task ConsistentWith()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
-            var upsertResult = await TestSetup.Collection.UpsertAsync("test-mutation", new {a = "a"});
+            var upsertResult = await TestSetup.Bucket.DefaultCollection().UpsertAsync("test-mutation", new {a = "a"});
             try
             {
                 var mutationState = MutationState.From(upsertResult);
@@ -43,7 +43,7 @@ namespace Couchbase.Linq.IntegrationTests
             }
             finally
             {
-                await TestSetup.Collection.RemoveAsync("test-mutation");
+                await TestSetup.Bucket.DefaultCollection().RemoveAsync("test-mutation");
             }
         }
     }

--- a/Src/Couchbase.Linq.IntegrationTests/CountQueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/CountQueryTests.cs
@@ -13,7 +13,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Count_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -25,7 +25,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task CountAsync_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -37,7 +37,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task CountAsync_WithPredicate_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -51,7 +51,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void LongCount_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -63,7 +63,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task LongCountAsync_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -75,7 +75,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task LongCountAsync_WithPredicate_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"

--- a/Src/Couchbase.Linq.IntegrationTests/FirstQueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/FirstQueryTests.cs
@@ -13,7 +13,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void First_Empty()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "abcdefg"
@@ -29,7 +29,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void FirstAsync_Empty()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "abcdefg"
@@ -41,7 +41,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void First_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -53,7 +53,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task FirstAsync_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -65,7 +65,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task FirstAsync_WithPredicate_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -79,7 +79,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void FirstOrDefault_Empty()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "abcdefg"
@@ -92,7 +92,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task FirstOrDefaultAsync_Empty()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "abcdefg"
@@ -105,7 +105,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void FirstOrDefault_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -119,7 +119,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task FirstOrDefaultAsync_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -133,7 +133,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task FirstOrDefaultAsync_WithPredicate_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -16,14 +16,14 @@ namespace Couchbase.Linq.IntegrationTests
     [TestFixture]
     public class QueryTests : N1QlTestBase
     {
-        private ICouchbaseCollection _travelSample;
+        private IBucket _travelSample;
 
         [OneTimeSetUp]
         public async Task OneTimeSetup()
         {
             await PrepareBeerDocuments();
 
-            _travelSample = (await TestSetup.Cluster.BucketAsync("travel-sample")).DefaultCollection();
+            _travelSample = await TestSetup.Cluster.BucketAsync("travel-sample");
         }
 
         [SetUp]
@@ -35,7 +35,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from b in context.Query<Beer>()
                 select b;
@@ -52,7 +52,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task Map2PocoTestsAsync()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from b in context.Query<Beer>()
                 select b;
@@ -69,7 +69,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Simple_Projections()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from b in context.Query<Beer>()
                 select new {name = b.Name, abv = b.Abv};
@@ -86,7 +86,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_StronglyTyped_Projections()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from b in context.Query<Beer>()
                 select new Beer {Name = b.Name, Abv = b.Abv};
@@ -103,7 +103,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Simple_Projections_Where()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from b in context.Query<Beer>()
                 where b.Type == "beer"
@@ -121,7 +121,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Simple_Projections_WhereNot()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from b in context.Query<Beer>()
                 where b.Type == "beer" && !(b.Abv < 4)
@@ -139,7 +139,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Simple_Projections_WhereDateTime()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from b in context.Query<Beer>()
                 where (b.Type == "beer") && (b.Updated >= new DateTime(2010, 1, 1))
@@ -157,7 +157,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Simple_Projections_WhereEnum()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = (from b in context.Query<BeerWithEnum>()
                 where (b.Type == "beer") && (b.Style == BeerStyle.OatmealStout)
@@ -177,7 +177,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Simple_Projections_StartsWith()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from b in context.Query<Beer>()
                         where b.Type == "beer" && b.Name.StartsWith("563")
@@ -195,7 +195,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Simple_Projections_EndsWithExpression()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             // This query is not useful, but tests more advanced string contains use cases
             var beers = from b in context.Query<Beer>()
@@ -214,7 +214,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Simple_Projections_Limit()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = (from b in context.Query<Beer>()
                 where b.Type == "beer"
@@ -234,7 +234,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Simple_Projections_Meta()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var beers = (from b in context.Query<Beer>()
@@ -254,7 +254,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Simple_Projections_Key()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var beers = (from b in context.Query<Beer>()
@@ -275,7 +275,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Explain()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var explanation = (from b in context.Query<Beer>()
@@ -289,7 +289,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Explain_QueryWithPropertyExtraction()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var explanation = (from b in context.Query<Beer>()
@@ -303,7 +303,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_NewObjectsInArray()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var query = from brewery in context.Query<Brewery>()
@@ -330,7 +330,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void NoProjection_Meta()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var beers = (from b in context.Query<Beer>()
@@ -350,7 +350,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void NoProjection_Number()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var beers = (from b in context.Query<Beer>()
@@ -370,7 +370,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void UseKeys_SelectDocuments()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var query =
@@ -394,9 +394,9 @@ namespace Couchbase.Linq.IntegrationTests
             // in the actual USE INDEX clause itself in this query, since the index isn't used in the predicate.
             // In a real world query, this should be a specific index helpful to the query.
 
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
-            await EnsureIndexExists(context.Collection.Scope.Bucket, "brewery_id", "brewery_id");
+            await EnsureIndexExists(context.Bucket, "brewery_id", "brewery_id");
 
 
 
@@ -421,7 +421,7 @@ namespace Couchbase.Linq.IntegrationTests
             // in the actual USE INDEX clause itself in this query, since the index isn't used in the predicate.
             // In a real world query, this should be a specific index helpful to the query.
 
-            var context = new CollectionContext(_travelSample);
+            var context = new BucketContext(_travelSample);
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -451,7 +451,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task UseHash_SelectDocuments()
         {
-            var context = new CollectionContext(_travelSample);
+            var context = new BucketContext(_travelSample);
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -483,7 +483,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task UseHashAndIndex_SelectDocuments()
         {
-            var context = new CollectionContext(_travelSample);
+            var context = new BucketContext(_travelSample);
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -516,7 +516,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Map2PocoTests_Simple_Projections_TypeFilterAttribute()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var beers = (from b in context.Query<BeerFiltered>()
@@ -531,7 +531,7 @@ namespace Couchbase.Linq.IntegrationTests
         {
             DocumentFilterManager.SetFilter(new BreweryFilter());
 
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var breweries = (from b in context.Query<Brewery>()
@@ -543,7 +543,7 @@ namespace Couchbase.Linq.IntegrationTests
 
         public void Map2PocoTests_Simple_Projections_MetaWhere()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var beers = (from b in context.Query<Beer>()
@@ -562,7 +562,7 @@ namespace Couchbase.Linq.IntegrationTests
 
         public void Map2PocoTests_Simple_Projections_MetaId()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var beers = (from b in context.Query<Beer>()
@@ -581,7 +581,7 @@ namespace Couchbase.Linq.IntegrationTests
 
         public void AnyAllTests_AnyNestedArray()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var breweries = (from b in context.Query<Brewery>()
@@ -596,7 +596,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void JoinTests_InnerJoin_Simple()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var beers = from beer in context.Query<Beer>()
@@ -616,7 +616,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void JoinTests_InnerJoin_SortAndFilter()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var beers = from beer in context.Query<Beer>()
@@ -638,7 +638,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void JoinTests_InnerJoin_Prefiltered()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var beers = from beer in context.Query<Beer>().Where(p => p.Type == "beer")
@@ -660,9 +660,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task JoinTests_InnerJoin_IndexJoin()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
-            await EnsureIndexExists(context.Collection.Scope.Bucket, "brewery_id", "brewery_id");
+            await EnsureIndexExists(context.Bucket, "brewery_id", "brewery_id");
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -689,7 +689,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task JoinTests_InnerJoin_AnsiJoin()
         {
-            var context = new CollectionContext(_travelSample);
+            var context = new BucketContext(_travelSample);
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -716,7 +716,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task JoinTests_InnerJoin_AnsiJoinPrefiltered()
         {
-            var context = new CollectionContext(_travelSample);
+            var context = new BucketContext(_travelSample);
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -742,7 +742,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void JoinTests_LeftJoin_Simple()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 join breweryGroup in context.Query<Brewery>()
@@ -762,7 +762,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void JoinTests_LeftJoin_SortAndFilter()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 join breweryGroup in context.Query<Brewery>()
@@ -784,7 +784,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void JoinTests_LeftJoin_Prefiltered()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>().Where(p => p.Type == "beer")
                 join breweryGroup in context.Query<Brewery>().Where(p => p.Type == "brewery")
@@ -806,9 +806,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task JoinTests_LeftJoin_IndexJoin()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
-            await EnsureIndexExists(context.Collection.Scope.Bucket, "brewery_id", "brewery_id");
+            await EnsureIndexExists(context.Bucket, "brewery_id", "brewery_id");
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -838,7 +838,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task JoinTests_LeftJoin_AnsiJoin()
         {
-            var context = new CollectionContext(_travelSample);
+            var context = new BucketContext(_travelSample);
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -866,7 +866,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task JoinTests_LeftJoin_AnsiJoinPrefiltered()
         {
-            var context = new CollectionContext(_travelSample);
+            var context = new BucketContext(_travelSample);
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -893,7 +893,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void NestTests_Unnest_Simple()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var breweries = from brewery in context.Query<Brewery>()
@@ -912,7 +912,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void NestTests_Unnest_Sort()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var breweries = from brewery in context.Query<Brewery>()
@@ -932,7 +932,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void NestTests_Unnest_Scalar()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var breweries = from brewery in context.Query<Brewery>()
@@ -951,9 +951,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task NestTests_Nest_IndexJoin()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
-            await EnsureIndexExists(context.Collection.Scope.Bucket, "brewery_id", "brewery_id");
+            await EnsureIndexExists(context.Bucket, "brewery_id", "brewery_id");
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -982,9 +982,9 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task NestTests_Nest_IndexJoinPrefiltered()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
-            await EnsureIndexExists(context.Collection.Scope.Bucket, "brewery_id", "brewery_id");
+            await EnsureIndexExists(context.Bucket, "brewery_id", "brewery_id");
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -1013,7 +1013,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task Test_AnsiNest_Prefiltered()
         {
-            var context = new CollectionContext(_travelSample);
+            var context = new BucketContext(_travelSample);
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -1042,7 +1042,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SubqueryTests_ArraySubqueryWithFilter()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var breweries = from brewery in context.Query<Brewery>()
                 where brewery.Type == "brewery"
@@ -1061,7 +1061,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SubqueryTests_ArraySubqueryContains()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var breweries = from brewery in context.Query<Brewery>()
                 where brewery.Type == "brewery" && brewery.Address.Contains("563 Second Street")
@@ -1080,7 +1080,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SubqueryTests_StaticArraySubqueryContains()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var breweryNames = new[] { "21st Amendment Brewery Cafe", "357" };
             var breweries = from brewery in context.Query<Brewery>()
@@ -1100,7 +1100,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SubqueryTests_ArraySubquerySelectNewObject()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var breweries = from brewery in context.Query<Brewery>()
                 where brewery.Type == "brewery"
@@ -1120,7 +1120,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SubqueryTests_ArraySubquerySorted()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var breweries = from brewery in context.Query<Brewery>()
                 where brewery.Type == "brewery"
@@ -1140,7 +1140,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SubqueryTests_Union()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var names = (from brewery in context.Query<Brewery>()
                 where brewery.Type == "brewery"
@@ -1162,7 +1162,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SubqueryTests_UnionAll()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var names = (from brewery in context.Query<Brewery>()
                          where brewery.Type == "brewery"
@@ -1184,7 +1184,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AggregateTests_SimpleAverage()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var avg =
                 context.Query<Beer>().Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv)).Average(p => p.Abv);
@@ -1195,7 +1195,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AggregateTests_SimpleCount()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var count = context.Query<Beer>().Count(p => p.Type == "beer");
             Assert.Greater(count, 0);
@@ -1205,7 +1205,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AggregateTests_GroupBy()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var breweries =
                 from beer in context.Query<Beer>()
@@ -1228,7 +1228,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AggregateTests_Having()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var breweries =
                 from beer in context.Query<Beer>()
@@ -1252,7 +1252,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AggregateTests_OrderByAggregate()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var breweries =
                 from beer in context.Query<Beer>()
@@ -1275,7 +1275,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void AggregateTests_JoinBeforeGroupByAndMultipartKey()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var breweries =
                 from beer in context.Query<Beer>()
@@ -1300,7 +1300,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void DateTime_DateAdd()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -1318,7 +1318,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void DateTime_DateAdd_UnixMillis()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                         where beer.Type == "beer" && N1QlFunctions.IsValued(beer.UpdatedUnixMillis)
@@ -1336,7 +1336,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void DateTime_DateDiff()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -1354,7 +1354,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void DateTime_DateDiff_UnixMillis()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                         where beer.Type == "beer"
@@ -1372,7 +1372,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void DateTime_DatePart()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -1390,7 +1390,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void DateTime_DatePart_UnixMillis()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                         where beer.Type == "beer"
@@ -1408,7 +1408,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void DateTime_DateTrunc()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -1423,7 +1423,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task DateTime_DateTrunc_UnixMillis()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
@@ -1457,7 +1457,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void DictionaryTests_Indexer()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var breweries =
@@ -1472,7 +1472,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void DictionaryTests_ContainsKey()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var breweries =
@@ -1487,7 +1487,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void DictionaryTests_Keys()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var breweries =
@@ -1503,7 +1503,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void DictionaryTests_Values()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
 
             var breweries =

--- a/Src/Couchbase.Linq.IntegrationTests/SingleQueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/SingleQueryTests.cs
@@ -15,7 +15,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Single_Empty()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "abcdefg"
@@ -31,7 +31,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SingleAsync_Empty()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "abcdefg"
@@ -43,7 +43,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Single_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Name == "21A IPA"
@@ -55,7 +55,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task SingleAsync_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Name == "21A IPA"
@@ -67,7 +67,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task SingleAsync_WithPredicate_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 select new {beer.Name};
@@ -80,7 +80,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Single_HasManyResults()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -96,7 +96,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SingleAsync_HasManyResults()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -108,7 +108,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SingleOrDefault_Empty()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "abcdefg"
@@ -121,7 +121,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task SingleOrDefaultAsync_Empty()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "abcdefg"
@@ -134,7 +134,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SingleOrDefault_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Name == "21A IPA"
@@ -148,7 +148,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task SingleOrDefaultAsync_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Name == "21A IPA"
@@ -162,7 +162,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task SingleOrDefaultAsync_WithPredicate_HasResult()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 select new {beer.Name};
@@ -175,7 +175,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SingleOrDefault_HasManyResults()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -191,7 +191,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void SingleOrDefaultAsync_HasManyResults()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"

--- a/Src/Couchbase.Linq.IntegrationTests/SumTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/SumTests.cs
@@ -13,7 +13,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public void Sum_NoSelector()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -25,7 +25,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task SumAsync_NoSelector()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"
@@ -37,7 +37,7 @@ namespace Couchbase.Linq.IntegrationTests
         [Test]
         public async Task SumAsync_WithSelector()
         {
-            var context = new CollectionContext(TestSetup.Collection);
+            var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
                 where beer.Type == "beer"

--- a/Src/Couchbase.Linq.IntegrationTests/TestSetup.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/TestSetup.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Couchbase.KeyValue;
 using NUnit.Framework;
 
 namespace Couchbase.Linq.IntegrationTests
@@ -10,7 +9,7 @@ namespace Couchbase.Linq.IntegrationTests
     {
         public static ICluster Cluster { get; private set; }
 
-        public static ICouchbaseCollection Collection { get; private set; }
+        public static IBucket Bucket { get; private set; }
 
         [OneTimeSetUp]
         public async Task SetUp()
@@ -21,7 +20,7 @@ namespace Couchbase.Linq.IntegrationTests
             var bucket = await Cluster.BucketAsync("beer-sample");
             await EnsurePrimaryIndexExists(bucket);
 
-            Collection = bucket.DefaultCollection();
+            Bucket = bucket;
         }
 
         [OneTimeTearDown]
@@ -30,7 +29,7 @@ namespace Couchbase.Linq.IntegrationTests
             Cluster.Dispose();
 
             Cluster = null;
-            Collection = null;
+            Bucket = null;
         }
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/BeerSample.cs
+++ b/Src/Couchbase.Linq.UnitTests/BeerSample.cs
@@ -9,9 +9,9 @@ namespace Couchbase.Linq.UnitTests
     /// <summary>
     /// A concrete DbContext for the beer-sample example bucket.
     /// </summary>
-    public class BeerSample : CollectionContext
+    public class BeerSample : BucketContext
     {
-        public BeerSample(ICouchbaseCollection collection) : base(collection)
+        public BeerSample(IBucket bucket) : base(bucket)
         {
             //Two ways of applying a filter are included in this example.
             //This is by implementing IDocumentFilter and then adding explicitly.

--- a/Src/Couchbase.Linq.UnitTests/CollectionContextTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/CollectionContextTests.cs
@@ -12,10 +12,10 @@ namespace Couchbase.Linq.UnitTests
         [Test]
         public void Can_Get_The_Bucket_The_Context_Was_Created_With()
         {
-            var collection = new Mock<ICouchbaseCollection>();
-            var context = new CollectionContext(collection.Object);
+            var bucket = new Mock<IBucket>();
+            var context = new BucketContext(bucket.Object);
 
-            Assert.AreSame(collection.Object, context.Collection);
+            Assert.AreSame(bucket.Object, context.Bucket);
         }
 
         [Test]
@@ -35,9 +35,11 @@ namespace Couchbase.Linq.UnitTests
             var mockCollection = new Mock<ICouchbaseCollection>();
             mockCollection
                 .SetupGet(p => p.Scope.Bucket)
-                .Returns(mockBucket.Object);
+                .Returns(() => mockBucket.Object);
 
-            var ctx = new CollectionContext(mockCollection.Object);
+            mockBucket.Setup(e => e.DefaultCollection()).Returns(mockCollection.Object);
+
+            var ctx = new BucketContext(mockBucket.Object);
 
             // Act
 
@@ -67,9 +69,11 @@ namespace Couchbase.Linq.UnitTests
             var mockCollection = new Mock<ICouchbaseCollection>();
             mockCollection
                 .SetupGet(p => p.Scope.Bucket)
-                .Returns(mockBucket.Object);
+                .Returns(() => mockBucket.Object);
 
-            var ctx = new CollectionContext(mockCollection.Object);
+            mockBucket.Setup(e => e.DefaultCollection()).Returns(mockCollection.Object);
+
+            var ctx = new BucketContext(mockBucket.Object);
 
             // Act
 
@@ -99,9 +103,11 @@ namespace Couchbase.Linq.UnitTests
             var mockCollection = new Mock<ICouchbaseCollection>();
             mockCollection
                 .SetupGet(p => p.Scope.Bucket)
-                .Returns(mockBucket.Object);
+                .Returns(() => mockBucket.Object);
 
-            var ctx = new CollectionContext(mockCollection.Object);
+            mockBucket.Setup(e => e.DefaultCollection()).Returns(mockCollection.Object);
+
+            var ctx = new BucketContext(mockBucket.Object);
 
             // Act
 

--- a/Src/Couchbase.Linq/BucketContext.cs
+++ b/Src/Couchbase.Linq/BucketContext.cs
@@ -8,44 +8,33 @@ namespace Couchbase.Linq
     /// Provides a single point of entry to a Couchbase bucket which makes it easier to compose
     /// and execute queries and to group together changes which will be submitted back into the bucket.
     /// </summary>
-    public class CollectionContext : ICollectionContext
+    public class BucketContext : IBucketContext
     {
         /// <summary>
-        /// Creates a new CollectionContext for a given Couchbase collection.
+        /// Creates a new BucketContext for a given Couchbase bucket.
         /// </summary>
-        /// <param name="collection">Collection referenced by the new CollectionContext.</param>
-        public CollectionContext(ICouchbaseCollection collection)
+        /// <param name="bucket">Bucket referenced by the new BucketContext.</param>
+        public BucketContext(IBucket bucket)
         {
-            Collection = collection;
+            Bucket = bucket;
         }
 
         /// <summary>
-        /// Gets the collection the <see cref="ICollectionContext"/> was created against.
+        /// Gets the bucket the <see cref="IBucketContext"/> was created against.
         /// </summary>
         /// <value>The <see cref="IBucket"/>.</value>
-        public ICouchbaseCollection Collection { get; private set; }
+        public IBucket Bucket { get; }
 
-        /// <summary>
-        /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
-        /// a LINQ query and requires that the associated JSON document have a type property that is the same as T.
-        /// </summary>
-        /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
-        /// <returns><see cref="IQueryable{T}" /> which can be used to query the bucket.</returns>
+        /// <inheritdoc />
         public IQueryable<T> Query<T>()
         {
             return Query<T>(BucketQueryOptions.None);
         }
 
-        /// <summary>
-        /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
-        /// a LINQ query and requires that the associated JSON document have a type property that is the same as T.
-        /// </summary>
-        /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
-        /// <param name="options">Options to control the returned query.</param>
-        /// <returns><see cref="IQueryable{T}" /> which can be used to query the bucket.</returns>
+        /// <inheritdoc />
         public IQueryable<T> Query<T>(BucketQueryOptions options)
         {
-            IQueryable<T> query = new CollectionQueryable<T>(Collection);
+            IQueryable<T> query = new CollectionQueryable<T>(Bucket.DefaultCollection());
 
             if ((options & BucketQueryOptions.SuppressFilters) == BucketQueryOptions.None)
             {
@@ -56,13 +45,13 @@ namespace Couchbase.Linq
         }
 
         /// <inheritdoc />
-        public string CollectionName => Collection.Name;
+        public string CollectionName => "_default";
 
         /// <inheritdoc />
-        public string ScopeName => Collection.Scope.Name;
+        public string ScopeName => "_default";
 
         /// <inheritdoc />
-        public string BucketName => Collection.Scope.Bucket.Name;
+        public string BucketName => Bucket.Name;
     }
 }
 

--- a/Src/Couchbase.Linq/BucketQueryOptions.cs
+++ b/Src/Couchbase.Linq/BucketQueryOptions.cs
@@ -4,7 +4,7 @@ using Couchbase.Linq.Filters;
 namespace Couchbase.Linq
 {
     /// <summary>
-    /// Options to control queries against an <see cref="ICollectionContext"/>.
+    /// Options to control queries against an <see cref="IBucketContext"/>.
     /// </summary>
     [Flags]
     public enum BucketQueryOptions

--- a/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/EnumerableExtensions.cs
@@ -11,7 +11,7 @@ namespace Couchbase.Linq.Extensions
 {
     /// <summary>
     /// Extensions to <see cref="IEnumerable{T}"/> which emulate query extensions in <see cref="QueryExtensions"/>.
-    /// This helps to provide support for unit tests against a fake <see cref="CollectionContext"/>.
+    /// This helps to provide support for unit tests against a fake <see cref="BucketContext"/>.
     /// </summary>
     public static class EnumerableExtensions
     {

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.cs
@@ -10,7 +10,7 @@ using Couchbase.Linq.Execution;
 namespace Couchbase.Linq.Extensions
 {
     /// <summary>
-    /// Extensions to <see cref="IQueryable{T}" /> for use in queries against a <see cref="CollectionContext"/>.
+    /// Extensions to <see cref="IQueryable{T}" /> for use in queries against a <see cref="BucketContext"/>.
     /// </summary>
     public static partial class QueryExtensions
     {

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -7,16 +7,16 @@ namespace Couchbase.Linq
     /// Provides a single point of entry to a Couchbase collection which makes it easier to compose
     /// and execute queries and to group together changes which will be submitted back into the bucket.
     /// </summary>
-    public interface ICollectionContext : ICollectionQueryable
+    public interface IBucketContext : ICollectionQueryable
     {
         /// <summary>
-        /// Gets the collection the <see cref="ICollectionContext"/> was created against.
+        /// Gets the bucket the <see cref="IBucketContext"/> was created against.
         /// </summary>
         /// <value>The <see cref="ICouchbaseCollection"/>.</value>
-        ICouchbaseCollection Collection { get; }
+        IBucket Bucket { get; }
 
         /// <summary>
-        /// Queries the current <see cref="ICouchbaseCollection" /> for entities of type T. This is the target of
+        /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
         /// a LINQ query and requires that the associated JSON document have a type property that is the same as T.
         /// </summary>
         /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
@@ -24,7 +24,7 @@ namespace Couchbase.Linq
         IQueryable<T> Query<T>();
 
         /// <summary>
-        /// Queries the current <see cref="ICouchbaseCollection" /> for entities of type T. This is the target of
+        /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
         /// a LINQ query and requires that the associated JSON document have a type property that is the same as T.
         /// </summary>
         /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>


### PR DESCRIPTION
Motivation
----------
After further consideration, BucketContext still makes sense for the
main context instead of CollectionContext. ICollectionQueryable still
works best for the actual IQueryable, since any given extent being
queried should be from a particular scope/collection.

By using BucketContext, if we reenable change tracking in the future
we'll be able to track changes across multiple scopes/collections and
submit them with a single method call. This was lost with the change
to CollectionContext.

Modifications
-------------
Switch CollectionContext back to BucketContext, and ICollectionContext
back to IBucketContext. For IBucketContext.Query, assume the default
collection.

Update tests and XML docs to match.

Results
-------
We're in a better position to add additional features in the future
which are backward compatible. This includes:

- Queries against collections other than the default collection, using
more specific method calls, or perhaps auto-filled properties on the
BucketContext (like DbSet in Entity Framework)
- Change tracking across the entire bucket

The API surface is also more backward compatible with 1.x of the LINQ
SDK, making upgrading easier.