### PR TITLE
Add scan wait to ConsistentWith

### DIFF
--- a/Src/Couchbase.Linq/Clauses/ConsistentWithClause.cs
+++ b/Src/Couchbase.Linq/Clauses/ConsistentWithClause.cs
@@ -16,15 +16,22 @@ namespace Couchbase.Linq.Clauses
         /// Initializes a new instance of the <see cref="ConsistentWithClause" /> class.
         /// </summary>
         /// <param name="mutationState">Mutation state for the query.</param>
-        public ConsistentWithClause(MutationState mutationState)
+        /// <param name="scanWait">Time to wait for index scan.</param>
+        public ConsistentWithClause(MutationState mutationState, TimeSpan? scanWait)
         {
             MutationState = mutationState;
+            ScanWait = scanWait;
         }
 
         /// <summary>
         /// Mutation state for the query.
         /// </summary>
         public MutationState MutationState { get; set; }
+
+        /// <summary>
+        /// Time to wait for index scan.
+        /// </summary>
+        public TimeSpan? ScanWait { get; }
 
         /// <inheritdoc />
         public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
@@ -35,7 +42,7 @@ namespace Couchbase.Linq.Clauses
         /// <inheritdoc />
         public IBodyClause Clone(CloneContext cloneContext)
         {
-            return new ConsistentWithClause(MutationState);
+            return new ConsistentWithClause(MutationState, ScanWait);
         }
 
         /// <inheritdoc />

--- a/Src/Couchbase.Linq/Execution/ClusterQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/ClusterQueryExecutor.cs
@@ -58,6 +58,11 @@ namespace Couchbase.Linq.Execution
                     case ConsistentWithClause consistentWith:
                         combinedMutationState ??= new MutationState();
                         combinedMutationState.Add(consistentWith.MutationState);
+
+                        if (consistentWith.ScanWait != null)
+                        {
+                            queryOptions.ScanWait(consistentWith.ScanWait.Value);
+                        }
                         break;
                 }
             }

--- a/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
@@ -49,6 +49,7 @@ namespace Couchbase.Linq.Extensions
 
         public static MethodInfo ScanConsistency { get; }
         public static MethodInfo ConsistentWith { get; }
+        public static MethodInfo ConsistentWithScanWait { get; }
 
         static QueryExtensionMethods()
         {
@@ -119,7 +120,10 @@ namespace Couchbase.Linq.Extensions
             UseHash = allMethods.Single(p => p.Name == nameof(QueryExtensions.UseHash));
 
             ScanConsistency = allMethods.Single(p => p.Name == nameof(QueryExtensions.ScanConsistency));
-            ConsistentWith = allMethods.Single(p => p.Name == nameof(QueryExtensions.ConsistentWith));
+            ConsistentWith = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.ConsistentWith) && p.GetParameters().Length == 2);
+            ConsistentWithScanWait = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.ConsistentWith) && p.GetParameters().Length == 3);
         }
     }
 }

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.Consistency.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.Consistency.cs
@@ -46,5 +46,27 @@ namespace Couchbase.Linq.Extensions
                     source.Expression,
                     Expression.Constant(state)));
         }
+
+        /// <summary>
+        /// Requires that the indexes but up to date with a <see cref="MutationState"/> before the query is executed.
+        /// </summary>
+        /// <param name="source">Sets consistency requirement for this query.  Must be a Couchbase LINQ query.</param>
+        /// <param name="state"><see cref="MutationState"/> used for consistency controls.</param>
+        /// <param name="scanWait">Time to wait for index scan.</param>
+        /// <remarks>If called multiple times, the states from the calls are combined.</remarks>
+        public static IQueryable<T> ConsistentWith<T>(this IQueryable<T> source, MutationState state, TimeSpan scanWait)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return source.Provider.CreateQuery<T>(
+                Expression.Call(
+                    QueryExtensionMethods.ConsistentWithScanWait.MakeGenericMethod(typeof(T)),
+                    source.Expression,
+                    Expression.Constant(state),
+                    Expression.Constant(scanWait)));
+        }
     }
 }


### PR DESCRIPTION
Motivation
----------
When using ConsistentWith allow the consumer to specify a scan wait
limit.

Modifications
-------------
Add overload of ConsistentWith that accepts a scan wait TimeSpan, and
pass down through the expression node and clause. Apply this value
in ClusterQueryExecutor to the QueryOptions.

Results
-------
Scan wait can be controlled for queries performing RYOW using
ConsistentWith.

Relates to #308 