### PR TITLE
Support using collections as query extents

### DIFF
--- a/Src/Couchbase.Linq.UnitTests/BucketContextTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/BucketContextTests.cs
@@ -40,12 +40,16 @@ namespace Couchbase.Linq.UnitTests
             mockBucket.SetupGet(e => e.Name).Returns("default");
             mockBucket.SetupGet(e => e.Cluster).Returns(mockCluster.Object);
 
-            var mockCollection = new Mock<ICouchbaseCollection>();
-            mockCollection
-                .SetupGet(p => p.Scope.Bucket)
-                .Returns(() => mockBucket.Object);
+            var mockScope = new Mock<IScope>();
+            mockScope.SetupGet(e => e.Bucket).Returns(mockBucket.Object);
 
+            var mockCollection = new Mock<ICouchbaseCollection>();
+            mockCollection.SetupGet(e => e.Scope).Returns(() => mockScope.Object);
+
+            mockBucket.Setup(e => e.Scope("_default")).Returns(mockScope.Object);
+            mockBucket.Setup(e => e.DefaultScope()).Returns(mockScope.Object);
             mockBucket.Setup(e => e.DefaultCollection()).Returns(mockCollection.Object);
+            mockScope.Setup(e => e.Collection("_default")).Returns(mockCollection.Object);
 
             var ctx = new BucketContext(mockBucket.Object);
 
@@ -74,12 +78,16 @@ namespace Couchbase.Linq.UnitTests
             mockBucket.SetupGet(e => e.Name).Returns("default");
             mockBucket.SetupGet(e => e.Cluster).Returns(mockCluster.Object);
 
-            var mockCollection = new Mock<ICouchbaseCollection>();
-            mockCollection
-                .SetupGet(p => p.Scope.Bucket)
-                .Returns(() => mockBucket.Object);
+            var mockScope = new Mock<IScope>();
+            mockScope.SetupGet(e => e.Bucket).Returns(mockBucket.Object);
 
+            var mockCollection = new Mock<ICouchbaseCollection>();
+            mockCollection.SetupGet(e => e.Scope).Returns(() => mockScope.Object);
+
+            mockBucket.Setup(e => e.Scope("_default")).Returns(mockScope.Object);
+            mockBucket.Setup(e => e.DefaultScope()).Returns(mockScope.Object);
             mockBucket.Setup(e => e.DefaultCollection()).Returns(mockCollection.Object);
+            mockScope.Setup(e => e.Collection("_default")).Returns(mockCollection.Object);
 
             var ctx = new BucketContext(mockBucket.Object);
 
@@ -108,12 +116,16 @@ namespace Couchbase.Linq.UnitTests
             mockBucket.SetupGet(e => e.Name).Returns("default");
             mockBucket.SetupGet(e => e.Cluster).Returns(mockCluster.Object);
 
-            var mockCollection = new Mock<ICouchbaseCollection>();
-            mockCollection
-                .SetupGet(p => p.Scope.Bucket)
-                .Returns(() => mockBucket.Object);
+            var mockScope = new Mock<IScope>();
+            mockScope.SetupGet(e => e.Bucket).Returns(mockBucket.Object);
 
+            var mockCollection = new Mock<ICouchbaseCollection>();
+            mockCollection.SetupGet(e => e.Scope).Returns(() => mockScope.Object);
+
+            mockBucket.Setup(e => e.Scope("_default")).Returns(mockScope.Object);
+            mockBucket.Setup(e => e.DefaultScope()).Returns(mockScope.Object);
             mockBucket.Setup(e => e.DefaultCollection()).Returns(mockCollection.Object);
+            mockScope.Setup(e => e.Collection("_default")).Returns(mockCollection.Object);
 
             var ctx = new BucketContext(mockBucket.Object);
 

--- a/Src/Couchbase.Linq.UnitTests/QueryFactory.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryFactory.cs
@@ -10,9 +10,16 @@ namespace Couchbase.Linq.UnitTests
 {
     internal class QueryFactory
     {
-        public static IQueryable<T> Queryable<T>(IBucket bucket) => Queryable<T>(bucket.Name);
+        public static IQueryable<T> Queryable<T>(IBucket bucket) =>
+            Queryable<T>(bucket.Name, "_default", "_default");
 
-        public static IQueryable<T> Queryable<T>(string bucketName)
+        public static IQueryable<T> Queryable<T>(IBucket bucket, string scopeName, string collectionName) =>
+            Queryable<T>(bucket.Name, scopeName, collectionName);
+
+        public static IQueryable<T> Queryable<T>(string bucketName) =>
+            Queryable<T>(bucketName, "_default", "_default");
+
+        public static IQueryable<T> Queryable<T>(string bucketName, string scopeName, string collectionName)
         {
             var serializer = new DefaultSerializer();
 
@@ -38,6 +45,12 @@ namespace Couchbase.Linq.UnitTests
             mockCollection
                 .SetupGet(p => p.Scope.Bucket)
                 .Returns(mockBucket.Object);
+            mockCollection
+                .SetupGet(p => p.Scope.Name)
+                .Returns(scopeName);
+            mockCollection
+                .SetupGet(p => p.Name)
+                .Returns(collectionName);
 
             return new CollectionQueryable<T>(mockCollection.Object, default);
         }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/N1QlHelpersTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/N1QlHelpersTests.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 using Couchbase.Linq.QueryGeneration;
+using Moq;
 using NUnit.Framework;
 
 // ReSharper disable StringCompareIsCultureSpecific.1
@@ -53,6 +54,46 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
             var result = N1QlHelpers.IsValidKeyword(identifier);
 
             Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void GetCollectionExpression_DefaultCollection_ReturnsJustBucket()
+        {
+            // Arrange
+
+            var collectionQueryable = new Mock<ICollectionQueryable>();
+            collectionQueryable.SetupGet(m => m.BucketName).Returns("default");
+            collectionQueryable.SetupGet(m => m.ScopeName).Returns(N1QlHelpers.DefaultScopeName);
+            collectionQueryable.SetupGet(m => m.CollectionName).Returns(N1QlHelpers.DefaultCollectionName);
+
+            // Act
+
+            var result = N1QlHelpers.GetCollectionExpression(collectionQueryable.Object);
+
+            // Assert
+
+            Assert.AreEqual("`default`", result);
+        }
+
+        [TestCase("scope", "collection")]
+        [TestCase("_default", "collection")]
+        [TestCase("scope", "_default")]
+        public void GetCollectionExpression_NamedCollection_ReturnsFullExpression(string scopeName, string collectionName)
+        {
+            // Arrange
+
+            var collectionQueryable = new Mock<ICollectionQueryable>();
+            collectionQueryable.SetupGet(m => m.BucketName).Returns("default");
+            collectionQueryable.SetupGet(m => m.ScopeName).Returns(scopeName);
+            collectionQueryable.SetupGet(m => m.CollectionName).Returns(collectionName);
+
+            // Act
+
+            var result = N1QlHelpers.GetCollectionExpression(collectionQueryable.Object);
+
+            // Assert
+
+            Assert.AreEqual($"`default`.`{scopeName}`.`{collectionName}`", result);
         }
     }
 }

--- a/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryGeneration/SelectTests.cs
@@ -31,6 +31,23 @@ namespace Couchbase.Linq.UnitTests.QueryGeneration
         }
 
         [Test]
+        public void Test_Select_Collection()
+        {
+            var mockBucket = new Mock<IBucket>();
+            mockBucket.SetupGet(e => e.Name).Returns("default");
+
+            var query =
+                QueryFactory.Queryable<Contact>(mockBucket.Object, "business", "contacts")
+                    .Select(e => new {age = e.Age, name = e.FirstName});
+
+            const string expected = "SELECT `Extent1`.`age` as `age`, `Extent1`.`fname` as `name` FROM `default`.`business`.`contacts` as `Extent1`";
+
+            var n1QlQuery = CreateN1QlQuery(mockBucket.Object, query.Expression);
+
+            Assert.AreEqual(expected, n1QlQuery);
+        }
+
+        [Test]
         public void Test_Select_WithStronglyTypedProjection()
         {
             var mockBucket = new Mock<IBucket>();

--- a/Src/Couchbase.Linq/CollectionQueryable.cs
+++ b/Src/Couchbase.Linq/CollectionQueryable.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using Couchbase.KeyValue;
 using Couchbase.Linq.Execution;
+using Couchbase.Linq.QueryGeneration;
 using Remotion.Linq;
 using Remotion.Linq.Parsing.Structure;
 
@@ -18,11 +19,11 @@ namespace Couchbase.Linq
         private readonly ICouchbaseCollection? _collection;
 
         /// <inheritdoc />
-        public string CollectionName => _collection?.Name ?? "";
+        public string CollectionName => _collection?.Name ?? N1QlHelpers.DefaultCollectionName;
 
 
         /// <inheritdoc />
-        public string ScopeName => _collection?.Scope.Name ?? "";
+        public string ScopeName => _collection?.Scope.Name ?? N1QlHelpers.DefaultScopeName;
 
 
         /// <inheritdoc />

--- a/Src/Couchbase.Linq/QueryGeneration/N1QlHelpers.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QlHelpers.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Couchbase.Linq.Utils;
 
 namespace Couchbase.Linq.QueryGeneration
 {
@@ -11,6 +8,8 @@ namespace Couchbase.Linq.QueryGeneration
     /// </summary>
     internal static class N1QlHelpers
     {
+        public const string DefaultScopeName = "_default";
+        public const string DefaultCollectionName = "_default";
 
         /// <summary>
         ///     Escapes a N1QL identifier using tick (`) characters
@@ -60,6 +59,29 @@ namespace Couchbase.Linq.QueryGeneration
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Formats the bucket name and optionally the scope and collection names into an expression
+        /// for inclusion in a N1QL query. This includes all required escaping.
+        /// </summary>
+        /// <param name="queryable">Collection being queried.</param>
+        /// <returns>The expression string.</returns>
+        public static string GetCollectionExpression(ICollectionQueryable queryable)
+        {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (queryable == null)
+            {
+                ThrowHelpers.ThrowArgumentNullException(nameof(queryable));
+            }
+
+            var bucketName = queryable.BucketName;
+            var scopeName = queryable.ScopeName;
+            var collectionName = queryable.CollectionName;
+
+            return scopeName == DefaultScopeName && collectionName == DefaultCollectionName
+                ? EscapeIdentifier(bucketName)
+                : $"{EscapeIdentifier(queryable.BucketName)}.{EscapeIdentifier(scopeName)}.{EscapeIdentifier(collectionName)}";
         }
     }
 }

--- a/Src/Couchbase.Linq/Utils/ThrowHelpers.cs
+++ b/Src/Couchbase.Linq/Utils/ThrowHelpers.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Couchbase.Linq.Utils
+{
+    internal static class ThrowHelpers
+    {
+        [DoesNotReturn]
+        public static void ThrowArgumentNullException(string paramName) =>
+            throw new ArgumentNullException(paramName);
+    }
+}

--- a/Src/couchbase-net-linq.sln
+++ b/Src/couchbase-net-linq.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31515.178
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{33CA2A25-DD9D-4E05-A786-6FF4DB1C5C3C}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
Motivation
----------
Provide the back-end plumbing for querying against collections.

Modifications
-------------
Implement the query rendering logic that will format a query extent
which is a reference to a collection other than the default collection.

Add supporting unit tests.

Results
-------
This still doesn't add support for scopes/collections because they must
be exposed on the BucketContext. However, it is a key step in that
direction.

Relates to #354