### PR TITLE
Treat a string split as a query source for subqueries

### DIFF
--- a/Src/Couchbase.Linq/Clauses/ArrayGeneratingFunctionExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/ArrayGeneratingFunctionExpressionNode.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Linq.Expressions;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+using Remotion.Linq.Utilities;
+
+namespace Couchbase.Linq.Clauses
+{
+    internal sealed class ArrayGeneratingFunctionExpressionNode : IQuerySourceExpressionNode
+    {
+        private readonly Type _querySourceElementType;
+        public Type QuerySourceElementType => _querySourceElementType;
+
+        public Type QuerySourceType { get; }
+        public Expression ParsedExpression { get; }
+        public string AssociatedIdentifier { get; }
+        public IExpressionNode Source => null;
+
+        public ArrayGeneratingFunctionExpressionNode(MethodCallExpressionParseInfo parseInfo, Expression argument1)
+        {
+            QuerySourceType = parseInfo.ParsedExpression.Type;
+
+            if (!ItemTypeReflectionUtility.TryGetItemTypeOfClosedGenericIEnumerable(parseInfo.ParsedExpression.Type,
+                out _querySourceElementType))
+            {
+                _querySourceElementType = typeof(object);
+            }
+
+            ParsedExpression = parseInfo.ParsedExpression;
+            AssociatedIdentifier = parseInfo.AssociatedIdentifier;
+        }
+
+        public Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            if (inputParameter == null)
+            {
+                throw new ArgumentNullException(nameof(inputParameter));
+            }
+            if (expressionToBeResolved == null)
+            {
+                throw new ArgumentNullException(nameof(expressionToBeResolved));
+            }
+
+            return QuerySourceExpressionNodeUtility.ReplaceParameterWithReference(
+                this,
+                inputParameter,
+                expressionToBeResolved,
+                clauseGenerationContext);
+        }
+
+        public QueryModel Apply(QueryModel queryModel, ClauseGenerationContext clauseGenerationContext)
+        {
+            if (queryModel != null)
+            {
+                throw new ArgumentException(
+                    "QueryModel has to be null because MainSourceExpressionNode marks the start of a query.",
+                    nameof(queryModel));
+            }
+
+            var mainFromClause = CreateMainFromClause(clauseGenerationContext);
+            var defaultSelectClause = new SelectClause(new QuerySourceReferenceExpression(mainFromClause));
+            return new QueryModel (mainFromClause, defaultSelectClause) { ResultTypeOverride = QuerySourceType };
+        }
+
+        private MainFromClause CreateMainFromClause(ClauseGenerationContext clauseGenerationContext)
+        {
+            var fromClause = new MainFromClause (
+                AssociatedIdentifier,
+                QuerySourceElementType,
+                ParsedExpression);
+
+            clauseGenerationContext.AddContextInfo(this, fromClause);
+            return fromClause;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
@@ -10,7 +10,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 {
     internal class StringSplitMethodCallTranslator : IMethodCallTranslator
     {
-        private static readonly MethodInfo[] SupportedMethodsStatic =
+        public static readonly MethodInfo[] SupportedMethodsStatic =
         {
             typeof (string).GetMethod("Split", new[] { typeof (char[]) })
         };

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -171,9 +171,9 @@ namespace Couchbase.Linq.QueryGeneration
                 // This is an Array type subquery, since we're querying against a member not a bucket
                 _queryPartsAggregator.QueryType = N1QlQueryType.Array;
             }
-            else if (fromClause.FromExpression is SubQueryExpression)
+            else if (fromClause.FromExpression is SubQueryExpression subQueryExpression)
             {
-                VisitSubQueryFromClause(fromClause, (SubQueryExpression) fromClause.FromExpression);
+                VisitSubQueryFromClause(fromClause, subQueryExpression);
             }
             else if (fromClause.FromExpression is QuerySourceReferenceExpression querySourceReferenceExpression)
             {
@@ -196,9 +196,9 @@ namespace Couchbase.Linq.QueryGeneration
                     throw new NotSupportedException("From Clause Is Referencing An Invalid Query Source");
                 }
             }
-            else if (fromClause.FromExpression is ConstantExpression)
+            else if (fromClause.FromExpression is ConstantExpression || fromClause.FromExpression is MethodCallExpression)
             {
-                // From clause for this subquery is a constant array
+                // From clause for this subquery is a constant array or a function returning an array
 
                 VisitArrayFromClause(fromClause);
             }

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -1,7 +1,10 @@
-﻿using Couchbase.Linq.Clauses;
+﻿using System.Linq;
+using Couchbase.Linq.Clauses;
 using Couchbase.Linq.Extensions;
 using Couchbase.Linq.Operators;
+using Couchbase.Linq.QueryGeneration;
 using Couchbase.Linq.QueryGeneration.ExpressionTransformers;
+using Couchbase.Linq.QueryGeneration.MethodCallTranslators;
 using Couchbase.Linq.Serialization;
 using Couchbase.Linq.Utils;
 using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
@@ -50,6 +53,9 @@ namespace Couchbase.Linq
             nodeTypeRegistry.Register(AverageAsyncExpressionNode.GetSupportedMethods(), typeof(AverageAsyncExpressionNode));
             nodeTypeRegistry.Register(MinAsyncExpressionNode.GetSupportedMethods(), typeof(MinAsyncExpressionNode));
             nodeTypeRegistry.Register(MaxAsyncExpressionNode.GetSupportedMethods(), typeof(MaxAsyncExpressionNode));
+
+            // register ArrayGeneratingFunctionExpressionNode
+            nodeTypeRegistry.Register(StringSplitMethodCallTranslator.SupportedMethodsStatic, typeof(ArrayGeneratingFunctionExpressionNode));
 
             //This creates all the default node types
             var nodeTypeProvider = ExpressionTreeParser.CreateDefaultNodeTypeProvider();


### PR DESCRIPTION
Motivation
----------
Allow the application of filters like .Any() to the array that results
from a call to String.Split.

Modifications
-------------
Add an IQuerySourceExpressionNode for any call to String.Split so that
it may be treated as the source of an expression, and then handle this
as an array subquery in N1QLQueryModelVisitor.

Results
-------
`.Where(p => p.attr.Split().Any(q => q == 'x')` or similar queries will
now function.

Closes #337