### PR TITLE
Added support of DateTimeOffset in N1QlFunctions

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/Documents/Beer.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/Documents/Beer.cs
@@ -39,6 +39,9 @@ namespace Couchbase.Linq.IntegrationTests.Documents
         [JsonProperty("updated")]
         public virtual DateTime Updated { get; set; }
 
+        [JsonProperty("updated_offset")]
+        public virtual DateTimeOffset UpdatedOffset { get; set; }
+
         // This property isn't normally on beers in the beer-sample bucket
         // But we need it for some integration tests so we'll add it
         [JsonProperty("updatedUnixMillis")]

--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -1241,6 +1241,24 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void DateTimeOffset_DateAdd()
+        {
+            var context = new BucketContext(TestSetup.Bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name, Updated = N1QlFunctions.DateAdd(beer.UpdatedOffset, -10, N1QlDatePart.Day)};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
+            {
+                Console.WriteLine("Beer {0} was updated 10 days after {1:g}", b.Name, b.Updated);
+            }
+        }
+
+        [Test]
         public void DateTime_DateAdd_UnixMillis()
         {
             var context = new BucketContext(TestSetup.Bucket);
@@ -1295,6 +1313,24 @@ namespace Couchbase.Linq.IntegrationTests
         }
 
         [Test]
+        public void DateOffset_DateDiff()
+        {
+            var context = new BucketContext(TestSetup.Bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name, DaysOld = N1QlFunctions.DateDiff(DateTimeOffset.Now, beer.UpdatedOffset, N1QlDatePart.Day)};
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
+            {
+                Console.WriteLine("Beer {0} is {1} days old", b.Name, b.DaysOld);
+            }
+        }
+
+        [Test]
         public void DateTime_DatePart()
         {
             var context = new BucketContext(TestSetup.Bucket);
@@ -1320,6 +1356,24 @@ namespace Couchbase.Linq.IntegrationTests
             var beers = from beer in context.Query<Beer>()
                         where beer.Type == "beer"
                         select new { beer.Name, Year = N1QlFunctions.DatePart(beer.UpdatedUnixMillis.Value, N1QlDatePart.Year) };
+
+            var results = beers.Take(1).ToList();
+            Assert.AreEqual(1, results.Count());
+
+            foreach (var b in results)
+            {
+                Console.WriteLine("Beer {0} was updated in {1:0000}", b.Name, b.Year);
+            }
+        }
+
+        [Test]
+        public void DateTimeOffset_DatePart()
+        {
+            var context = new BucketContext(TestSetup.Bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name, Year = N1QlFunctions.DatePart(beer.UpdatedOffset, N1QlDatePart.Year)};
 
             var results = beers.Take(1).ToList();
             Assert.AreEqual(1, results.Count());
@@ -1360,6 +1414,21 @@ namespace Couchbase.Linq.IntegrationTests
             var beers = from beer in context.Query<Beer>()
                         where beer.Type == "beer" && N1QlFunctions.IsValued(beer.UpdatedUnixMillis)
                         select new { beer.Name, Updated = N1QlFunctions.DateTrunc(beer.UpdatedUnixMillis.Value, N1QlDatePart.Month) };
+
+            foreach (var b in beers.Take(1))
+            {
+                Console.WriteLine("Beer {0} is in {1:MMMM yyyy}", b.Name, b.Updated);
+            }
+        }
+
+        [Test]
+        public void DateTimeOffset_DateTrunc()
+        {
+            var context = new BucketContext(TestSetup.Bucket);
+
+            var beers = from beer in context.Query<Beer>()
+                where beer.Type == "beer"
+                select new {beer.Name, Updated = N1QlFunctions.DateTrunc(beer.UpdatedOffset, N1QlDatePart.Month)};
 
             foreach (var b in beers.Take(1))
             {

--- a/Src/Couchbase.Linq/N1QlFunctions.DateTime.cs
+++ b/Src/Couchbase.Linq/N1QlFunctions.DateTime.cs
@@ -23,6 +23,20 @@ namespace Couchbase.Linq
         }
 
         /// <summary>
+        /// Adds an interval to a DateTimeOffset, where the unit of interval is part.
+        /// </summary>
+        /// <param name="date">DateTimeOffset on which to perform arithmetic.</param>
+        /// <param name="interval">Interval to add to date.</param>
+        /// <param name="part">Unit of the interval being added to date.</param>
+        /// <returns>New DateTimeOffset</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_ADD_STR")]
+        public static DateTimeOffset DateAdd(DateTimeOffset date, long interval, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+
+        /// <summary>
         /// Returns the elapsed time between date/times as an integer whose unit is part.
         /// </summary>
         /// <param name="date1">Starting date/time for difference.</param>
@@ -32,6 +46,20 @@ namespace Couchbase.Linq
         /// <remarks>Only valid for use in N1QL queries.</remarks>
         [N1QlFunction("DATE_DIFF_STR")]
         public static long DateDiff(DateTime date1, DateTime date2, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+
+        /// <summary>
+        /// Returns the elapsed time between date/times as an integer whose unit is part.
+        /// </summary>
+        /// <param name="date1">Starting DateTimeOffset for difference.</param>
+        /// <param name="date2">Ending DateTimeOffset for difference.</param>
+        /// <param name="part">Unit of the interval to return.</param>
+        /// <returns>Difference between date1 and date2 in part units.  Result is positive if date1 is later than date2.</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_DIFF_STR")]
+        public static long DateDiff(DateTimeOffset date1, DateTimeOffset date2, N1QlDatePart part)
         {
             throw NotSupportedError();
         }
@@ -50,6 +78,19 @@ namespace Couchbase.Linq
         }
 
         /// <summary>
+        /// Returns the date part as an integer.
+        /// </summary>
+        /// <param name="date">DateTimeOffset to extract the part of</param>
+        /// <param name="part">Part to extract.</param>
+        /// <returns>Portion of the date/time, based on part.</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_PART_STR")]
+        public static long DatePart(DateTimeOffset date, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+
+        /// <summary>
         /// Truncates the given date/time so that the given date part is the least significant.
         /// </summary>
         /// <param name="date">Date/time to be truncated.</param>
@@ -58,6 +99,19 @@ namespace Couchbase.Linq
         /// <remarks>Only valid for use in N1QL queries.</remarks>
         [N1QlFunction("DATE_TRUNC_STR")]
         public static DateTime DateTrunc(DateTime date, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+
+        /// <summary>
+        /// Truncates the given DateTimeOffset so that the given date part is the least significant.
+        /// </summary>
+        /// <param name="date">DateTimeOffset to be truncated.</param>
+        /// <param name="part">Part to be the least significant.</param>
+        /// <returns>Truncated DateTimeOffset.</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_TRUNC_STR")]
+        public static DateTimeOffset DateTrunc(DateTimeOffset date, N1QlDatePart part)
         {
             throw NotSupportedError();
         }


### PR DESCRIPTION
Adding overloads of `N1QlFunctions` which work with `DateTime` to support `DateTimeOffset` too.

I couldn't find how test data should be set up for functional tests, so assuming it's done manually.