### PR TITLE
Move DocumentFilterManager into cluster DI container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,75 @@
-Linq2Couchbase
-==================
+# Linq2Couchbase
 
 [![Join the chat at https://gitter.im/couchbaselabs/Linq2Couchbase](https://badges.gitter.im/couchbaselabs/Linq2Couchbase.svg)](https://gitter.im/couchbaselabs/Linq2Couchbase?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build status](https://ci.appveyor.com/api/projects/status/urml45drbj7781it?svg=true)](https://ci.appveyor.com/project/Couchbase/linq2couchbase)
+![.NET Core](https://github.com/couchbaselabs/Linq2Couchbase/workflows/.NET%20Core/badge.svg)
 
 The official Language Integrated Query (LINQ) provider for querying Couchbase Server with [N1QL](https://docs.couchbase.com/server/current/n1ql/n1ql-intro/queriesandresults.html) using the Couchbase .NET SDK. The goal of Linq2Couchbase is to create a lightweight ORM/ODM for querying Couchbase Buckets using LINQ as the lingua-franca between your application and Couchbase Server using N1QL, a SQL-like query language for JSON documents. It also provides a write API for performing CRUD operations on JSON documents.
 
 While not an officially supported Couchbase project, this repo is actively maintained and monitored. If you happen to find a bug or have any questions, please either create an [issue](https://github.com/couchbaselabs/linq2couchbase/issues) or make a post on [forums.couchbase.com](https://forums.couchbase.com/c/net-sdk). Additionally, we actively accept contributions!
 
-## Getting started ##
+> :info: This documentation is for Linq2Couchbase 2.x, compatible with Couchbase SDK 3.x. For documentation on
+> Linq2Couchbase 1.x compatible with Couchbase SDK 2.x, see [the release14 branch](https://github.com/couchbaselabs/Linq2Couchbase/blob/release14/README.md).
+
+## Getting started
+
 The Linq2Couchbase project has the following dependencies:
 
 - Couchbase Server 4.0 or greater with the query service enabled on at least one node
-- Couchbase .NET SDK 2.3.10 or greater
-- Common.Logging 3.3.1 or greater
-- Common.Logging.Core 3.3.1 or greater
-- Newtonsoft JSON 9.0.1 or greater
-- re-linq 2.1.1
+- Couchbase .NET SDK 3.0.3 or greater
 
-If you are using NuGet, then the dependencies (other than Couchbase Server) will be installed for you via the package manager.
+### Installing Couchbase Server
 
-### Installing Couchbase Server ###
 For a single instance of Couchbase Server running on localhost, you can [download Couchbase Server here](https://www.couchbase.com/downloads) (make sure it's 4.0 or later). If you would like to create a cluster, the easiest way is by using the [Vagrant scripts for provisioning clusters](https://github.com/couchbaselabs/vagrants). Additionally, you can use [Docker scripts](https://hub.docker.com/r/couchbase/server/). Follow the directions on each respective link for installation information.
 
-### Installing the package using NuGet ###
-Once you have a Couchbase Server instance or cluster setup, open Visual Studio 13 or greater or [MonoDevelop](http://www.monodevelop.com/) and create a .NET or .NET Core application. Open the NuGet Package Manager and search for "Couchbase Linq" or type the following into the Package Manager console:
+### Installing the package using NuGet
+
+Once you have a Couchbase Server instance or cluster setup, open Visual Studio 2019 or greater or [MonoDevelop](http://www.monodevelop.com/) and create a .NET or .NET Core application. Open the NuGet Package Manager and search for "Couchbase Linq" or type the following into the Package Manager console:
 
     Install-Package Linq2Couchbase
 
-NuGet will install the package and all dependencies. Once you have the resolved the dependencies, you will initialize a `ClusterHelper` object which will manage the bucket resources needed by the Linq provider.
+## Quick Start
 
-## Quick Start ##
 This Quick Start assumes that you have [already installed the travel-sample bucket](https://docs.couchbase.com/server/current/manage/manage-settings/install-sample-buckets.html), which is available and built-in to Couchbase Server.
 
 Query the 'travel-sample' bucket and return 10 airlines in any order:
 
-    ClusterHelper.Initialize(new ClientConfiguration
-    {
-         Servers = new List<Uri> {new Uri("http://localhost:8091/")}
-    }, new PasswordAuthenticator("Administrator", "password"));
+```cs
+static async void Main() {
+    var cluster = await Cluster.ConnectAsync("couchbase://localhost", options => {
+        options.UserName = "Administrator";
+        options.Password = "password";
 
-    var context = new BucketContext(ClusterHelper.GetBucket("travel-sample"));
+        options.AddLinq();
+    });
+
+    // Wait until the cluster is bootstrapped
+    await cluster.WaitUntilReadyAsync(TimeSpan.FromSeconds(10));
+
+    var context = new BucketContext(await cluster.BucketAsync("travel-sample"));
     var query = (from a in context.Query<AirLine>()
-			     where a.Country == "United Kingdom"
-			     select a).
-			     Take(10);
+                where a.Country == "United Kingdom"
+                select a)
+                .Take(10);
 
-    query.ToList().ForEach(Console.WriteLine);
-    ClusterHelper.Close();
+    await foreach (var airline in query.ToAsyncEnumerable())
+    {
+        Console.WriteLine(airline.Name);
+    }
+}
+```
 
 Upon running this query, you should expect console output similar to:
 
-```
+```json
 {"Id":"10642","Type":"airline","Name":"Jc royal.britannica","Iata":null,"Icao":"JRB","Callsign":null,"Country":"United Kingdom"}
 {"Id":"112","Type":"airline","Name":"Astraeus","Iata":"5W","Icao":"AEU","Callsign":"FLYSTAR","Country":"United Kingdom"}
 ...
 {"Id":"16881","Type":"airline","Name":"Air Cudlua","Iata":null,"Icao":"CUD","Callsign":"Cudlua","Country":"United Kingdom"}
-
 ```
 
 [Full code example](https://gist.github.com/jeffrymorris/c3bf85d73a1e7dfcc5f25f4e581d689a "Linq2Couchbase quick start!"), including `AirLine` class definition.
 
-
-
-## Developer Guide ##
+## Developer Guide
 
 - [The BucketContext: how to use with ASP.NET and Owin/Katana applications](docs/bucket-context.md)
 - [Mapping JSON fields to POCO properties](docs/poco-mapping.md)
@@ -92,13 +98,14 @@ Upon running this query, you should expect console output similar to:
 - [Using Read Your Own Write (RYOW) Consistency](docs/ryow.md)
 - [Change Tracking (Experimental Developer Preview)](docs/change-tracking.md)
 
-## Building From Source ##
+## Building From Source
 
 Linq2Couchbase uses the NuGet package manager for handling dependencies.  To build from the source, simply clone the GitHub repository and build in Visual Studio.  The NuGet package manager should download all required dependencies.
 
-## Project management ##
+## Project management
 
 In the [Jira project for Linq2Couchbase](http://issues.couchbase.com/browse/LINQ), you can file bugs, propose features or get an idea for the roadmap there. There is also a [list of supported and proposed N1QL features for Linq2Couchbase](https://docs.google.com/document/d/1hPNZ-qTKpVzQsFwg_1uUueltzNL1wA75L5F-hYF92Cw/edit?usp=sharing).
 
-## Contributors ##
+## Contributors
+
 Linq2Couchbase is an open source project and community contributions are welcome whether they be pull-requests, feedback or filing bug tickets or feature requests. We appreciate any contribution no matter how big or small! If you do decide to contribute, please browse the Jira project and ensure that that feature or issue hasn't already been documented. If you want to work on a feature, bug or whatever please create or select a ticket and set the status to "in-progress".

--- a/Src/Couchbase.Linq.IntegrationTests/BeerSample.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/BeerSample.cs
@@ -3,6 +3,7 @@ using Couchbase.KeyValue;
 using Couchbase.Linq.Filters;
 
 using Couchbase.Linq.IntegrationTests.Documents;
+using Couchbase.Linq.Utils;
 
 namespace Couchbase.Linq.IntegrationTests
 {
@@ -21,7 +22,8 @@ namespace Couchbase.Linq.IntegrationTests
             //Two ways of applying a filter are included in this example.
             //This is by implementing IDocumentFilter and then adding explicitly.
             //adding it to the DocumentFilterManager
-            DocumentFilterManager.SetFilter(new BreweryFilter());
+
+            bucket.Cluster.ClusterServices.GetRequiredService<DocumentFilterManager>().SetFilter(new BreweryFilter());
         }
 
         public IQueryable<BeerFiltered> Beers

--- a/Src/Couchbase.Linq.IntegrationTests/TestConfigurations.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/TestConfigurations.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.Configuration;
 
 namespace Couchbase.Linq.IntegrationTests
@@ -6,17 +7,19 @@ namespace Couchbase.Linq.IntegrationTests
     {
         private static IConfigurationRoot _jsonConfiguration;
 
-        public static ClusterOptions DefaultConfig()
+        public static ClusterOptions DefaultConfig(Action<CouchbaseLinqConfiguration> setupAction = null)
         {
-            return DefaultLocalhostConfig();
+            return DefaultLocalhostConfig(setupAction);
         }
 
-        private static ClusterOptions DefaultLocalhostConfig()
+        private static ClusterOptions DefaultLocalhostConfig(Action<CouchbaseLinqConfiguration> setupAction = null)
         {
             EnsureConfigurationLoaded();
 
             var options = new ClusterOptions();
             _jsonConfiguration.GetSection("couchbase").Bind(options);
+
+            options.AddLinq(setupAction);
 
             return options;
         }

--- a/Src/Couchbase.Linq.UnitTests/BeerSample.cs
+++ b/Src/Couchbase.Linq.UnitTests/BeerSample.cs
@@ -3,6 +3,7 @@ using Couchbase.KeyValue;
 using Couchbase.Linq.Filters;
 
 using Couchbase.Linq.UnitTests.Documents;
+using Couchbase.Linq.Utils;
 
 namespace Couchbase.Linq.UnitTests
 {
@@ -16,7 +17,7 @@ namespace Couchbase.Linq.UnitTests
             //Two ways of applying a filter are included in this example.
             //This is by implementing IDocumentFilter and then adding explicitly.
             //adding it to the DocumentFilterManager
-            DocumentFilterManager.SetFilter(new BreweryFilter());
+            bucket.Cluster.ClusterServices.GetRequiredService<DocumentFilterManager>().SetFilter(new BreweryFilter());
         }
 
         public IQueryable<BeerFiltered> Beers

--- a/Src/Couchbase.Linq.UnitTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/BucketContextTests.cs
@@ -7,15 +7,23 @@ using NUnit.Framework;
 namespace Couchbase.Linq.UnitTests
 {
     [TestFixture]
-    public class CollectionContextTests : N1QLTestBase
+    public class BucketContextTests : N1QLTestBase
     {
         [Test]
         public void Can_Get_The_Bucket_The_Context_Was_Created_With()
         {
-            var bucket = new Mock<IBucket>();
-            var context = new BucketContext(bucket.Object);
+            var mockCluster = new Mock<ICluster>();
+            mockCluster
+                .Setup(p => p.ClusterServices)
+                .Returns(ServiceProvider);
 
-            Assert.AreSame(bucket.Object, context.Bucket);
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+            mockBucket.SetupGet(e => e.Cluster).Returns(mockCluster.Object);
+
+            var context = new BucketContext(mockBucket.Object);
+
+            Assert.AreSame(mockBucket.Object, context.Bucket);
         }
 
         [Test]

--- a/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
@@ -5,6 +5,7 @@ using Couchbase.Core.IO.Serializers;
 using Couchbase.Core.Version;
 using Couchbase.KeyValue;
 using Couchbase.Linq.Execution;
+using Couchbase.Linq.Filters;
 using Couchbase.Linq.QueryGeneration;
 using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
 using Microsoft.Extensions.DependencyInjection;
@@ -48,6 +49,7 @@ namespace Couchbase.Linq.UnitTests
 
             var services = new ServiceCollection();
 
+            services.AddSingleton(new DocumentFilterManager());
             services.AddSingleton<ITypeSerializer>(serializer);
             services.AddLogging();
             services.AddSingleton(Mock.Of<IClusterVersionProvider>());

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="3.0.2" />
+    <PackageReference Include="CouchbaseNetClient" Version="3.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
   </ItemGroup>

--- a/Src/Couchbase.Linq/CouchbaseLinqConfiguration.cs
+++ b/Src/Couchbase.Linq/CouchbaseLinqConfiguration.cs
@@ -1,0 +1,22 @@
+﻿using Couchbase.Linq.Filters;
+
+#nullable enable
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Configuration for Linq2Couchbase.
+    /// </summary>
+    /// <remarks>
+    /// Can be configured during calls to <see cref="LinqClusterOptionsExtensions.AddLinq(ClusterOptions)"/>.
+    /// </remarks>
+    public class CouchbaseLinqConfiguration
+    {
+        /// <summary>
+        /// A <see cref="DocumentFilterManager"/> which registers various extensions that control how
+        /// POCOs are filtered from the bucket. By default, POCOs are inspected for <see cref="DocumentFilterAttribute"/>
+        /// attributes, such as the <see cref="DocumentTypeFilterAttribute"/>.
+        /// </summary>
+        public DocumentFilterManager DocumentFilterManager { get; } = new DocumentFilterManager();
+    }
+}

--- a/Src/Couchbase.Linq/Filters/AttributeDocumentFilterSetGenerator.cs
+++ b/Src/Couchbase.Linq/Filters/AttributeDocumentFilterSetGenerator.cs
@@ -1,31 +1,26 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
+
+#nullable enable
 
 namespace Couchbase.Linq.Filters
 {
     /// <summary>
-    /// Generates an <see cref="DocumentFilterSet{T}">DocumentFilterSet</see> for a particular type, using <see cref="DocumentFilterAttribute">DocumentFilterAttributes</see>
+    /// Generates a <see cref="DocumentFilterSet{T}" /> for a particular type, using <see cref="DocumentFilterAttribute" />.
     /// </summary>
     public class AttributeDocumentFilterSetGenerator : IDocumentFilterSetGenerator
     {
-
         /// <summary>
-        /// Generates an <see cref="DocumentFilterSet{T}">DocumentFilterSet</see> for a particular type, using <see cref="DocumentFilterAttribute">DocumentFilterAttribute</see>s
+        /// Generates a <see cref="DocumentFilterSet{T}" /> for a particular type, using <see cref="DocumentFilterAttribute" />.
         /// </summary>
-        /// <returns>Returns null if there are no filters.  This is to improve efficieny.</returns>
-        public DocumentFilterSet<T> GenerateDocumentFilterSet<T>()
+        /// <returns>Returns null if there are no filters. This is to improve efficiency.</returns>
+        public DocumentFilterSet<T>? GenerateDocumentFilterSet<T>()
         {
-            var filters = (DocumentFilterAttribute[])typeof(T).GetTypeInfo().GetCustomAttributes(typeof (DocumentFilterAttribute), true);
+            var filters = typeof(T).GetTypeInfo().GetCustomAttributes<DocumentFilterAttribute>(true).ToArray();
 
-            if (filters.Length == 0)
-            {
-                return null;
-            }
-            else 
-            {
-                return new DocumentFilterSet<T>(filters.Select(p => p.GetFilter<T>()));
-            }
+            return filters.Length > 0
+                ? new DocumentFilterSet<T>(filters.Select(p => p.CreateFilter<T>()))
+                : null;
         }
 
     }

--- a/Src/Couchbase.Linq/Filters/DocumentFilterAttribute.cs
+++ b/Src/Couchbase.Linq/Filters/DocumentFilterAttribute.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 
+#nullable enable
+
 namespace Couchbase.Linq.Filters
 {
     /// <summary>
-    /// Abstract base class for attribute-based <see cref="IDocumentFilter{T}">IDocumentFilter</see> implementations
+    /// Abstract base class for attribute-based <see cref="IDocumentFilter{T}" /> implementations.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public abstract class DocumentFilterAttribute : Attribute
@@ -18,7 +20,6 @@ namespace Couchbase.Linq.Filters
         /// </summary>
         /// <typeparam name="T">Type of the document being filtered.</typeparam>
         /// <returns>The <see cref="IDocumentFilter{T}"/> to be applied by this attribute.</returns>
-        public abstract IDocumentFilter<T> GetFilter<T>();
-
+        public abstract IDocumentFilter<T> CreateFilter<T>();
     }
 }

--- a/Src/Couchbase.Linq/Filters/DocumentFilterManager.cs
+++ b/Src/Couchbase.Linq/Filters/DocumentFilterManager.cs
@@ -1,122 +1,92 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
+
+#nullable enable
 
 namespace Couchbase.Linq.Filters
 {
     /// <summary>
-    /// Static class to cache and execute <see cref="IDocumentFilter{T}">IDocumentFilter</see> objects based on the type being queried
+    /// Caches and execute <see cref="IDocumentFilter{T}">IDocumentFilter</see> objects based on the type being queried.
+    /// This class is thread-safe.
     /// </summary>
     public class DocumentFilterManager
     {
-
         /// <summary>
         /// Stores currently loaded filters.
         /// </summary>
         /// <remarks>
-        /// Any type which has no filters will be in the dictionary, with a value of null.  This will prevent another attempt
-        /// to generate the default <see cref="DocumentFilterSet{T}">DocumentFilterSet</see> each time it is requested.
+        /// Any type which has no filters will be in the dictionary, with a value of null. This will prevent another attempt
+        /// to generate the default <see cref="DocumentFilterSet{T}" /> each time it is requested.
         /// </remarks>
-        private static readonly Dictionary<Type, object> Filters = new Dictionary<Type, object>();
+        private readonly ConcurrentDictionary<Type, object?> _filters = new ConcurrentDictionary<Type, object?>();
 
-        private static IDocumentFilterSetGenerator _filterSetGenerator = new AttributeDocumentFilterSetGenerator();
+        private IDocumentFilterSetGenerator _filterSetGenerator = new AttributeDocumentFilterSetGenerator();
+
         /// <summary>
-        /// Generates the <see cref="DocumentFilterSet{T}">DocumentFilterSet</see> for a type if no filters have been previously loaded
+        /// Generates the <see cref="DocumentFilterSet{T}">DocumentFilterSet</see> for a type if no filters have been previously loaded.
         /// </summary>
-        /// <remarks>By default, uses an <see cref="AttributeDocumentFilterSetGenerator">AttributeDocumentFeatureSetGenerator</see></remarks>
-        public static IDocumentFilterSetGenerator FilterSetGenerator
+        /// <remarks>By default, uses an <see cref="AttributeDocumentFilterSetGenerator" />.</remarks>
+        public IDocumentFilterSetGenerator FilterSetGenerator
         {
-            get { return _filterSetGenerator; }
-            set
-            {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
-
-                _filterSetGenerator = value;
-            }
+            get => _filterSetGenerator;
+            set => _filterSetGenerator = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>
-        /// Returns the filter set for a type, creating a new filters set using the <see cref="FilterSetGenerator">FilterSetGenerator</see> if there is no key in the Filters dictionary.
+        /// Returns the filter set for a type, creating a new filters set using the <see cref="DocumentFilterManager.FilterSetGenerator" />
+        /// if there is no key in the Filters dictionary.
         /// </summary>
         /// <returns>Returns null if there are no filters defined for this type</returns>
-        public static DocumentFilterSet<T> GetFilterSet<T>()
+        public DocumentFilterSet<T>? GetFilterSet<T>()
         {
-            object filterSet;
-            lock (Filters)
-            {
-                if (!Filters.TryGetValue(typeof(T), out filterSet))
-                {
-                    filterSet = FilterSetGenerator.GenerateDocumentFilterSet<T>();
-                    Filters.Add(typeof(T), filterSet);
-                }
-            }
-
-            return (DocumentFilterSet<T>)filterSet;
+            return (DocumentFilterSet<T>?) _filters.GetOrAdd(typeof(T),
+                key => FilterSetGenerator.GenerateDocumentFilterSet<T>());
         }
 
         /// <summary>
         /// Add or change filter, replacing the entire filter set if present
         /// </summary>
-        public static void SetFilter<T>(IDocumentFilter<T> filter)
+        public void SetFilter<T>(IDocumentFilter<T> filter)
         {
             if (filter == null)
             {
-                throw new ArgumentNullException("filter");
+                throw new ArgumentNullException(nameof(filter));
             }
 
-            lock (Filters)
-            {
-                Filters[typeof(T)] = new DocumentFilterSet<T>(filter);
-            }
+            SetFilterSet(new DocumentFilterSet<T>(filter));
         }
 
         /// <summary>
-        /// Add or change a filter set
+        /// Add or change a filter set.
         /// </summary>
-        public static void SetFilterSet<T>(DocumentFilterSet<T> filterSet)
+        public void SetFilterSet<T>(DocumentFilterSet<T> filterSet)
         {
-            if (filterSet == null)
-            {
-                throw new ArgumentNullException("filterSet");
-            }
-
-            lock (Filters)
-            {
-                Filters[typeof(T)] = filterSet;
-            }
+            _filters[typeof(T)] = filterSet ?? throw new ArgumentNullException(nameof(filterSet));
         }
 
         /// <summary>
         /// Remove a filter set.
         /// </summary>
-        public static void RemoveFilterSet<T>()
-        {
 
-            lock (Filters)
-            {
-                Filters[typeof(T)] = null;
-            }
+        public void RemoveFilterSet<T>()
+        {
+            _filters[typeof(T)] = null;
         }
 
         /// <summary>
         /// Clear all filter sets.
         /// </summary>
-        /// <remarks>Will cause future requests to be regenerated using the <see cref="FilterSetGenerator">FilterSetGenerator</see>.</remarks>
-        public static void Clear()
+        /// <remarks>Will cause future requests to be regenerated using the <see cref="DocumentFilterManager.FilterSetGenerator" />.</remarks>
+        public void Clear()
         {
-            lock (Filters)
-            {
-                Filters.Clear();
-            }
+            _filters.Clear();
         }
 
         /// <summary>
-        /// Apply filters to a LINQ query
+        /// Apply filters to a LINQ query.
         /// </summary>
-        public static IQueryable<T> ApplyFilters<T>(IQueryable<T> source)
+        public IQueryable<T> ApplyFilters<T>(IQueryable<T> source)
         {
             var filterSet = GetFilterSet<T>();
 
@@ -129,6 +99,5 @@ namespace Couchbase.Linq.Filters
                 return source;
             }
         }
-
     }
 }

--- a/Src/Couchbase.Linq/Filters/DocumentFilterSet.cs
+++ b/Src/Couchbase.Linq/Filters/DocumentFilterSet.cs
@@ -1,48 +1,55 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace Couchbase.Linq.Filters
 {
     /// <summary>
-    /// Stores a list of <see cref="IDocumentFilter{T}">IDocumentFilter</see>s, sorted by Priority
+    /// Stores a list of <see cref="IDocumentFilter{T}"/>, sorted by <see cref="IDocumentFilter{T}.Priority"/>.
     /// </summary>
     /// <remarks>
-    /// Sort order of IDocumentFilters with the same Priority is undefined
+    /// Sort order of filters with the same Priority is undefined. This set is immutable.
     /// </remarks>
-    public class DocumentFilterSet<T> : SortedSet<IDocumentFilter<T>>
+    public class DocumentFilterSet<T> : IEnumerable<IDocumentFilter<T>>
     {
+        private readonly SortedSet<IDocumentFilter<T>> _sortedSet =
+            new SortedSet<IDocumentFilter<T>>(new PriorityComparer());
 
         /// <summary>
-        /// Create an empty DocumentFilterSet
+        /// Create an DocumentFilterSet, filled with a set of filters.
         /// </summary>
-        public DocumentFilterSet() : base(new PriorityComparer())
+        public DocumentFilterSet(IEnumerable<IDocumentFilter<T>> filters)
         {
+            if (filters == null)
+            {
+                throw new ArgumentNullException(nameof(filters));
+            }
+
+            foreach (var filter in filters)
+            {
+                _sortedSet.Add(filter);
+            }
         }
 
         /// <summary>
-        /// Create an DocumentFilterSet, filled with a set of filters
-        /// </summary>
-        public DocumentFilterSet(IEnumerable<IDocumentFilter<T>> filters) : base(filters, new PriorityComparer())
-        {   
-        }
-
-        /// <summary>
-        /// Create an DocumentFilterSet, filled with a set of filters
+        /// Create an DocumentFilterSet, filled with a set of filters.
         /// </summary>
         public DocumentFilterSet(params IDocumentFilter<T>[] filters)
-            : base(filters, new PriorityComparer())
+            : this((IEnumerable<IDocumentFilter<T>>) filters)
         {
         }
 
         /// <summary>
-        /// Apply the filters to a LINQ query, in order
+        /// Apply the filters to a LINQ query, in order.
         /// </summary>
         public IQueryable<T> ApplyFilters(IQueryable<T> source)
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
 
             foreach (var filter in this)
@@ -53,14 +60,16 @@ namespace Couchbase.Linq.Filters
             return source;
         }
 
+        public IEnumerator<IDocumentFilter<T>> GetEnumerator() => _sortedSet.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
         private class PriorityComparer : IComparer<IDocumentFilter<T>>
         {
-
             public int Compare(IDocumentFilter<T> x, IDocumentFilter<T> y)
             {
                 return x.Priority.CompareTo(y.Priority);
             }
-
         }
     }
 }

--- a/Src/Couchbase.Linq/Filters/DocumentTypeFilterAttribute.cs
+++ b/Src/Couchbase.Linq/Filters/DocumentTypeFilterAttribute.cs
@@ -2,31 +2,31 @@
 using System.Linq;
 using System.Linq.Expressions;
 
+#nullable enable
+
 namespace Couchbase.Linq.Filters
 {
     /// <summary>
-    /// When using Linq2Couchbase, automatically filter returned documents by the "type" attribute
+    /// When using Linq2Couchbase, automatically filter returned documents by the "type" attribute.
     /// </summary>
     public class DocumentTypeFilterAttribute : DocumentFilterAttribute
     {
         /// <summary>
-        /// Filter the results to include documents with this string as the "type" attribute
+        /// Filter the results to include documents with this string as the "type" attribute.
         /// </summary>
         public string Type { get; set; }
 
         /// <summary>
-        /// Creates a new DocumentTypeFilterAttribute
+        /// Creates a new DocumentTypeFilterAttribute.
         /// </summary>
-        /// <param name="type">Filter the results to include documents with this string as the "type" attribute</param>
+        /// <param name="type">Filter the results to include documents with this string as the "type" attribute.</param>
         public DocumentTypeFilterAttribute(string type)
         {
-            Type = type;
+            Type = type ?? throw new ArgumentNullException(nameof(type));
         }
 
-        /// <summary>
-        /// Apply the filter to a LINQ query
-        /// </summary>
-        public override IDocumentFilter<T> GetFilter<T>()
+        /// <inheritdoc />
+        public override IDocumentFilter<T> CreateFilter<T>()
         {
             return new WhereFilter<T>
             {
@@ -39,12 +39,16 @@ namespace Couchbase.Linq.Filters
         {
             var parameter = Expression.Parameter(typeof (T), "p");
 
-            return Expression.Lambda<Func<T, bool>>(Expression.Equal(Expression.PropertyOrField(parameter, "type"), Expression.Constant(Type)), parameter);
+            return Expression.Lambda<Func<T, bool>>(
+                Expression.Equal(
+                    Expression.PropertyOrField(parameter, "type"),
+                    Expression.Constant(Type)),
+                parameter);
         }
 
         private class WhereFilter<T> : IDocumentFilter<T>
         {
-            public Expression<Func<T, bool>> WhereExpression { get; set; }
+            public Expression<Func<T, bool>> WhereExpression { get; set; } = null!;
             public int Priority { get; set; }
 
             public IQueryable<T> ApplyFilter(IQueryable<T> source)

--- a/Src/Couchbase.Linq/Filters/IDocumentFilter.cs
+++ b/Src/Couchbase.Linq/Filters/IDocumentFilter.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
 
+#nullable enable
+
 namespace Couchbase.Linq.Filters
 {
     /// <summary>

--- a/Src/Couchbase.Linq/Filters/IDocumentFilterSetGenerator.cs
+++ b/Src/Couchbase.Linq/Filters/IDocumentFilterSetGenerator.cs
@@ -1,18 +1,16 @@
-﻿    using System;
+﻿#nullable enable
 
 namespace Couchbase.Linq.Filters
 {
     /// <summary>
-    /// Generates an <see cref="DocumentFilterSet&lt;T&gt;">DocumentFilterSet</see> for a particular type.
+    /// Generates a <see cref="DocumentFilterSet{T}" /> for a particular type.
     /// </summary>
     public interface IDocumentFilterSetGenerator
     {
-
         /// <summary>
-        /// Generates an <see cref="DocumentFilterSet&lt;T&gt;">DocumentFilterSet</see> for a particular type.
+        /// Generates a <see cref="DocumentFilterSet{T}" /> for a particular type.
         /// </summary>
-        /// <returns>Returns null if there are no filters.  This is to improve efficieny.</returns>
-        DocumentFilterSet<T> GenerateDocumentFilterSet<T>();
-
+        /// <returns>Returns null if there are no filters.  This is to improve efficiency.</returns>
+        DocumentFilterSet<T>? GenerateDocumentFilterSet<T>();
     }
 }

--- a/Src/Couchbase.Linq/LinqClusterOptionsExtensions.cs
+++ b/Src/Couchbase.Linq/LinqClusterOptionsExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+#nullable enable
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// <see cref="ClusterOptions"/> extensions.
+    /// </summary>
+    public static class LinqClusterOptionsExtensions
+    {
+        /// <summary>
+        /// Add Linq2Couchbase support to the cluster.
+        /// </summary>
+        /// <param name="options">Options to extend.</param>
+        /// <returns>The <see cref="ClusterOptions"/> to allow chaining.</returns>
+        public static ClusterOptions AddLinq(this ClusterOptions options) =>
+            options.AddLinq(null);
+
+        /// <summary>
+        /// Add Linq2Couchbase support to the cluster.
+        /// </summary>
+        /// <param name="options">Options to extend.</param>
+        /// <param name="setupAction">Action to apply additional configuration to <see cref="CouchbaseLinqConfiguration"/>.</param>
+        /// <returns>The <see cref="ClusterOptions"/> to allow chaining.</returns>
+        public static ClusterOptions AddLinq(this ClusterOptions options,
+            Action<CouchbaseLinqConfiguration>? setupAction)
+        {
+            var configuration = new CouchbaseLinqConfiguration();
+
+            setupAction?.Invoke(configuration);
+
+            return options
+                .AddClusterService(configuration.DocumentFilterManager);
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
Make the DocumentFilterManager scoped to the cluster instead of a
static singleton. This will better support multiple clusters which may
have different requirements, as well as unit testing injection.

Modifications
-------------
Rewrite DocumentFilterManager to be an instance class instead of a
singleton. Perform some cleanup as well, such as making
DocumentFilterSet truly immutable, using nullable ref types, and fixing
up the XML doc comments.

Create extensions for ClusterOptions that register Linq2Couchbase on the
cluster services and allow extensibility.

Update some of the documentation with a modern example

Results
-------
DocumentFilterManager now lives on the ICluster.ClusterServices for
each cluster, with independent configuration.

To use Linq2Couchbase, AddLinq *must* be called on ClusterOptions prior
to connecting to the cluster.

Relates to #324