### PR TITLE
Add IDocumentSet<T> support to BucketContext

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/BeerSample.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/BeerSample.cs
@@ -26,13 +26,7 @@ namespace Couchbase.Linq.IntegrationTests
             bucket.Cluster.ClusterServices.GetRequiredService<DocumentFilterManager>().SetFilter(new BreweryFilter());
         }
 
-        public IQueryable<BeerFiltered> Beers
-        {
-            //This is an example of adding a filter declaratively by using an atribute
-            //to your document. If you check out BeerFiltered clas you will see the DocumentTypeFilter
-            //has been added to the class definition.
-            get { return Query<BeerFiltered>(); }
-        }
+        public IDocumentSet<BeerFiltered> Beers { get; set; } = null!;
 
         public IQueryable<Brewery> Breweries
         {

--- a/Src/Couchbase.Linq.IntegrationTests/TravelSample.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/TravelSample.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Couchbase.Linq.IntegrationTests.Documents;
+
+namespace Couchbase.Linq.IntegrationTests
+{
+    public class TravelSample : BucketContext
+    {
+        public IDocumentSet<Airline> Airlines { get; set; }
+        public IDocumentSet<RouteInCollection> Routes { get; set; }
+
+        public TravelSample(IBucket bucket)
+            : base(bucket)
+        {
+        }
+    }
+}

--- a/Src/Couchbase.Linq.UnitTests/Metadata/ContextMetadataTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Metadata/ContextMetadataTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Couchbase.Linq.Metadata;
+using Couchbase.Linq.UnitTests.Documents;
+using Moq;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.Metadata
+{
+    public class ContextMetadataTests
+    {
+        #region ctor
+
+        [Test]
+        public void ctor_GetsAllPublicDocumentSets()
+        {
+            // Act
+
+            var result = new ContextMetadata(typeof(TestContext));
+
+            // Assert
+
+            Assert.AreEqual(3, result.Properties.Length);
+        }
+
+        [Test]
+        public void ctor_ValidInitializer()
+        {
+            // Arrange
+
+            var context = new TestContext();
+            var metadata = new ContextMetadata(typeof(TestContext));
+
+            // Act
+
+            metadata.Fill(context);
+
+            // Assert
+
+            Assert.NotNull(context.Beers);
+            Assert.NotNull(context.Routes);
+            Assert.NotNull(context.RoutesOverridden);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private class TestContext : BucketContext
+        {
+            public IDocumentSet<Beer> Beers { get; set; }
+
+            public IDocumentSet<RouteInCollection> Routes { get; set; }
+
+            [CouchbaseCollection("my", "override")]
+            public IDocumentSet<RouteInCollection> RoutesOverridden { get; set; }
+
+            private IDocumentSet<Beer> PrivateBeers { get; set; }
+
+            private IDocumentSet<Beer> NoSetterBeers => null;
+
+            private int OtherType { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq.UnitTests/Metadata/DocumentSetMetadataTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Metadata/DocumentSetMetadataTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using Couchbase.Linq.Metadata;
+using Couchbase.Linq.UnitTests.Documents;
+using NUnit.Framework;
+
+namespace Couchbase.Linq.UnitTests.Metadata
+{
+    public class DocumentSetMetadataTests
+    {
+        #region ctor
+
+        [Test]
+        public void ctor_GetsCorrectDocumentType()
+        {
+            // Arrange
+
+            var property = typeof(TestDoc).GetProperty(nameof(TestDoc.Beers));
+
+            // Act
+
+            var result = new DocumentSetMetadata(property!);
+
+            // Assert
+
+            Assert.AreEqual(typeof(Beer), result.DocumentType);
+        }
+
+        [Test]
+        public void ctor_GetsDefaultCollection()
+        {
+            // Arrange
+
+            var property = typeof(TestDoc).GetProperty(nameof(TestDoc.Beers));
+
+            // Act
+
+            var result = new DocumentSetMetadata(property!);
+
+            // Assert
+
+            Assert.AreEqual(CouchbaseCollectionAttribute.Default, result.CollectionInfo);
+        }
+
+        [Test]
+        public void ctor_GetsDocumentCollectionAttribute()
+        {
+            // Arrange
+
+            var property = typeof(TestDoc).GetProperty(nameof(TestDoc.Routes));
+
+            // Act
+
+            var result = new DocumentSetMetadata(property!);
+
+            // Assert
+
+            Assert.AreEqual("inventory", result.CollectionInfo.Scope);
+            Assert.AreEqual("route", result.CollectionInfo.Collection);
+        }
+
+        [Test]
+        public void ctor_PrefersPropertyCollectionAttribute()
+        {
+            // Arrange
+
+            var property = typeof(TestDoc).GetProperty(nameof(TestDoc.RoutesOverridden));
+
+            // Act
+
+            var result = new DocumentSetMetadata(property!);
+
+            // Assert
+
+            Assert.AreEqual("my", result.CollectionInfo.Scope);
+            Assert.AreEqual("override", result.CollectionInfo.Collection);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private class TestDoc
+        {
+            public IDocumentSet<Beer> Beers { get; set; }
+
+            public IDocumentSet<RouteInCollection> Routes { get; set; }
+
+            [CouchbaseCollection("my", "override")]
+            public IDocumentSet<RouteInCollection> RoutesOverridden { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://github.com/couchbaselabs/Linq2Couchbase</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/couchbaselabs/Linq2Couchbase/master/Packaging/couchbase-logo.png</PackageIconUrl>
 
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <RootNamespace>Couchbase.Linq</RootNamespace>
     <AssemblyName>Couchbase.Linq</AssemblyName>
 
@@ -35,6 +35,10 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/Src/Couchbase.Linq/CouchbaseCollectionAttribute.cs
+++ b/Src/Couchbase.Linq/CouchbaseCollectionAttribute.cs
@@ -8,7 +8,11 @@ namespace Couchbase.Linq
     /// <summary>
     /// Annotates a document as belonging to a specific scope/collection. If not present, the default collection is assumed.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    /// <remarks>
+    /// This may be applied to a document class or to a property implementing <see cref="IDocumentSet{T}"/> on a class
+    /// inherited from <see cref="BucketContext"/>.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public class CouchbaseCollectionAttribute : Attribute
     {
         internal static CouchbaseCollectionAttribute Default { get; } =

--- a/Src/Couchbase.Linq/DocumentSet`1.cs
+++ b/Src/Couchbase.Linq/DocumentSet`1.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using Couchbase.KeyValue;
+using Couchbase.Linq.Extensions;
+using Couchbase.Linq.Utils;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// Default implementation of <see cref="IDocumentSet{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of the document.</typeparam>
+    internal class DocumentSet<T> : IDocumentSet<T>, ICollectionQueryable<T>
+    {
+        private readonly BucketContext _bucketContext;
+
+        /// <inheritdoc />
+        public string BucketName => _bucketContext.Bucket.Name;
+
+        /// <inheritdoc />
+        public string ScopeName { get; }
+
+        /// <inheritdoc />
+        public string CollectionName { get; }
+
+        /// <inheritdoc />
+        public ICouchbaseCollection Collection => _bucketContext.Bucket.Scope(ScopeName).Collection(CollectionName);
+
+        public DocumentSet(BucketContext bucketContext, string scopeName, string collectionName)
+        {
+            // ReSharper disable ConditionIsAlwaysTrueOrFalse
+            if (bucketContext == null)
+            {
+                ThrowHelpers.ThrowArgumentNullException(nameof(bucketContext));
+            }
+            if (scopeName == null)
+            {
+                ThrowHelpers.ThrowArgumentNullException(nameof(scopeName));
+            }
+            if (collectionName == null)
+            {
+                ThrowHelpers.ThrowArgumentNullException(nameof(collectionName));
+            }
+            // ReSharper restore ConditionIsAlwaysTrueOrFalse
+
+            _bucketContext = bucketContext;
+            ScopeName = scopeName;
+            CollectionName = collectionName;
+
+            // Note: For this to work, we must implement ICollectionQueryable
+            Expression = Expression.Constant(this);
+        }
+
+        /// <summary>
+        /// Makes a new queryable for each query. This way the latest settings, such as timeout, are
+        /// collected.
+        /// </summary>
+        private IQueryable<T> MakeQueryable() =>
+            _bucketContext.Query<T>(ScopeName, CollectionName);
+
+        #region IQueryable
+
+        public IEnumerator<T> GetEnumerator() => MakeQueryable().GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public Type ElementType => typeof(T);
+        public Expression Expression { get; }
+        public IQueryProvider Provider => MakeQueryable().Provider;
+
+        #endregion
+
+        #region IAsyncEnumerable
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) =>
+            MakeQueryable().AsAsyncEnumerable().GetAsyncEnumerator(cancellationToken);
+
+        #endregion
+    }
+}

--- a/Src/Couchbase.Linq/ICollectionQueryable.cs
+++ b/Src/Couchbase.Linq/ICollectionQueryable.cs
@@ -6,7 +6,7 @@ namespace Couchbase.Linq
     /// <summary>
     /// IQueryable sourced from a Couchbase collection.  Used to provide the collection name to the query generator.
     /// </summary>
-    public interface ICollectionQueryable
+    internal interface ICollectionQueryable
     {
         /// <summary>
         /// Collection query is run against
@@ -27,7 +27,7 @@ namespace Couchbase.Linq
     /// <summary>
     /// IQueryable sourced from a Couchbase collection.  Used to provide the collection name to the query generator.
     /// </summary>
-    public interface ICollectionQueryable<out T> : IQueryable<T>, ICollectionQueryable, IAsyncEnumerable<T>
+    internal interface ICollectionQueryable<out T> : IQueryable<T>, ICollectionQueryable, IAsyncEnumerable<T>
     {
     }
 }

--- a/Src/Couchbase.Linq/IDocumentSet`1.cs
+++ b/Src/Couchbase.Linq/IDocumentSet`1.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq;
+using Couchbase.KeyValue;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// A set of documents in a Couchbase collection.
+    /// </summary>
+    /// <typeparam name="T">Type of the document.</typeparam>
+    // ReSharper disable once TypeParameterCanBeVariant
+    public interface IDocumentSet<T> : IQueryable<T>
+    {
+        /// <summary>
+        /// The couchbase collection for these documents.
+        /// </summary>
+        ICouchbaseCollection Collection { get; }
+    }
+}

--- a/Src/Couchbase.Linq/Metadata/ContextMetadata.cs
+++ b/Src/Couchbase.Linq/Metadata/ContextMetadata.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Couchbase.Linq.Utils;
+
+namespace Couchbase.Linq.Metadata
+{
+    /// <summary>
+    /// Metadata about a type inherited from <see cref="BucketContext"/>.
+    /// </summary>
+    internal class ContextMetadata
+    {
+        private static readonly Type[] DocumentSetConstructorArgumentTypes =
+        {
+            typeof(BucketContext),
+            typeof(string),
+            typeof(string)
+        };
+
+        /// <summary>
+        /// The type inherited from <see cref="BucketContext"/>.
+        /// </summary>
+        public Type ContextType { get; }
+
+        /// <summary>
+        /// Properties that return <see cref="IDocumentSet{T}"/>.
+        /// </summary>
+        public DocumentSetMetadata[] Properties { get; }
+
+        /// <summary>
+        /// An action that initializes <see cref="Properties"/> with <see cref="DocumentSet{T}"/> instances.
+        /// </summary>
+        private Action<BucketContext> Initialize { get; }
+
+        public ContextMetadata(Type contextType)
+        {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (contextType == null)
+            {
+                ThrowHelpers.ThrowArgumentNullException(nameof(contextType));
+            }
+
+            ContextType = contextType;
+            Properties = contextType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.CanWrite && IsDocumentSet(p.PropertyType))
+                .Select(p => new DocumentSetMetadata(p))
+                .ToArray();
+
+            Initialize = CreateInitializeAction();
+        }
+
+        /// <summary>
+        /// Compiles an action which will initialize the BucketContext properties. We use a compiled action
+        /// instead of reflection here for speed. This executes once the first time a given type is used,
+        /// after which the action is reused for each new instance of BucketContext.
+        /// </summary>
+#if NET5_0_OR_GREATER
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(DocumentSet<>))]
+#endif
+        private Action<BucketContext> CreateInitializeAction()
+        {
+            var dynMethod = new DynamicMethod("Initialize", null, new[] { typeof(BucketContext) })
+            {
+                InitLocals = false // Don't need this, very minor perf improvement
+            };
+
+            var il = dynMethod.GetILGenerator();
+            il.DeclareLocal(ContextType);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, ContextType);
+            il.Emit(OpCodes.Stloc_0);
+
+            foreach (var property in Properties)
+            {
+                // load for property setter
+                il.Emit(OpCodes.Ldloc_0);
+
+
+                // load again for constructor
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldstr, property.CollectionInfo.Scope);
+                il.Emit(OpCodes.Ldstr, property.CollectionInfo.Collection);
+
+                var documentSetType = typeof(DocumentSet<>).MakeGenericType(property.DocumentType);
+                var documentSetConstructor = documentSetType.GetConstructor(DocumentSetConstructorArgumentTypes)!;
+                il.Emit(OpCodes.Newobj, documentSetConstructor);
+                il.Emit(OpCodes.Castclass, typeof(IDocumentSet<>).MakeGenericType(property.DocumentType));
+
+                var setter = property.Property.GetSetMethod()!;
+                il.Emit(OpCodes.Callvirt, setter);
+            }
+
+            il.Emit(OpCodes.Ret);
+
+            return (Action<BucketContext>)dynMethod.CreateDelegate(typeof(Action<BucketContext>));
+        }
+
+        public void Fill(BucketContext bucketContext)
+        {
+            Debug.Assert(ContextType.IsInstanceOfType(bucketContext));
+
+            Initialize(bucketContext);
+        }
+
+        private static bool IsDocumentSet(Type propertyType) =>
+            propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(IDocumentSet<>);
+    }
+}

--- a/Src/Couchbase.Linq/Metadata/ContextMetadataCache.cs
+++ b/Src/Couchbase.Linq/Metadata/ContextMetadataCache.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Concurrent;
+
+namespace Couchbase.Linq.Metadata
+{
+    /// <summary>
+    /// Static cache of <see cref="ContextMetadata"/> keyed by type inherited from <see cref="BucketContext"/>.
+    /// </summary>
+    internal class ContextMetadataCache
+    {
+        public static ContextMetadataCache Instance { get; } = new();
+
+        private readonly ConcurrentDictionary<Type, ContextMetadata> _cache = new();
+
+        public ContextMetadata Get(Type type)
+        {
+            return _cache.GetOrAdd(type, static t => new ContextMetadata(t));
+        }
+    }
+}

--- a/Src/Couchbase.Linq/Metadata/DocumentSetMetadata.cs
+++ b/Src/Couchbase.Linq/Metadata/DocumentSetMetadata.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Reflection;
+
+namespace Couchbase.Linq.Metadata
+{
+    /// <summary>
+    /// Metadata about a specific property returning <see cref="IDocumentSet{T}"/> present on
+    /// a class inherited from <see cref="BucketContext"/>.
+    /// </summary>
+    internal class DocumentSetMetadata
+    {
+        /// <summary>
+        /// The property.
+        /// </summary>
+        public PropertyInfo Property { get; }
+
+        /// <summary>
+        /// The type of document.
+        /// </summary>
+        public Type DocumentType { get; set; }
+
+        /// <summary>
+        /// The collection where the document resides.
+        /// </summary>
+        public CouchbaseCollectionAttribute CollectionInfo { get; }
+
+        public DocumentSetMetadata(PropertyInfo property)
+        {
+            Property = property;
+            DocumentType = GetDocumentType(property.PropertyType);
+
+            CollectionInfo = property.GetCustomAttribute<CouchbaseCollectionAttribute>()
+                             ?? DocumentType.GetCustomAttribute<CouchbaseCollectionAttribute>()
+                             ?? CouchbaseCollectionAttribute.Default;
+        }
+
+        private static Type GetDocumentType(Type propertyType) =>
+            propertyType.GenericTypeArguments[0];
+    }
+}

--- a/docs/bucket-context.md
+++ b/docs/bucket-context.md
@@ -13,3 +13,21 @@ var context = new BucketContext(bucket);
 ```
 
 It's important to note that the ICluster and IBucket objects are a long-lived objects, so you will usually want to create a singleton per application and reuse it over the lifespan of the application. A BucketContext is slightly different; it contains no Dispose method and is more ephemeral compared to the Cluster.
+
+## Extending BucketContext
+
+To extend BucketContext into a more powerful tool exposing strongly-typed document sets, inherit from `BucketContext` and add properties that return `IDocumentSet<T>`. These properties will be automatically initialized with an appropriate object for running queries.
+
+```cs
+public class MyContext : BucketContext
+{
+    // Adding "= null!" is only necessary if nullable reference types is enabled
+    public IDocumentSet<Airline> Airlines { get; set; } = null!;
+    public IDocumentSet<Airport> Airports { get; set; } = null!;
+    public IDocumentSet<Route> Routes { get; set; } = null!;
+
+    public MyContext(IBucket bucket) : base(bucket)
+    {
+    }
+}
+```

--- a/docs/scopes-collections.md
+++ b/docs/scopes-collections.md
@@ -28,6 +28,26 @@ public class MyDocument
 Queries for this document will automatically account for the scope and collection,
 including in joins, nests, and subqueries.
 
+## Specifying a Collection in BucketContext
+
+In some cases adding the CouchbaseCollection attribute to a POCO may not be an option.
+In this case, the collection may also be added to `IDocumentSet<T>` properties on a class
+inherited from `BucketContext`. This will take precedence over any settings on the POCO.
+
+```cs
+public class MyContext : BucketContext
+{
+    [CouchbaseCollection("inventory", "route")]
+    public IDocumentSet<Route> Routes { get; set; }
+
+    public MyContext(IBucket bucket) : base(bucket)
+    {
+    }
+}
+```
+
+See [Bucket Context](./bucket-context.md) for more details.
+
 ## DocumentTypeFilter
 
 For previous versions of Linq2Couchbase, a very common pattern was to apply the


### PR DESCRIPTION
Motivation
----------
Provide a cleaner mechanism for exposing strongly typed queryables on
classes inherited from BucketContext.

Allow the CouchbaseCollection attribute to be applied when it is either
not an option to add it to the POCO or the value on the POCO needs to be
overriden.

Modifications
-------------
Create the concept of a DocumentSet which mostly just exposes IQueryable
for a particular document type. It also accepts an overriden
scope/collection.

Add ContextMetadata with a cache to keep reflected information to build
a dynamic action that can quickly create DocumentSet instances and fill
the properties on the BucketContext. Use this cache whenever an
inherited BucketContext is created.

Make ICollectionQueryable interfaces internal, as they aren't used
externally and IDocumentSet is a cleaner way to expose the info to the
consumer.

Add a net5.0 target so we can use DynamicDependency to mark our
reflection from trimming. Note that this isn't the complete body of
work required to support member level trimming, but it's a start.

Results
-------
Consumers may now easily expose document sets as properties on their
BucketContext inherited classes. This will allow extensibility in the
future if support for other operations on IDocumentSet is desired.

Consumers may also use the IDocumentSet<T> properties to access the
backing ICouchbaseCollection to perform key/value operations. This
encourages a clean architecture where the CouchbaseCollection attribute
becomes the single point of truth for document storage location.

Consumers may now apply CouchbaseCollection attributes to documents in
a location other than on the POCO definition.