### PR TITLE
Add scan wait to ScanConsistency

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/ConsistencyTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/ConsistencyTests.cs
@@ -26,6 +26,19 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public async Task ScanConsistency_ScanWait()
+        {
+            var context = new BucketContext(TestSetup.Bucket);
+
+            var beers = from b in context.Query<Beer>().ScanConsistency(QueryScanConsistency.RequestPlus, TimeSpan.FromSeconds(10))
+                select b;
+
+            var beer = await beers.FirstAsync();
+            Console.WriteLine(beer.Name);
+        }
+
+
+        [Test]
         public async Task ConsistentWith()
         {
             var context = new BucketContext(TestSetup.Bucket);

--- a/Src/Couchbase.Linq/Clauses/ScanConsistencyClause.cs
+++ b/Src/Couchbase.Linq/Clauses/ScanConsistencyClause.cs
@@ -15,15 +15,22 @@ namespace Couchbase.Linq.Clauses
         /// Initializes a new instance of the <see cref="ScanConsistencyClause" /> class.
         /// </summary>
         /// <param name="scanConsistency">Scan consistency for the query.</param>
-        public ScanConsistencyClause(QueryScanConsistency scanConsistency)
+        /// <param name="scanWait">Time to wait for index scan.</param>
+        public ScanConsistencyClause(QueryScanConsistency scanConsistency, TimeSpan? scanWait)
         {
             ScanConsistency = scanConsistency;
+            ScanWait = scanWait;
         }
 
         /// <summary>
         /// Scan consistency for the query.
         /// </summary>
         public QueryScanConsistency ScanConsistency { get; set; }
+
+        /// <summary>
+        /// Time to wait for index scan.
+        /// </summary>
+        public TimeSpan? ScanWait { get; }
 
         /// <inheritdoc />
         public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
@@ -34,7 +41,7 @@ namespace Couchbase.Linq.Clauses
         /// <inheritdoc />
         public IBodyClause Clone(CloneContext cloneContext)
         {
-            return new ScanConsistencyClause(ScanConsistency);
+            return new ScanConsistencyClause(ScanConsistency, ScanWait);
         }
 
         /// <inheritdoc />

--- a/Src/Couchbase.Linq/Clauses/ScanConsistencyExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/ScanConsistencyExpressionNode.cs
@@ -14,15 +14,20 @@ namespace Couchbase.Linq.Clauses
     /// </summary>
     internal class ScanConsistencyExpressionNode : MethodCallExpressionNodeBase
     {
-        public static IEnumerable<MethodInfo> GetSupportedMethods() =>
-            new[] {QueryExtensionMethods.ScanConsistency};
+        public static IEnumerable<MethodInfo> GetSupportedMethods() => new[]
+        {
+            QueryExtensionMethods.ScanConsistency,
+            QueryExtensionMethods.ScanConsistencyWithScanWait
+        };
 
         /// <summary>
         /// Creates a new ScanConsistencyExpressionNode.
         /// </summary>
         /// <param name="parseInfo">Method parse info.</param>
         /// <param name="scanConsistency">Scan consistency for the query.</param>
-        public ScanConsistencyExpressionNode(MethodCallExpressionParseInfo parseInfo, ConstantExpression scanConsistency)
+        /// <param name="scanWait">Time to wait for index scan.</param>
+        public ScanConsistencyExpressionNode(MethodCallExpressionParseInfo parseInfo, ConstantExpression scanConsistency,
+            ConstantExpression scanWait)
             : base(parseInfo)
         {
             if (scanConsistency == null)
@@ -33,14 +38,24 @@ namespace Couchbase.Linq.Clauses
             {
                 throw new ArgumentException($"{nameof(scanConsistency)} must return a {typeof(QueryScanConsistency)}", nameof(scanConsistency));
             }
+            if (scanWait != null && scanWait.Type != typeof(TimeSpan))
+            {
+                throw new ArgumentException($"{nameof(scanWait)} must return a {typeof(TimeSpan)}", nameof(scanWait));
+            }
 
             ScanConsistency = scanConsistency;
+            ScanWait = scanWait;
         }
 
         /// <summary>
         /// Scan consistency for the query.
         /// </summary>
         public ConstantExpression ScanConsistency { get; }
+
+        /// <summary>
+        /// Time to wait for index scan.
+        /// </summary>
+        public ConstantExpression ScanWait { get; }
 
         /// <inheritdoc />
         public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
@@ -53,7 +68,9 @@ namespace Couchbase.Linq.Clauses
         protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
             ClauseGenerationContext clauseGenerationContext)
         {
-            queryModel.BodyClauses.Add(new ScanConsistencyClause((QueryScanConsistency) ScanConsistency.Value));
+            queryModel.BodyClauses.Add(new ScanConsistencyClause(
+                (QueryScanConsistency) ScanConsistency.Value,
+                (TimeSpan?) ScanWait?.Value));
         }
     }
 }

--- a/Src/Couchbase.Linq/Execution/ClusterQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/ClusterQueryExecutor.cs
@@ -58,6 +58,11 @@ namespace Couchbase.Linq.Execution
                 {
                     case ScanConsistencyClause scanConsistency:
                         queryOptions.ScanConsistency(scanConsistency.ScanConsistency);
+
+                        if (scanConsistency.ScanWait != null)
+                        {
+                            queryOptions.ScanWait(scanConsistency.ScanWait.Value);
+                        }
                         break;
 
                     case ConsistentWithClause consistentWith:

--- a/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensionMethods.cs
@@ -48,6 +48,7 @@ namespace Couchbase.Linq.Extensions
         public static MethodInfo UseHash { get; }
 
         public static MethodInfo ScanConsistency { get; }
+        public static MethodInfo ScanConsistencyWithScanWait { get; }
         public static MethodInfo ConsistentWith { get; }
         public static MethodInfo ConsistentWithScanWait { get; }
 
@@ -119,7 +120,10 @@ namespace Couchbase.Linq.Extensions
             UseIndexWithType = allMethods.Single(p => p.Name == nameof(QueryExtensions.UseIndex) && p.GetParameters().Length == 3);
             UseHash = allMethods.Single(p => p.Name == nameof(QueryExtensions.UseHash));
 
-            ScanConsistency = allMethods.Single(p => p.Name == nameof(QueryExtensions.ScanConsistency));
+            ScanConsistency = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.ScanConsistency) && p.GetParameters().Length == 2);
+            ScanConsistencyWithScanWait = allMethods.Single(p =>
+                p.Name == nameof(QueryExtensions.ScanConsistency) && p.GetParameters().Length == 3);
             ConsistentWith = allMethods.Single(p =>
                 p.Name == nameof(QueryExtensions.ConsistentWith) && p.GetParameters().Length == 2);
             ConsistentWithScanWait = allMethods.Single(p =>

--- a/Src/Couchbase.Linq/Extensions/QueryExtensions.Consistency.cs
+++ b/Src/Couchbase.Linq/Extensions/QueryExtensions.Consistency.cs
@@ -28,6 +28,28 @@ namespace Couchbase.Linq.Extensions
         }
 
         /// <summary>
+        /// Specifies the consistency guarantee/constraint for index scanning.
+        /// </summary>
+        /// <param name="source">Sets scan consistency for this query.  Must be a Couchbase LINQ query.</param>
+        /// <param name="scanConsistency">Specify the consistency guarantee/constraint for index scanning.</param>
+        /// <param name="scanWait">Time to wait for index scan.</param>
+        /// <remarks>The default is <see cref="QueryScanConsistency.NotBounded"/>.</remarks>
+        public static IQueryable<T> ScanConsistency<T>(this IQueryable<T> source, QueryScanConsistency scanConsistency, TimeSpan scanWait)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return source.Provider.CreateQuery<T>(
+                Expression.Call(
+                    QueryExtensionMethods.ScanConsistencyWithScanWait.MakeGenericMethod(typeof(T)),
+                    source.Expression,
+                    Expression.Constant(scanConsistency),
+                    Expression.Constant(scanWait)));
+        }
+
+        /// <summary>
         /// Requires that the indexes but up to date with a <see cref="MutationState"/> before the query is executed.
         /// </summary>
         /// <param name="source">Sets consistency requirement for this query.  Must be a Couchbase LINQ query.</param>


### PR DESCRIPTION
Motivation
----------
When using ScanConsistency allow the consumer to specify a scan wait
limit.

Modifications
-------------
Add overload of ScanConsistency that accepts a scan wait TimeSpan, and
pass down through the expression node and clause. Apply this value
in ClusterQueryExecutor to the QueryOptions.

Results
-------
Scan wait can be controlled for queries performing with RequestPlus
consistency using ScanConsistency.

Close #308