### PR TITLE
Support for scope and collection identification

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -13,14 +13,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core 2.1
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '2.1.807'
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.301'
+    - name: Setup .NET Core 5.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
     - name: Install dependencies
       run: dotnet restore Src/couchbase-net-linq.sln
     - name: Build

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ public class MyController : ControllerBase
 ## Developer Guide
 
 - [The BucketContext: how to use with ASP.NET and Owin/Katana applications](docs/bucket-context.md)
+- [Scopes and Collections](docs/scopes-collections.md)
 - [Mapping JSON fields to POCO properties](docs/poco-mapping.md)
 - [Mapping JSON documents to POCOs with DocumentFilters](docs/document-filters.md)
 - [Controlling output with Select](docs/simple-select.md)

--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,19 +18,11 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="3.2.0" />
+    <PackageReference Include="CouchbaseNetClient" Version="3.2.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
@@ -27,13 +27,6 @@
 
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-
-  <!-- Hack to import Couchbase SDK 3 until next package is published -->
-  <ItemGroup>
-    <Reference Include="Couchbase.NetClient">
-      <HintPath>..\..\..\couchbase-net-client\src\Couchbase\bin\Debug\$(TargetFramework)\Couchbase.NetClient.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>

--- a/Src/Couchbase.Linq.IntegrationTests/Documents/RouteInCollection.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/Documents/RouteInCollection.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Couchbase.Linq.IntegrationTests.Documents
+{
+    [CouchbaseCollection("inventory", "route")]
+    public class RouteInCollection : Route
+    {
+    }
+ }

--- a/Src/Couchbase.Linq.IntegrationTests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/N1QLTestBase.cs
@@ -40,17 +40,19 @@ namespace Couchbase.Linq.IntegrationTests
         /// <summary>
         /// Switches between two different queries depending on support for collections on the current version of Couchbase.
         /// </summary>
-        protected async Task<IQueryable<T>> CollectionSwitch<T, TCollection>(IBucketContext bucketContext)
-            where TCollection : T
+        /// <typeparam name="TBase">Base type to query if collections are not supported.</typeparam>
+        /// <typeparam name="TCollection">Type to query if collections are supported. Should be annotated with <see cref="CouchbaseCollectionAttribute"/>.</typeparam>
+        protected async Task<IQueryable<TBase>> SwitchIfCollectionsSupportedAsync<TBase, TCollection>(IBucketContext bucketContext)
+            where TCollection : TBase
         {
             var versionProvider = TestSetup.Cluster.ClusterServices.GetRequiredService<IClusterVersionProvider>();
             var clusterVersion = await versionProvider.GetVersionAsync() ?? FeatureVersions.DefaultVersion;
             if (clusterVersion.Version < new Version(7, 0, 0))
             {
-                return bucketContext.Query<T>();
+                return bucketContext.Query<TBase>();
             }
 
-            return (IQueryable<T>) bucketContext.Query<TCollection>();
+            return (IQueryable<TBase>) bucketContext.Query<TCollection>();
         }
     }
 }

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -432,7 +432,7 @@ namespace Couchbase.Linq.IntegrationTests
             var context = new BucketContext(_travelSample);
 
             var query =
-                from route in context.Query<Route>()
+                from route in await CollectionSwitch<Route, RouteInCollection>(context)
                 join airport in context.Query<Airport>()
                         .UseIndex("def_faa")
                         .Where(p => p.Type == "airport")
@@ -478,7 +478,7 @@ namespace Couchbase.Linq.IntegrationTests
             var context = new BucketContext(_travelSample);
 
             var query =
-                from route in context.Query<Route>()
+                from route in await CollectionSwitch<Route, RouteInCollection>(context)
                 join airport in context.Query<Airport>()
                         .UseHash(HashHintType.Build)
                         .UseIndex("def_faa")
@@ -675,7 +675,7 @@ namespace Couchbase.Linq.IntegrationTests
         {
             var context = new BucketContext(_travelSample);
 
-            var routes = from route in context.Query<Route>()
+            var routes = from route in await CollectionSwitch<Route, RouteInCollection>(context)
                 join airport in context.Query<Airport>()
                     on route.DestinationAirport equals airport.Faa
                 where (route.Type == "route") && (airport.Type == "airport")
@@ -695,7 +695,7 @@ namespace Couchbase.Linq.IntegrationTests
         {
             var context = new BucketContext(_travelSample);
 
-            var routes = from route in context.Query<Route>().Where(p => p.Type == "route")
+            var routes = from route in (await CollectionSwitch<Route, RouteInCollection>(context)).Where(p => p.Type == "route")
                 join airport in context.Query<Airport>().Where(p => p.Type == "airport")
                     on route.DestinationAirport equals airport.Faa
                 select new { airport.AirportName, route.Airline };
@@ -801,7 +801,7 @@ namespace Couchbase.Linq.IntegrationTests
         {
             var context = new BucketContext(_travelSample);
 
-            var routes = from route in context.Query<Route>()
+            var routes = from route in await CollectionSwitch<Route, RouteInCollection>(context)
                 join airport in context.Query<Airport>()
                     on route.DestinationAirport equals airport.Faa into ra
                 from airport in ra.DefaultIfEmpty()

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -431,8 +431,10 @@ namespace Couchbase.Linq.IntegrationTests
 
             var context = new BucketContext(_travelSample);
 
+            var routeQueryable = await SwitchIfCollectionsSupportedAsync<Route, RouteInCollection>(context);
+
             var query =
-                from route in await CollectionSwitch<Route, RouteInCollection>(context)
+                from route in routeQueryable
                 join airport in context.Query<Airport>()
                         .UseIndex("def_faa")
                         .Where(p => p.Type == "airport")
@@ -477,8 +479,10 @@ namespace Couchbase.Linq.IntegrationTests
         {
             var context = new BucketContext(_travelSample);
 
+            var routeQueryable = await SwitchIfCollectionsSupportedAsync<Route, RouteInCollection>(context);
+
             var query =
-                from route in await CollectionSwitch<Route, RouteInCollection>(context)
+                from route in routeQueryable
                 join airport in context.Query<Airport>()
                         .UseHash(HashHintType.Build)
                         .UseIndex("def_faa")
@@ -675,7 +679,9 @@ namespace Couchbase.Linq.IntegrationTests
         {
             var context = new BucketContext(_travelSample);
 
-            var routes = from route in await CollectionSwitch<Route, RouteInCollection>(context)
+            var routeQueryable = await SwitchIfCollectionsSupportedAsync<Route, RouteInCollection>(context);
+
+            var routes = from route in routeQueryable
                 join airport in context.Query<Airport>()
                     on route.DestinationAirport equals airport.Faa
                 where (route.Type == "route") && (airport.Type == "airport")
@@ -695,7 +701,9 @@ namespace Couchbase.Linq.IntegrationTests
         {
             var context = new BucketContext(_travelSample);
 
-            var routes = from route in (await CollectionSwitch<Route, RouteInCollection>(context)).Where(p => p.Type == "route")
+            var routeQueryable = await SwitchIfCollectionsSupportedAsync<Route, RouteInCollection>(context);
+
+            var routes = from route in routeQueryable.Where(p => p.Type == "route")
                 join airport in context.Query<Airport>().Where(p => p.Type == "airport")
                     on route.DestinationAirport equals airport.Faa
                 select new { airport.AirportName, route.Airline };
@@ -801,7 +809,9 @@ namespace Couchbase.Linq.IntegrationTests
         {
             var context = new BucketContext(_travelSample);
 
-            var routes = from route in await CollectionSwitch<Route, RouteInCollection>(context)
+            var routeQueryable = await SwitchIfCollectionsSupportedAsync<Route, RouteInCollection>(context);
+
+            var routes = from route in routeQueryable
                 join airport in context.Query<Airport>()
                     on route.DestinationAirport equals airport.Faa into ra
                 from airport in ra.DefaultIfEmpty()

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,19 +17,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="3.2.0" />
+    <PackageReference Include="CouchbaseNetClient" Version="3.2.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
@@ -26,13 +26,6 @@
 
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-
-  <!-- Hack to import Couchbase SDK 3 until next package is published -->
-  <ItemGroup>
-    <Reference Include="Couchbase.NetClient">
-      <HintPath>..\..\..\couchbase-net-client\src\Couchbase\bin\Debug\$(TargetFramework)\Couchbase.NetClient.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>

--- a/Src/Couchbase.Linq.UnitTests/Documents/BeerFiltered.cs
+++ b/Src/Couchbase.Linq.UnitTests/Documents/BeerFiltered.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Couchbase.Linq.UnitTests.Documents
 {
-    [Filters.DocumentTypeFilter("beer")]
+    [Couchbase.Linq.Filters.DocumentTypeFilter("beer")]
     public class BeerFiltered
     {
         [JsonProperty("name")]

--- a/Src/Couchbase.Linq.UnitTests/Documents/RouteInCollection.cs
+++ b/Src/Couchbase.Linq.UnitTests/Documents/RouteInCollection.cs
@@ -1,0 +1,153 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Couchbase.Linq.UnitTests.Documents
+{
+    [CouchbaseCollection("inventory", "route")]
+    public class RouteInCollection
+    {
+        public string Id { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("airline")]
+        public string Airline { get; set; }
+
+        [JsonProperty("airlineid")]
+        public string AirlineId { get; set; }
+
+        [JsonProperty("sourceairport")]
+        public string SourceAirport { get; set; }
+
+        [JsonProperty("destinationairport")]
+        public string DestinationAirport { get; set; }
+
+        [JsonProperty("stops")]
+        public uint Stops { get; set; }
+
+        [JsonProperty("equipment")]
+        public string Equipment { get; set; }
+
+        [JsonProperty("schedule")]
+        public List<Schedule> Schedule { get; set; }
+    }
+
+    /*{
+  "id": 5966,
+  "type": "route",
+  "airline": "AA",
+  "airlineid": "airline_24",
+  "sourceairport": "MCO",
+  "destinationairport": "SEA",
+  "stops": 0,
+  "equipment": "737",
+  "schedule": [
+    {
+      "day": 0,
+      "utc": "22:03:00",
+      "flight": "AA138"
+    },
+    {
+      "day": 0,
+      "utc": "17:57:00",
+      "flight": "AA809"
+    },
+    {
+      "day": 1,
+      "utc": "14:29:00",
+      "flight": "AA544"
+    },
+    {
+      "day": 2,
+      "utc": "03:34:00",
+      "flight": "AA188"
+    },
+    {
+      "day": 2,
+      "utc": "13:01:00",
+      "flight": "AA932"
+    },
+    {
+      "day": 2,
+      "utc": "10:14:00",
+      "flight": "AA491"
+    },
+    {
+      "day": 2,
+      "utc": "23:25:00",
+      "flight": "AA819"
+    },
+    {
+      "day": 3,
+      "utc": "14:27:00",
+      "flight": "AA107"
+    },
+    {
+      "day": 3,
+      "utc": "02:40:00",
+      "flight": "AA494"
+    },
+    {
+      "day": 3,
+      "utc": "03:14:00",
+      "flight": "AA768"
+    },
+    {
+      "day": 3,
+      "utc": "01:17:00",
+      "flight": "AA719"
+    },
+    {
+      "day": 3,
+      "utc": "06:00:00",
+      "flight": "AA349"
+    },
+    {
+      "day": 4,
+      "utc": "00:37:00",
+      "flight": "AA096"
+    },
+    {
+      "day": 4,
+      "utc": "19:00:00",
+      "flight": "AA162"
+    },
+    {
+      "day": 5,
+      "utc": "23:57:00",
+      "flight": "AA346"
+    },
+    {
+      "day": 5,
+      "utc": "11:23:00",
+      "flight": "AA871"
+    },
+    {
+      "day": 6,
+      "utc": "15:07:00",
+      "flight": "AA951"
+    },
+    {
+      "day": 6,
+      "utc": "07:02:00",
+      "flight": "AA093"
+    },
+    {
+      "day": 6,
+      "utc": "19:29:00",
+      "flight": "AA558"
+    },
+    {
+      "day": 6,
+      "utc": "21:59:00",
+      "flight": "AA147"
+    },
+    {
+      "day": 6,
+      "utc": "17:13:00",
+      "flight": "AA262"
+    }
+  ]
+}*/
+}

--- a/Src/Couchbase.Linq.UnitTests/Filters/CollectionMetadataCacheTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Filters/CollectionMetadataCacheTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Couchbase.Linq.Filters;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.Filters
+{
+    public class CollectionMetadataCacheTests
+    {
+        [Test]
+        public void GetCollection_Annotated_AnnotationValues()
+        {
+            // Arrange
+
+            var cache = new CollectionMetadataCache();
+
+            // Act
+
+            var (scope, collection) = cache.GetCollection<Annotated>();
+
+            // Assert
+
+            Assert.AreEqual("my_scope", scope);
+            Assert.AreEqual("my_collection", collection);
+        }
+
+        [Test]
+        public void GetCollection_Unannotated_DefaultValues()
+        {
+            // Arrange
+
+            var cache = new CollectionMetadataCache();
+
+            // Act
+
+            var (scope, collection) = cache.GetCollection<Unannotated>();
+
+            // Assert
+
+            Assert.AreEqual("_default", scope);
+            Assert.AreEqual("_default", collection);
+        }
+
+        #region Helpers
+
+        [CouchbaseCollection("my_scope", "my_collection")]
+        public class Annotated
+        {
+        }
+
+        public class Unannotated
+        {
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq/BucketContext.cs
+++ b/Src/Couchbase.Linq/BucketContext.cs
@@ -46,7 +46,9 @@ namespace Couchbase.Linq
         /// <inheritdoc />
         public IQueryable<T> Query<T>(BucketQueryOptions options)
         {
-            IQueryable<T> query = new CollectionQueryable<T>(Bucket.DefaultCollection(), QueryTimeout);
+            var (scope, collection) = CollectionMetadataCache.Instance.GetCollection<T>();
+
+            IQueryable<T> query = new CollectionQueryable<T>(Bucket.Scope(scope).Collection(collection), QueryTimeout);
 
             if ((options & BucketQueryOptions.SuppressFilters) == BucketQueryOptions.None)
             {

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -23,7 +23,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
 
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="3.2.0" />
+    <PackageReference Include="CouchbaseNetClient" Version="3.2.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/Couchbase.Linq/CouchbaseCollectionAttribute.cs
+++ b/Src/Couchbase.Linq/CouchbaseCollectionAttribute.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Couchbase.Linq.QueryGeneration;
+
+#nullable enable
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Annotates a document as belonging to a specific scope/collection. If not present, the default collection is assumed.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class CouchbaseCollectionAttribute : Attribute
+    {
+        internal static CouchbaseCollectionAttribute Default { get; } =
+            new(N1QlHelpers.DefaultScopeName, N1QlHelpers.DefaultCollectionName);
+
+        /// <summary>
+        /// Name of the scope.
+        /// </summary>
+        public string Scope { get; set; }
+
+        /// <summary>
+        /// Name of the collection.
+        /// </summary>
+        public string Collection { get; set; }
+
+        /// <summary>
+        /// Create a new CouchbaseCollectionAttribute.
+        /// </summary>
+        /// <param name="scope">Name of the scope.</param>
+        /// <param name="collection">Name of the collection.</param>
+        public CouchbaseCollectionAttribute(string scope, string collection)
+        {
+            Scope = scope;
+            Collection = collection;
+        }
+
+        /// <summary>
+        /// Deconstruct into variables.
+        /// </summary>
+        /// <param name="scope">Name of the scope.</param>
+        /// <param name="collection">Name of the collection.</param>
+        public void Deconstruct(out string scope, out string collection)
+        {
+            scope = Scope;
+            collection = Collection;
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Filters/CollectionMetadataCache.cs
+++ b/Src/Couchbase.Linq/Filters/CollectionMetadataCache.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace Couchbase.Linq.Filters
+{
+    /// <summary>
+    /// Caches reflection information regarding <see cref="CouchbaseCollectionAttribute"/>.
+    /// </summary>
+    internal class CollectionMetadataCache
+    {
+        public static CollectionMetadataCache Instance { get; } = new();
+
+        private readonly ConcurrentDictionary<Type, CouchbaseCollectionAttribute> _typeCache = new();
+
+        public CouchbaseCollectionAttribute GetCollection<T>() =>
+            GetCollection(typeof(T));
+
+        public CouchbaseCollectionAttribute GetCollection(Type type) =>
+            _typeCache.GetOrAdd(type, static key => key.GetCustomAttribute<CouchbaseCollectionAttribute>()
+                                                    ?? CouchbaseCollectionAttribute.Default);
+    }
+}

--- a/docs/scopes-collections.md
+++ b/docs/scopes-collections.md
@@ -1,0 +1,43 @@
+# Scopes and Collections
+
+Beginning with Couchbase Server 7.0, querying against documents stored in
+[scopes and collections](https://docs.couchbase.com/server/current/learn/data/scopes-and-collections.html)
+is fully supported. Linq2Couchbase 2.0 supports querying against documents
+stored within a non-default collection.
+
+## Default Behavior
+
+The default behavior is to query documents located in the default collection
+(scope "_default" and collection "_default"). Queries against these documents
+are generated in a backward-compatible format that doesn't include the scope
+or collection name. No code changes are necessary to query against these documents.
+
+## Specifying a Collection
+
+To specify a non-default collection, add the `CouchbaseCollection` attribute to your
+POCO.
+
+```cs
+[CouchbaseCollection("my_scope", "my_collection")]
+public class MyDocument
+{
+    // Properties here
+}
+```
+
+Queries for this document will automatically account for the scope and collection,
+including in joins, nests, and subqueries.
+
+## DocumentTypeFilter
+
+For previous versions of Linq2Couchbase, a very common pattern was to apply the
+`DocumentTypeFilter` attribute to POCOs to filter queries based on the `type`
+attribute. This attribute will still work in combination with scopes and collections.
+
+However, with collections it is often unnecessary and removing the attribute may improve
+performance. This is because a collection generally only has a single document type,
+making additional filtering redundant. Therefore, if your collection only has a single
+document type, the recommended practice is to not use `DocumentTypeFilter` attributes.
+
+> :info: Note that you must also remove any `WHERE type = 'x'` predicates from your
+> index definitions.


### PR DESCRIPTION
Motivation
----------
We need a way to annotate that a particular document resides in a
particular collection.

Modifications
-------------
Add the CouchbaseCollectionAttribute which annotates a POCO to indicate
the scope and collection of that POCO. If not present, assume the
document resides on the default collection.

Add tests and documentation.

Results
-------
POCOs controlled by the user may be targeted to a specific collection.
Some additional work is still required to allow extensibility for
overriding or POCOs not within the consumers control.

Relates to #354