### PR TITLE
Added DateMethodCallTranslator to better support Date truncation

### DIFF
--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DateMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DateMethodCallTranslator.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators;
+
+internal class DateMethodCallTranslator : IMethodCallTranslator
+{
+    private static readonly MethodInfo[] SupportedMethodsStatic =
+    {
+        typeof (DateTime).GetMethod("get_Date"),
+        typeof (DateTimeOffset).GetMethod("get_Date")
+    };
+
+    public IEnumerable<MethodInfo> SupportMethods
+    {
+        get
+        {
+            return SupportedMethodsStatic;
+        }
+    }
+
+    public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+    {
+        if (methodCallExpression == null)
+        {
+            throw new ArgumentNullException("methodCallExpression");
+        }
+
+        var expression = expressionTreeVisitor.Expression;
+
+        expression.Append("DATE_TRUNC_STR(");
+        expressionTreeVisitor.Visit(methodCallExpression.Object);
+        expression.Append(",");
+        expression.Append(@"""day""");
+        expression.Append(")");
+
+        return methodCallExpression;
+    }
+}

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DateMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DateMethodCallTranslator.cs
@@ -32,9 +32,7 @@ internal class DateMethodCallTranslator : IMethodCallTranslator
 
         expression.Append("DATE_TRUNC_STR(");
         expressionTreeVisitor.Visit(methodCallExpression.Object);
-        expression.Append(",");
-        expression.Append(@"""day""");
-        expression.Append(")");
+        expression.Append(@",""day"")");
 
         return methodCallExpression;
     }


### PR DESCRIPTION
We can now use the `DateTime.Date` and `DateTimeOffset.Date` properties in LINQ without needing the `N1QlFunctions.DateTrunc` method. This enhancement makes LINQ expressions cleaner and more consistent with other LINQ providers that already support this behavior.
