### PR TITLE
Move serialization converters to DI

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
@@ -8,6 +8,7 @@ using Couchbase.Linq.Execution;
 using Couchbase.Linq.Filters;
 using Couchbase.Linq.QueryGeneration;
 using Couchbase.Linq.QueryGeneration.MemberNameResolvers;
+using Couchbase.Linq.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -53,6 +54,9 @@ namespace Couchbase.Linq.UnitTests
             services.AddSingleton<ITypeSerializer>(serializer);
             services.AddLogging();
             services.AddSingleton(Mock.Of<IClusterVersionProvider>());
+            services.AddSingleton<ISerializationConverterProvider>(
+                new DefaultSerializationConverterProvider(serializer,
+                    TypeBasedSerializationConverterRegistry.CreateDefaultRegistry()));
 
             ServiceProvider = services.BuildServiceProvider();
         }

--- a/Src/Couchbase.Linq.UnitTests/QueryFactory.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryFactory.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Couchbase.Core.IO.Serializers;
 using Couchbase.Core.Version;
 using Couchbase.KeyValue;
+using Couchbase.Linq.Serialization;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace Couchbase.Linq.UnitTests
@@ -23,6 +21,9 @@ namespace Couchbase.Linq.UnitTests
             services.AddSingleton<ITypeSerializer>(serializer);
             services.AddLogging();
             services.AddSingleton(Mock.Of<IClusterVersionProvider>());
+            services.AddSingleton<ISerializationConverterProvider>(
+                new DefaultSerializationConverterProvider(serializer,
+                    TypeBasedSerializationConverterRegistry.CreateDefaultRegistry()));
 
             var mockCluster = new Mock<ICluster>();
             mockCluster

--- a/Src/Couchbase.Linq.UnitTests/Serialization/DefaultSerializationConverterProviderTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Serialization/DefaultSerializationConverterProviderTests.cs
@@ -14,28 +14,16 @@ namespace Couchbase.Linq.UnitTests.Serialization
     [TestFixture]
     public class DefaultSerializationConverterProviderTests
     {
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            DefaultSerializationConverterProvider.Registry = new TypeBasedSerializationConverterRegistry
-            {
-                { typeof(TestConverter), typeof(TestSerializationConverter)}
-            };
-        }
-
-        [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
-            DefaultSerializationConverterProvider.Registry =
-                TypeBasedSerializationConverterRegistry.CreateDefaultRegistry();
-        }
-
         [Test]
         public void GetSerializationConverter_AppliedToClass_ReturnsConverter()
         {
             // Arrange
 
-            var provider = new DefaultSerializationConverterProvider(new DefaultSerializer());
+            var provider = new DefaultSerializationConverterProvider(new DefaultSerializer(),
+                new TypeBasedSerializationConverterRegistry
+                {
+                    {typeof(TestConverter), typeof(TestSerializationConverter)}
+                });
 
             var member = typeof(ConverterOnSecondaryClass).GetProperty(nameof(ConverterOnSecondaryClass.Secondary));
 
@@ -53,7 +41,11 @@ namespace Couchbase.Linq.UnitTests.Serialization
         {
             // Arrange
 
-            var provider = new DefaultSerializationConverterProvider(new DefaultSerializer());
+            var provider = new DefaultSerializationConverterProvider(new DefaultSerializer(),
+                new TypeBasedSerializationConverterRegistry
+                {
+                    {typeof(TestConverter), typeof(TestSerializationConverter)}
+                });
 
             var member = typeof(ConverterOnProperty).GetProperty(nameof(ConverterOnSecondaryClass.Secondary));
 
@@ -79,7 +71,11 @@ namespace Couchbase.Linq.UnitTests.Serialization
                 }
             };
 
-            var provider = new DefaultSerializationConverterProvider(new DefaultSerializer(settings, settings));
+            var provider = new DefaultSerializationConverterProvider(new DefaultSerializer(settings, settings),
+                new TypeBasedSerializationConverterRegistry
+                {
+                    { typeof(TestConverter), typeof(TestSerializationConverter)}
+                });
 
             var member = typeof(NoConverter).GetProperty(nameof(ConverterOnSecondaryClass.Secondary));
 

--- a/Src/Couchbase.Linq/CouchbaseLinqConfiguration.cs
+++ b/Src/Couchbase.Linq/CouchbaseLinqConfiguration.cs
@@ -1,4 +1,9 @@
-﻿using Couchbase.Linq.Filters;
+﻿using System;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Linq.Filters;
+using Couchbase.Linq.Serialization;
+using Couchbase.Linq.Utils;
+using Newtonsoft.Json;
 
 #nullable enable
 
@@ -12,11 +17,38 @@ namespace Couchbase.Linq
     /// </remarks>
     public class CouchbaseLinqConfiguration
     {
+        public CouchbaseLinqConfiguration()
+        {
+            this.WithJsonNetConverterProvider();
+        }
+
+        /// <summary>
+        /// Factory used to create an <see cref="ISerializationConverterProvider"/> when required.
+        /// </summary>
+        internal Func<IServiceProvider, ISerializationConverterProvider> SerializationConverterProviderFactory
+        {
+            get;
+            private set;
+        } = null!; // Will be set by constructor, override null safety
+
         /// <summary>
         /// A <see cref="DocumentFilterManager"/> which registers various extensions that control how
         /// POCOs are filtered from the bucket. By default, POCOs are inspected for <see cref="DocumentFilterAttribute"/>
         /// attributes, such as the <see cref="DocumentTypeFilterAttribute"/>.
         /// </summary>
         public DocumentFilterManager DocumentFilterManager { get; } = new DocumentFilterManager();
+
+        /// <summary>
+        /// Sets a custom <see cref="ISerializationConverterProvider"/> using a factory method.
+        /// </summary>
+        /// <param name="factory">Factory method to create the <see cref="ISerializationConverterProvider"/>.</param>
+        /// <returns>The configuration for method chaining.</returns>
+        public CouchbaseLinqConfiguration WithSerializationConverterProvider(
+            Func<IServiceProvider, ISerializationConverterProvider> factory)
+        {
+            SerializationConverterProviderFactory = factory ?? throw new ArgumentNullException(nameof(factory));
+
+            return this;
+        }
     }
 }

--- a/Src/Couchbase.Linq/CouchbaseLinqConfigurationExtensions.cs
+++ b/Src/Couchbase.Linq/CouchbaseLinqConfigurationExtensions.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Linq.Serialization;
+using Couchbase.Linq.Utils;
+
+#nullable enable
+
+namespace Couchbase.Linq
+{
+    public static class CouchbaseLinqConfigurationExtensions
+    {
+        /// <summary>
+        /// Sets the default <see cref="ISerializationConverterProvider"/> with a default <see cref="IJsonNetSerializationConverterRegistry"/>.
+        /// </summary>
+        /// <param name="configuration">The configuration to update.</param>
+        /// <returns>The configuration for method chaining.</returns>
+        public static CouchbaseLinqConfiguration WithJsonNetConverterProvider(
+            this CouchbaseLinqConfiguration configuration) =>
+            configuration.WithJsonNetConverterProvider((Action<TypeBasedSerializationConverterRegistry>?) null);
+
+        /// <summary>
+        /// Sets the default <see cref="ISerializationConverterProvider"/>.
+        /// </summary>
+        /// <param name="configuration">The configuration to update.</param>
+        /// <param name="registryConfigurationAction">Action to configure the default registry.</param>
+        /// <returns>The configuration for method chaining.</returns>
+        public static CouchbaseLinqConfiguration WithJsonNetConverterProvider(
+            this CouchbaseLinqConfiguration configuration,
+            Action<TypeBasedSerializationConverterRegistry>? registryConfigurationAction)
+        {
+            return configuration.WithSerializationConverterProvider(serviceProvider =>
+            {
+                var registry = TypeBasedSerializationConverterRegistry.CreateDefaultRegistry();
+
+                registryConfigurationAction?.Invoke(registry);
+
+                return new DefaultSerializationConverterProvider(
+                    serviceProvider.GetRequiredService<ITypeSerializer>(),
+                    registry);
+            });
+        }
+
+        /// <summary>
+        /// Sets the default <see cref="ISerializationConverterProvider"/> with a custom registry.
+        /// </summary>
+        /// <param name="configuration">The configuration to update.</param>
+        /// <param name="registry">The registry to use.</param>
+        /// <returns>The configuration for method chaining.</returns>
+        public static CouchbaseLinqConfiguration WithJsonNetConverterProvider(
+            this CouchbaseLinqConfiguration configuration, IJsonNetSerializationConverterRegistry registry) =>
+            configuration.WithSerializationConverterProvider(
+                serviceProvider => new DefaultSerializationConverterProvider(
+                    serviceProvider.GetRequiredService<ITypeSerializer>(),
+                    registry ?? throw new ArgumentNullException(nameof(registry))));
+
+        /// <summary>
+        /// Sets a custom <see cref="ISerializationConverterProvider"/>.
+        /// </summary>
+        /// <param name="configuration">The configuration to update.</param>
+        /// <param name="serializationConverterProvider">The serialization converter provider to use.</param>
+        /// <returns>The configuration for method chaining.</returns>
+        public static CouchbaseLinqConfiguration WithSerializationConverterProvider(
+            this CouchbaseLinqConfiguration configuration, ISerializationConverterProvider serializationConverterProvider)
+        {
+            if (serializationConverterProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serializationConverterProvider));
+            }
+
+            return configuration.WithSerializationConverterProvider(_ => serializationConverterProvider);
+        }
+    }
+}

--- a/Src/Couchbase.Linq/LinqClusterOptionsExtensions.cs
+++ b/Src/Couchbase.Linq/LinqClusterOptionsExtensions.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Linq.Serialization;
+using Couchbase.Linq.Utils;
 
 #nullable enable
 
@@ -31,7 +34,8 @@ namespace Couchbase.Linq
             setupAction?.Invoke(configuration);
 
             return options
-                .AddClusterService(configuration.DocumentFilterManager);
+                .AddClusterService(configuration.DocumentFilterManager)
+                .AddClusterService<ISerializationConverterProvider, ISerializationConverterProvider>(configuration.SerializationConverterProviderFactory);
         }
     }
 }

--- a/Src/Couchbase.Linq/Serialization/SerializationExpressionTreeProcessor.cs
+++ b/Src/Couchbase.Linq/Serialization/SerializationExpressionTreeProcessor.cs
@@ -26,15 +26,9 @@ namespace Couchbase.Linq.Serialization
         /// </summary>
         /// <param name="cluster">The <see cref="ICluster"/>.</param>
         /// <returns>The <see cref="SerializationExpressionTreeProcessor"/>.</returns>
-        public static SerializationExpressionTreeProcessor FromCluster(ICluster cluster)
-        {
-            var serializer = cluster.ClusterServices.GetRequiredService<ITypeSerializer>();
-
-            // ReSharper disable once SuspiciousTypeConversion.Global
-            return new SerializationExpressionTreeProcessor(
-                serializer as ISerializationConverterProvider ??
-                new DefaultSerializationConverterProvider(serializer));
-        }
+        public static SerializationExpressionTreeProcessor FromCluster(ICluster cluster) =>
+            new SerializationExpressionTreeProcessor(
+                cluster.ClusterServices.GetRequiredService<ISerializationConverterProvider>());
 
         /// <inheritdoc/>
         public Expression Process(Expression expressionTree)

--- a/Src/Couchbase.Linq/Serialization/TypeBasedSerializationConverterRegistry.cs
+++ b/Src/Couchbase.Linq/Serialization/TypeBasedSerializationConverterRegistry.cs
@@ -15,13 +15,6 @@ namespace Couchbase.Linq.Serialization
     public class TypeBasedSerializationConverterRegistry : IJsonNetSerializationConverterRegistry,
         IEnumerable<KeyValuePair<Type, Type>>
     {
-        /// <summary>
-        /// Global instance of <see cref="TypeBasedSerializationConverterRegistry"/> which is used
-        /// by default by <see cref="DefaultSerializationConverterProvider"/>.
-        /// Built-in converters are registered by default.
-        /// </summary>
-        public static TypeBasedSerializationConverterRegistry Global { get; } = CreateDefaultRegistry();
-
         private readonly Dictionary<Type, Type> _registry = new Dictionary<Type, Type>();
 
         /// <summary>

--- a/docs/custom-serializers.md
+++ b/docs/custom-serializers.md
@@ -10,8 +10,12 @@ Here is [an example of how this method was implemented for Newtonsoft's Json.Net
 
 ## Non-standard conversions
 
-Some attributes may have additional decorators applied that change how they are serialized.  To support this, your serializer should implement `ISerializationConverterProvider` (in addition to `IExtendedTypeSerializer`).  This interface can return a custom `ISerializationConverter` for a particular member, altering query generation behavior when this member is used in a N1QL query.
+Some attributes may have additional decorators applied that change how they are serialized. To support this, you should also implement a customer `ISerializationConverterProvider`. This interface can return a custom `ISerializationConverter` for a particular member, altering query generation behavior when this member is used in a N1QL query.
+
+```cs
+services.AddCouchbase(options => {
+    options.AddLinq(linqOptions => linqOptions.WithSerializationConverterProvider(new MyCustomSerializationConverterProvider()));
+})
+```
 
 For more details, see [Serialization Converters](./serialization-converters.md).
-
-For performance reasons, be sure to use a cache in your internal implementation.  The method is called each time a candidate property is encountered.  In a system under load this could be many times per second for the same property.


### PR DESCRIPTION
Motivation
----------
Allow serialization converters to be registered for each cluster instead
of in a global static scope.

Modifications
-------------
Add a hidden DefaultSerializationConverterProvider as internal, and add
a method to inject an alternative via CouchbaseLinqConfiguration.

Also add the IJsonNetSerializationConverterRegistry as a setting to
CouchbaseLinqConfiguration to provide a method to easily inject custom
converters without replacing DefaultSerializationConverterProvider.

Update SerializationExpressionTreeProcessor to get the
ISerizationConverterProvider from DI.

Results
-------
Serialization converters are more easily customizable.

Closes #324