### PR TITLE
Use unix milliseconds when sorting by date/times

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/Documents/Beer.cs
+++ b/Src/Couchbase.Linq.UnitTests/Documents/Beer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using Couchbase.Core.IO.Serializers;
 using Newtonsoft.Json;
 
 namespace Couchbase.Linq.UnitTests.Documents
@@ -42,5 +43,9 @@ namespace Couchbase.Linq.UnitTests.Documents
 
         [JsonProperty("updatedOffset")]
         public virtual DateTimeOffset UpdatedOffset { get; set; }
+
+        [JsonProperty("updatedUnixMillis")]
+        [JsonConverter(typeof(UnixMillisecondsConverter))]
+        public virtual DateTime? UpdatedUnixMillis { get; set; }
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/OrderByClauseTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/OrderByClauseTests.cs
@@ -69,5 +69,149 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
 
             Assert.AreEqual(expected, n1QlQuery);
         }
+
+        #region date/time
+
+        [Test]
+        public void Test_OrderBy_DateTime_Ascending()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .OrderBy(e => e.Updated);
+
+            const string expected = "SELECT RAW `Extent1` FROM `default` as `Extent1` ORDER BY STR_TO_MILLIS(`Extent1`.`updated`) ASC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_OrderBy_DateTime_Descending()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .OrderByDescending(e => e.Updated);
+
+            const string expected = "SELECT RAW `Extent1` FROM `default` as `Extent1` ORDER BY STR_TO_MILLIS(`Extent1`.`updated`) DESC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_ThenBy_DateTime_Ascending()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .OrderBy(e => e.Name)
+                    .ThenBy(e => e.Updated);
+
+            const string expected = "SELECT RAW `Extent1` FROM `default` as `Extent1` ORDER BY `Extent1`.`name` ASC, STR_TO_MILLIS(`Extent1`.`updated`) ASC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_ThenBy_DateTime_Descending()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .OrderBy(e => e.Name)
+                    .ThenByDescending(e => e.Updated);
+
+            const string expected = "SELECT RAW `Extent1` FROM `default` as `Extent1` ORDER BY `Extent1`.`name` ASC, STR_TO_MILLIS(`Extent1`.`updated`) DESC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_OrderBy_DateTimeUnixMillis_Ascending()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .OrderBy(e => e.UpdatedUnixMillis);
+
+            const string expected = "SELECT RAW `Extent1` FROM `default` as `Extent1` ORDER BY `Extent1`.`updatedUnixMillis` ASC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_OrderBy_DateTimeUnixMillis_Descending()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .OrderByDescending(e => e.UpdatedUnixMillis);
+
+            const string expected = "SELECT RAW `Extent1` FROM `default` as `Extent1` ORDER BY `Extent1`.`updatedUnixMillis` DESC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_ThenBy_DateTimeUnixMillis_Ascending()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .OrderBy(e => e.Name)
+                    .ThenBy(e => e.UpdatedUnixMillis);
+
+            const string expected = "SELECT RAW `Extent1` FROM `default` as `Extent1` ORDER BY `Extent1`.`name` ASC, `Extent1`.`updatedUnixMillis` ASC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
+        public void Test_ThenBy_DateTimeUnixMillis_Descending()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Beer>(mockBucket.Object)
+                    .OrderBy(e => e.Name)
+                    .ThenByDescending(e => e.UpdatedUnixMillis);
+
+            const string expected = "SELECT RAW `Extent1` FROM `default` as `Extent1` ORDER BY `Extent1`.`name` ASC, `Extent1`.`updatedUnixMillis` DESC";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        #endregion
     }
 }

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeSortExpressionTransformer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeSortExpressionTransformer.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Linq.Serialization;
+using Couchbase.Linq.Serialization.Converters;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+
+namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
+{
+    /// <summary>
+    /// Converts any DateTime properties being used in OrderBy clauses to Unix milliseconds before sorting them.
+    /// This way the <see cref="MethodCallTranslators.SerializationConverterMethodCallTranslator">SerializationConverterMethodCallTranslator</see>
+    /// will later interpret the calls as STR_TO_MILLIS() calls in N1QL.  N1QL can't accurately sort ISO8601
+    /// date/time values unless they're converted to Unix milliseconds first. It may also be important for efficient index usage.
+    /// </summary>
+    internal class DateTimeSortExpressionTransformer : IExpressionTransformer<MethodCallExpression>
+    {
+        private static readonly UnixMillisecondsSerializationConverter Converter = new UnixMillisecondsSerializationConverter();
+
+        private static readonly HashSet<Type> Types = new HashSet<Type>
+        {
+            typeof(DateTime),
+            typeof(DateTime?),
+            typeof(DateTimeOffset),
+            typeof(DateTimeOffset?)
+        };
+
+        private static readonly HashSet<MethodInfo> Methods = new HashSet<MethodInfo>
+        {
+            typeof(Queryable).GetMethods().Single(p => p.Name == nameof(Queryable.OrderBy) && p.GetParameters().Length == 2),
+            typeof(Queryable).GetMethods().Single(p => p.Name == nameof(Queryable.OrderByDescending) && p.GetParameters().Length == 2),
+            typeof(Queryable).GetMethods().Single(p => p.Name == nameof(Queryable.ThenBy) && p.GetParameters().Length == 2),
+            typeof(Queryable).GetMethods().Single(p => p.Name == nameof(Queryable.ThenByDescending) && p.GetParameters().Length == 2)
+        };
+
+        private static readonly HashSet<MethodInfo> InverseConversionMethods = new HashSet<MethodInfo>(
+            Types.Select(type => typeof(ISerializationConverter<>).MakeGenericType(type)
+                .GetMethod(nameof(ISerializationConverter<DateTime>.ConvertFrom), new[] {type})));
+
+        private static readonly ExpressionType[] StaticSupportedExpressionTypes =
+        {
+            ExpressionType.Call
+        };
+
+        public ExpressionType[] SupportedExpressionTypes => StaticSupportedExpressionTypes;
+
+        public Expression Transform(MethodCallExpression expression)
+        {
+            var method = expression.Method;
+            if (!method.IsGenericMethod || !Methods.Contains(method.GetGenericMethodDefinition()))
+            {
+                // This isn't a sort
+                return expression;
+            }
+
+            var sortArgument = expression.Arguments[1];
+            var newSortArgument = TransformLambda(sortArgument);
+
+            if (sortArgument == newSortArgument)
+            {
+                // No change
+                return expression;
+            }
+
+            return expression.Update(
+                expression.Object,
+                expression.Arguments.Select((p, i) => i == 1 ? newSortArgument : p));
+        }
+
+        private static Expression TransformExpression(Expression expression) =>
+            Converter.GenerateConvertToExpression(expression);
+
+        private static Expression TransformLambda(Expression expression)
+        {
+            UnaryExpression unaryExpression = expression as UnaryExpression;
+
+            var lambdaExpression = unaryExpression != null
+                ? unaryExpression.Operand as LambdaExpression
+                : expression as LambdaExpression;
+
+            if (lambdaExpression == null)
+            {
+                return expression;
+            }
+
+            var sortExpression = lambdaExpression.Body;
+            if (!Types.Contains(sortExpression.Type))
+            {
+                // We're not sorting by a date/time property, so ignore
+                return expression;
+            };
+
+            if (sortExpression.NodeType != ExpressionType.MemberAccess)
+            {
+                // This isn't a simple property access sort. The only time we wrap that is if we're wrapping
+                // an existing inverse conversion. In that case, we'll wrap so that it's converted and then
+                // converted back. This gets translated into a no-op during query generation. We can't drop
+                // the conversions here because otherwise it gets wrapped again on the subsequent visit.
+
+                if (!(sortExpression is MethodCallExpression methodCallExpression) ||
+                    !InverseConversionMethods.Contains(methodCallExpression.Method))
+                {
+                    return expression;
+                }
+            }
+
+            var newBody = TransformExpression(sortExpression);
+            var newLambda = Expression.Lambda(newBody, lambdaExpression.Parameters);
+
+            return unaryExpression?.Update(newLambda) ?? (Expression) newLambda;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/QueryParserHelper.cs
+++ b/Src/Couchbase.Linq/QueryParserHelper.cs
@@ -69,6 +69,7 @@ namespace Couchbase.Linq
 
             //Register transformer to handle DateTime comparisons
             transformerRegistry.Register(new DateTimeComparisonExpressionTransformer());
+            transformerRegistry.Register(new DateTimeSortExpressionTransformer());
 
             return transformerRegistry;
         }


### PR DESCRIPTION
Motivation
----------
Since our comparisons are based on unix milliseconds when comparing
DateTime properties, the same should be true when sorting by DateTime
properties. This is especially important for ensuring that indices
are useful, since the predicate and the order by may both need to
match the index key.

Modifications
-------------
Detect sorting by simple properties on documents which are ISO8601
strings and replace them with a STR_TO_MILLIS call.

Closes #331