### PR TITLE
Add support for MinAsync and MaxAsync

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/MinMaxTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/MinMaxTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.IntegrationTests.Documents;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.IntegrationTests
+{
+    [TestFixture]
+    public class MinMaxTests : N1QlTestBase
+    {
+        [Test]
+        public void Min_WithSelector()
+        {
+            var context = new BucketContext(TestSetup.Bucket);
+
+            var min = context.Query<Beer>()
+                .Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv))
+                .Min(p => p.Abv);
+
+            Assert.AreEqual(min, 0);
+            Console.WriteLine("Min ABV of all beers is {0}", min);
+        }
+
+        [Test]
+        public async Task MinAsync_NoSelector()
+        {
+            var context = new BucketContext(TestSetup.Bucket);
+
+            var min = await context.Query<Beer>()
+                .Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv))
+                .Select(p => p.Abv)
+                .MinAsync();
+
+            Assert.AreEqual(min, 0);
+            Console.WriteLine("Min ABV of all beers is {0}", min);
+        }
+
+        [Test]
+        public async Task MinAsync_WithSelector()
+        {
+            var context = new BucketContext(TestSetup.Bucket);
+
+            var min = await context.Query<Beer>()
+                .Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv))
+                .MinAsync(p => p.Abv);
+
+            Assert.AreEqual(min, 0);
+            Console.WriteLine("Min ABV of all beers is {0}", min);
+        }
+
+        [Test]
+        public void Max_WithSelector()
+        {
+            var context = new BucketContext(TestSetup.Bucket);
+
+            var max = context.Query<Beer>()
+                .Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv))
+                .Max(p => p.Abv);
+
+            Assert.Greater(max, 0);
+            Console.WriteLine("Max ABV of all beers is {0}", max);
+        }
+
+        [Test]
+        public async Task MaxAsync_NoSelector()
+        {
+            var context = new BucketContext(TestSetup.Bucket);
+
+            var max = await context.Query<Beer>()
+                .Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv))
+                .Select(p => p.Abv)
+                .MaxAsync();
+
+            Assert.Greater(max, 0);
+            Console.WriteLine("Max ABV of all beers is {0}", max);
+        }
+
+        [Test]
+        public async Task MaxAsync_WithSelector()
+        {
+            var context = new BucketContext(TestSetup.Bucket);
+
+            var max = await context.Query<Beer>()
+                .Where(p => p.Type == "beer" && N1QlFunctions.IsValued(p.Abv))
+                .MaxAsync(p => p.Abv);
+
+            Assert.Greater(max, 0);
+            Console.WriteLine("Max ABV of all beers is {0}", max);
+        }
+    }
+}

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/AggregateTests.cs
@@ -237,11 +237,39 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             Assert.AreEqual(expected, n1QlQuery);
         }
 
+        #region Min/Max
+
         [Test]
         public void Test_Min()
         {
             // ReSharper disable once UnusedVariable
             _ = CreateQueryable<Beer>("default").Min(p => p.Abv);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT MIN(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_MinAsync_NoSelector()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").Select(p => p.Abv).MinAsync();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT MIN(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_MinAsync_WithSelector()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").MinAsync(p => p.Abv);
             var n1QlQuery = QueryExecutor.Query;
 
             const string expected =
@@ -262,6 +290,34 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             Assert.AreEqual(expected, n1QlQuery);
         }
+
+        [Test]
+        public async Task Test_MaxAsync_NoSelector()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").Select(p => p.Abv).MaxAsync();
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT MAX(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public async Task Test_MaxAsync_WithSelector()
+        {
+            // ReSharper disable once UnusedVariable
+            _ = await CreateQueryable<Beer>("default").MaxAsync(p => p.Abv);
+            var n1QlQuery = QueryExecutor.Query;
+
+            const string expected =
+                "SELECT MAX(`Extent1`.`abv`) as `result` FROM `default` as `Extent1`";
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
 
         [Test]
         public void Test_Sum()

--- a/Src/Couchbase.Linq/Clauses/MaxAsyncExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/MaxAsyncExpressionNode.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Operators;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    /// <summary>
+    /// Expression node for MaxAsync.
+    /// </summary>
+    internal class MaxAsyncExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        /// <summary>
+        /// Methods which are supported by this type of node.
+        /// </summary>
+        public static IEnumerable<MethodInfo> GetSupportedMethods() => new[]
+        {
+            QueryExtensionMethods.MaxAsyncNoSelector,
+            QueryExtensionMethods.MaxAsyncWithSelector
+        };
+
+        /// <summary>
+        /// Creates a new MaxAsyncExpressionNode.
+        /// </summary>
+        /// <param name="parseInfo">Method parse info.</param>
+        /// <param name="optionalSelector">Optional selector for value.</param>
+        public MaxAsyncExpressionNode(MethodCallExpressionParseInfo parseInfo, LambdaExpression optionalSelector)
+            : base(parseInfo, null, optionalSelector)
+        {
+        }
+
+        /// <inheritdoc />
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            throw new NotSupportedException($"Resolve is not supported by {typeof(MaxAsyncExpressionNode)}");
+        }
+
+        /// <inheritdoc />
+        protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext) =>
+            new MaxAsyncResultOperator();
+    }
+}

--- a/Src/Couchbase.Linq/Clauses/MinAsyncExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/MinAsyncExpressionNode.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Operators;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.Linq.Clauses
+{
+    /// <summary>
+    /// Expression node for MinAsync.
+    /// </summary>
+    internal class MinAsyncExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        /// <summary>
+        /// Methods which are supported by this type of node.
+        /// </summary>
+        public static IEnumerable<MethodInfo> GetSupportedMethods() => new[]
+        {
+            QueryExtensionMethods.MinAsyncNoSelector,
+            QueryExtensionMethods.MinAsyncWithSelector
+        };
+
+        /// <summary>
+        /// Creates a new MinAsyncExpressionNode.
+        /// </summary>
+        /// <param name="parseInfo">Method parse info.</param>
+        /// <param name="optionalSelector">Optional selector for value.</param>
+        public MinAsyncExpressionNode(MethodCallExpressionParseInfo parseInfo, LambdaExpression optionalSelector)
+            : base(parseInfo, null, optionalSelector)
+        {
+        }
+
+        /// <inheritdoc />
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            throw new NotSupportedException($"Resolve is not supported by {typeof(MinAsyncExpressionNode)}");
+        }
+
+        /// <inheritdoc />
+        protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext) =>
+            new MinAsyncResultOperator();
+    }
+}

--- a/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
@@ -33,6 +33,11 @@ namespace Couchbase.Linq.Extensions
         public static MethodInfo AverageAsyncNoSelector { get; }
         public static MethodInfo AverageAsyncWithSelector { get; }
 
+        public static MethodInfo MinAsyncNoSelector { get; }
+        public static MethodInfo MinAsyncWithSelector { get; }
+        public static MethodInfo MaxAsyncNoSelector { get; }
+        public static MethodInfo MaxAsyncWithSelector { get; }
+
         public static MethodInfo Nest { get; }
         public static MethodInfo LeftOuterNest { get; }
         public static MethodInfo Explain { get; }
@@ -92,6 +97,15 @@ namespace Couchbase.Linq.Extensions
                 p.Name == nameof(QueryExtensions.AverageAsync) && p.GetParameters().Length == 1);
             AverageAsyncWithSelector = allMethods.Single(p =>
                 p.Name == nameof(QueryExtensions.AverageAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
+
+            MinAsyncNoSelector = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.MinAsync) && p.GetParameters().Length == 1);
+            MinAsyncWithSelector = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.MinAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
+            MaxAsyncNoSelector = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.MaxAsync) && p.GetParameters().Length == 1);
+            MaxAsyncWithSelector = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.MaxAsync) && p.GetParameters().Length == 2 && p.GetParameters().Last().ParameterType != typeof(CancellationToken));
 
             Nest = allMethods.Single(p => p.Name == nameof(QueryExtensions.Nest));
             LeftOuterNest = allMethods.Single(p => p.Name == nameof(QueryExtensions.LeftOuterNest));

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.MinMax.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.MinMax.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Couchbase.Linq.Extensions
+{
+    // MinAsync and MaxAsync extensions
+
+    public static partial class QueryExtensions
+    {
+        /// <summary>
+        /// Asynchronously finds the minimum item returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <returns>The minimum item returned by the query.</returns>
+        public static Task<T> MinAsync<T>(this IQueryable<T> source) =>
+            source.MinAsync(default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously finds the minimum item returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The minimum item returned by the query.</returns>
+        public static Task<T> MinAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return ExecuteAsync<T, Task<T>>(QueryExtensionMethods.MinAsyncNoSelector, source, null,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously finds the minimum item returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <typeparam name="TResult">Type returned by the minimum operation.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="selector">Selector for value.</param>
+        /// <returns>The minimum item returned by the query.</returns>
+        public static Task<TResult> MinAsync<T, TResult>(this IQueryable<T> source, Expression<Func<T, TResult>> selector) =>
+            source.MinAsync(selector, default);
+
+        /// <summary>
+        /// Asynchronously finds the minimum item returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <typeparam name="TResult">Type returned by the minimum operation.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="selector">Selector for value.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The minimum item returned by the query.</returns>
+        public static Task<TResult> MinAsync<T, TResult>(this IQueryable<T> source, Expression<Func<T, TResult>> selector, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            return ExecuteAsync<T, Task<TResult>>(QueryExtensionMethods.MinAsyncWithSelector, source, selector,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously finds the maximum item returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <returns>The maximum item returned by the query.</returns>
+        public static Task<T> MaxAsync<T>(this IQueryable<T> source) =>
+            source.MaxAsync(default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously finds the maximum item returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The maximum item returned by the query.</returns>
+        public static Task<T> MaxAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return ExecuteAsync<T, Task<T>>(QueryExtensionMethods.MaxAsyncNoSelector, source, null,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously finds the maximum item returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <typeparam name="TResult">Type returned by the maximum operation.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="selector">Selector for value.</param>
+        /// <returns>The maximum item returned by the query.</returns>
+        public static Task<TResult> MaxAsync<T, TResult>(this IQueryable<T> source, Expression<Func<T, TResult>> selector) =>
+            source.MaxAsync(selector, default);
+
+        /// <summary>
+        /// Asynchronously finds the maximum item returned by a query.
+        /// </summary>
+        /// <typeparam name="T">Type of item to query.</typeparam>
+        /// <typeparam name="TResult">Type returned by the maximum operation.</typeparam>
+        /// <param name="source">Source <see cref="IQueryable{T}"/></param>.
+        /// <param name="selector">Selector for value.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The maximum item returned by the query.</returns>
+        public static Task<TResult> MaxAsync<T, TResult>(this IQueryable<T> source, Expression<Func<T, TResult>> selector, CancellationToken cancellationToken)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
+            }
+
+            return ExecuteAsync<T, Task<TResult>>(QueryExtensionMethods.MaxAsyncWithSelector, source, selector,
+                cancellationToken);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Operators/MaxAsyncResultOperator.cs
+++ b/Src/Couchbase.Linq/Operators/MaxAsyncResultOperator.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Couchbase.Linq.Execution.StreamedData;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Operators
+{
+    /// <summary>
+    /// Result operator for MaxAsync.
+    /// </summary>
+    internal class MaxAsyncResultOperator : AsyncValueFromSequenceResultOperatorBase
+    {
+        /// <inheritdoc />
+        public override ResultOperatorBase Clone(CloneContext cloneContext) =>
+            new MaxAsyncResultOperator();
+
+        /// <inheritdoc />
+        public override AsyncStreamedValue ExecuteInMemory<T>(StreamedSequence input)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            var sequence = input.GetTypedSequence<T>();
+            var result = sequence.Max();
+            return new AsyncStreamedValue(Task.FromResult(result), GetOutputDataInfo(input.DataInfo));
+        }
+
+        /// <inheritdoc />
+        public override IStreamedDataInfo GetOutputDataInfo(IStreamedDataInfo inputInfo)
+        {
+            if (inputInfo == null)
+            {
+                throw new ArgumentNullException(nameof(inputInfo));
+            }
+            if (!(inputInfo is StreamedSequenceInfo streamedSequenceInfo))
+            {
+                throw new ArgumentException($"{nameof(inputInfo)} must be of type {typeof(StreamedSequenceInfo)}");
+            }
+
+            return GetOutputDataInfo(streamedSequenceInfo);
+        }
+
+        protected AsyncStreamedValueInfo GetOutputDataInfo(StreamedSequenceInfo streamedSequenceInfo)
+        {
+            if (streamedSequenceInfo == null)
+            {
+                throw new ArgumentNullException(nameof(streamedSequenceInfo));
+            }
+
+            var resultType = typeof(Task<>).MakeGenericType(streamedSequenceInfo.ResultItemType);
+
+            return new AsyncStreamedScalarValueInfo(resultType);
+        }
+
+        /// <inheritdoc />
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Operators/MinAsyncResultOperator.cs
+++ b/Src/Couchbase.Linq/Operators/MinAsyncResultOperator.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Couchbase.Linq.Execution.StreamedData;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.Linq.Operators
+{
+    /// <summary>
+    /// Result operator for MinAsync.
+    /// </summary>
+    internal class MinAsyncResultOperator : AsyncValueFromSequenceResultOperatorBase
+    {
+        /// <inheritdoc />
+        public override ResultOperatorBase Clone(CloneContext cloneContext) =>
+            new MinAsyncResultOperator();
+
+        /// <inheritdoc />
+        public override AsyncStreamedValue ExecuteInMemory<T>(StreamedSequence input)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            var sequence = input.GetTypedSequence<T>();
+            var result = sequence.Min();
+            return new AsyncStreamedValue(Task.FromResult(result), GetOutputDataInfo(input.DataInfo));
+        }
+
+        /// <inheritdoc />
+        public override IStreamedDataInfo GetOutputDataInfo(IStreamedDataInfo inputInfo)
+        {
+            if (inputInfo == null)
+            {
+                throw new ArgumentNullException(nameof(inputInfo));
+            }
+            if (!(inputInfo is StreamedSequenceInfo streamedSequenceInfo))
+            {
+                throw new ArgumentException($"{nameof(inputInfo)} must be of type {typeof(StreamedSequenceInfo)}");
+            }
+
+            return GetOutputDataInfo(streamedSequenceInfo);
+        }
+
+        protected AsyncStreamedValueInfo GetOutputDataInfo(StreamedSequenceInfo streamedSequenceInfo)
+        {
+            if (streamedSequenceInfo == null)
+            {
+                throw new ArgumentNullException(nameof(streamedSequenceInfo));
+            }
+
+            var resultType = typeof(Task<>).MakeGenericType(streamedSequenceInfo.ResultItemType);
+
+            return new AsyncStreamedScalarValueInfo(resultType);
+        }
+
+        /// <inheritdoc />
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -702,11 +702,13 @@ namespace Couchbase.Linq.QueryGeneration
                     break;
 
                 case MaxResultOperator _:
+                case MaxAsyncResultOperator _:
                     _queryPartsAggregator.AggregateFunction = "MAX";
                     _isAggregated = true;
                     break;
 
                 case MinResultOperator _:
+                case MinAsyncResultOperator _:
                     _queryPartsAggregator.AggregateFunction = "MIN";
                     _isAggregated = true;
                     break;

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -48,6 +48,8 @@ namespace Couchbase.Linq
             nodeTypeRegistry.Register(LongCountAsyncExpressionNode.GetSupportedMethods(), typeof(LongCountAsyncExpressionNode));
             nodeTypeRegistry.Register(SumAsyncExpressionNode.GetSupportedMethods(), typeof(SumAsyncExpressionNode));
             nodeTypeRegistry.Register(AverageAsyncExpressionNode.GetSupportedMethods(), typeof(AverageAsyncExpressionNode));
+            nodeTypeRegistry.Register(MinAsyncExpressionNode.GetSupportedMethods(), typeof(MinAsyncExpressionNode));
+            nodeTypeRegistry.Register(MaxAsyncExpressionNode.GetSupportedMethods(), typeof(MaxAsyncExpressionNode));
 
             //This creates all the default node types
             var nodeTypeProvider = ExpressionTreeParser.CreateDefaultNodeTypeProvider();


### PR DESCRIPTION
Motivation
----------
Support asynchronous queries which return averages.

Modifications
-------------
Create extension methods, expression nodes, and result operators to
handle MinAsync and MaxAsync.

Update N1QLQueryModelVisitor to recognize the new result operators.

Add tests for the async methods.

Results
-------
MinAsync and MaxAsync may be called on IQueryable and will function
correctly so long as the IQueryable is from a CollectionContext.

Closes #281