### PR TITLE
Add QueryTimeout to IBucketContext

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/QueryFactory.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryFactory.cs
@@ -38,7 +38,7 @@ namespace Couchbase.Linq.UnitTests
                 .SetupGet(p => p.Scope.Bucket)
                 .Returns(mockBucket.Object);
 
-            return new CollectionQueryable<T>(mockCollection.Object);
+            return new CollectionQueryable<T>(mockCollection.Object, default);
         }
     }
 }

--- a/Src/Couchbase.Linq/BucketContext.cs
+++ b/Src/Couchbase.Linq/BucketContext.cs
@@ -1,5 +1,5 @@
-﻿using System.Linq;
-using Couchbase.KeyValue;
+﻿using System;
+using System.Linq;
 using Couchbase.Linq.Filters;
 
 namespace Couchbase.Linq
@@ -19,22 +19,20 @@ namespace Couchbase.Linq
             Bucket = bucket;
         }
 
-        /// <summary>
-        /// Gets the bucket the <see cref="IBucketContext"/> was created against.
-        /// </summary>
-        /// <value>The <see cref="IBucket"/>.</value>
+        /// <inheritdoc />
         public IBucket Bucket { get; }
 
         /// <inheritdoc />
-        public IQueryable<T> Query<T>()
-        {
-            return Query<T>(BucketQueryOptions.None);
-        }
+        public TimeSpan? QueryTimeout { get; set; }
+
+        /// <inheritdoc />
+        public IQueryable<T> Query<T>() =>
+            Query<T>(BucketQueryOptions.None);
 
         /// <inheritdoc />
         public IQueryable<T> Query<T>(BucketQueryOptions options)
         {
-            IQueryable<T> query = new CollectionQueryable<T>(Bucket.DefaultCollection());
+            IQueryable<T> query = new CollectionQueryable<T>(Bucket.DefaultCollection(), QueryTimeout);
 
             if ((options & BucketQueryOptions.SuppressFilters) == BucketQueryOptions.None)
             {
@@ -43,15 +41,6 @@ namespace Couchbase.Linq
 
             return query;
         }
-
-        /// <inheritdoc />
-        public string CollectionName => "_default";
-
-        /// <inheritdoc />
-        public string ScopeName => "_default";
-
-        /// <inheritdoc />
-        public string BucketName => Bucket.Name;
     }
 }
 

--- a/Src/Couchbase.Linq/CollectionQueryable.cs
+++ b/Src/Couchbase.Linq/CollectionQueryable.cs
@@ -56,10 +56,14 @@ namespace Couchbase.Linq
         /// Initializes a new instance of the <see cref="CollectionQueryable{T}"/> class.
         /// </summary>
         /// <param name="collection">The collection.</param>
-        public CollectionQueryable(ICouchbaseCollection collection)
+        /// <param name="queryTimeout">Query timeout, if null uses cluster default.</param>
+        public CollectionQueryable(ICouchbaseCollection collection, TimeSpan? queryTimeout)
             : this(collection,
                 QueryParserHelper.CreateQueryParser(collection.Scope.Bucket.Cluster),
-                new ClusterQueryExecutor(collection.Scope.Bucket.Cluster))
+                new ClusterQueryExecutor(collection.Scope.Bucket.Cluster)
+                {
+                    QueryTimeout = queryTimeout
+                })
         {
         }
 

--- a/Src/Couchbase.Linq/Execution/ClusterQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/ClusterQueryExecutor.cs
@@ -31,6 +31,11 @@ namespace Couchbase.Linq.Execution
             _serializer ??= _cluster.ClusterServices.GetRequiredService<ITypeSerializer>();
 
         /// <summary>
+        /// Query timeout, if null uses cluster default.
+        /// </summary>
+        public TimeSpan? QueryTimeout { get; set; }
+
+        /// <summary>
         /// Creates a new BucketQueryExecutor.
         /// </summary>
         /// <param name="cluster"><see cref="ICluster"/> to query.</param>
@@ -65,6 +70,11 @@ namespace Couchbase.Linq.Execution
             if (combinedMutationState != null)
             {
                 queryOptions.ConsistentWith(combinedMutationState);
+            }
+
+            if (QueryTimeout != null)
+            {
+                queryOptions.Timeout(QueryTimeout.Value);
             }
 
             return queryOptions;

--- a/Src/Couchbase.Linq/IBucketContext.cs
+++ b/Src/Couchbase.Linq/IBucketContext.cs
@@ -1,5 +1,5 @@
-﻿using System.Linq;
-using Couchbase.KeyValue;
+﻿using System;
+using System.Linq;
 
 namespace Couchbase.Linq
 {
@@ -7,13 +7,18 @@ namespace Couchbase.Linq
     /// Provides a single point of entry to a Couchbase collection which makes it easier to compose
     /// and execute queries and to group together changes which will be submitted back into the bucket.
     /// </summary>
-    public interface IBucketContext : ICollectionQueryable
+    public interface IBucketContext
     {
         /// <summary>
         /// Gets the bucket the <see cref="IBucketContext"/> was created against.
         /// </summary>
-        /// <value>The <see cref="ICouchbaseCollection"/>.</value>
+        /// <value>The <see cref="IBucket"/>.</value>
         IBucket Bucket { get; }
+
+        /// <summary>
+        /// Query timeout, if null uses cluster default.
+        /// </summary>
+        TimeSpan? QueryTimeout { get; set; }
 
         /// <summary>
         /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of


### PR DESCRIPTION
Motivation
----------
Allow the timeout for queries to be overridden from the cluster default
at the IBucketContext level.

Modifications
-------------
Add QueryTimeout to BucketContext and ClusterQueryExecutor.

Results
-------
When creating the BucketContext, possibly as part of the constructor
if inheriting, the timeout for queries can be overridden. If joining
between multiple BucketContexts, the timeout from the first referenced
BucketContext will apply.

Relates to #308