### PR TITLE
Apply document filters to DocumentSet<T> at query time

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/QueryTests.cs
@@ -174,7 +174,7 @@ namespace Couchbase.Linq.IntegrationTests
             var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from b in context.Query<Beer>()
-                        where b.Type == "beer" && b.Name.StartsWith("563")
+                        where b.Type == "beer" && b.Name.StartsWith("Amendment")
                         select new { name = b.Name, abv = b.Abv };
 
             var results = beers.Take(1).ToList();
@@ -1000,7 +1000,7 @@ namespace Couchbase.Linq.IntegrationTests
             var context = new BucketContext(TestSetup.Bucket);
 
             var breweries = from brewery in context.Query<Brewery>()
-                where brewery.Type == "brewery" && brewery.Address.Contains("563 Second Street")
+                where brewery.Type == "brewery" && brewery.Address.Contains("210 Aberdeen Dr.")
                 orderby brewery.Name
                 select new {name = brewery.Name, addresses = brewery.Address};
 

--- a/Src/Couchbase.Linq.IntegrationTests/SingleQueryTests.cs
+++ b/Src/Couchbase.Linq.IntegrationTests/SingleQueryTests.cs
@@ -46,7 +46,7 @@ namespace Couchbase.Linq.IntegrationTests
             var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
-                where beer.Name == "21A IPA"
+                where beer.Name == "Amendment Pale Ale"
                 select new {beer.Name};
 
             Console.WriteLine(beers.Single().Name);
@@ -58,8 +58,8 @@ namespace Couchbase.Linq.IntegrationTests
             var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
-                where beer.Name == "21A IPA"
-                select new {beer.Name};
+                where beer.Name == "Amendment Pale Ale"
+                select new { beer.Name };
 
             Console.WriteLine((await beers.SingleAsync()).Name);
         }
@@ -72,7 +72,7 @@ namespace Couchbase.Linq.IntegrationTests
             var beers = from beer in context.Query<Beer>()
                 select new {beer.Name};
 
-            var result = await beers.SingleAsync(p => p.Name == "21A IPA");
+            var result = await beers.SingleAsync(p => p.Name == "Amendment Pale Ale");
 
             Console.WriteLine(result.Name);
         }
@@ -137,7 +137,7 @@ namespace Couchbase.Linq.IntegrationTests
             var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
-                where beer.Name == "21A IPA"
+                where beer.Name == "Amendment Pale Ale"
                 select new {beer.Name};
 
             var aBeer = beers.SingleOrDefault();
@@ -151,7 +151,7 @@ namespace Couchbase.Linq.IntegrationTests
             var context = new BucketContext(TestSetup.Bucket);
 
             var beers = from beer in context.Query<Beer>()
-                where beer.Name == "21A IPA"
+                where beer.Name == "Amendment Pale Ale"
                 select new {beer.Name};
 
             var aBeer = await beers.SingleOrDefaultAsync();
@@ -167,7 +167,7 @@ namespace Couchbase.Linq.IntegrationTests
             var beers = from beer in context.Query<Beer>()
                 select new {beer.Name};
 
-            var aBeer = await beers.SingleOrDefaultAsync(p => p.Name == "21A IPA");
+            var aBeer = await beers.SingleOrDefaultAsync(p => p.Name == "Amendment Pale Ale");
             Assert.IsNotNull(aBeer);
             Console.WriteLine(aBeer.Name);
         }

--- a/Src/Couchbase.Linq.UnitTests/Metadata/ContextMetadataTests.cs
+++ b/Src/Couchbase.Linq.UnitTests/Metadata/ContextMetadataTests.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Couchbase.Linq.Metadata;
+﻿using Couchbase.Linq.Metadata;
 using Couchbase.Linq.UnitTests.Documents;
-using Moq;
 using NUnit.Framework;
 
 namespace Couchbase.Linq.UnitTests.Metadata
@@ -47,6 +45,10 @@ namespace Couchbase.Linq.UnitTests.Metadata
 
         private class TestContext : BucketContext
         {
+            public TestContext() : base(QueryFactory.CreateMockBucket("default"))
+            {
+            }
+
             public IDocumentSet<Beer> Beers { get; set; }
 
             public IDocumentSet<RouteInCollection> Routes { get; set; }

--- a/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
+++ b/Src/Couchbase.Linq.UnitTests/N1QLTestBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Security.Cryptography.X509Certificates;
 using Couchbase.Core.IO.Serializers;
 using Couchbase.Core.Version;
 using Couchbase.KeyValue;
@@ -13,6 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json.Serialization;
+using Remotion.Linq;
 
 namespace Couchbase.Linq.UnitTests
 {
@@ -109,30 +111,8 @@ namespace Couchbase.Linq.UnitTests
             return visitor.GetQuery();
         }
 
-        protected virtual IQueryable<T> CreateQueryable<T>(string bucketName)
-        {
-            return CreateQueryable<T>(bucketName, QueryExecutor);
-        }
-
-        internal virtual IQueryable<T> CreateQueryable<T>(string bucketName, IAsyncQueryExecutor queryExecutor)
-        {
-            var mockCluster = new Mock<ICluster>();
-            mockCluster
-                .Setup(p => p.ClusterServices)
-                .Returns(ServiceProvider);
-
-            var mockBucket = new Mock<IBucket>();
-            mockBucket.SetupGet(e => e.Name).Returns(bucketName);
-            mockBucket.SetupGet(e => e.Cluster).Returns(mockCluster.Object);
-
-            var mockCollection = new Mock<ICouchbaseCollection>();
-            mockCollection
-                .SetupGet(p => p.Scope.Bucket)
-                .Returns(mockBucket.Object);
-
-            return new CollectionQueryable<T>(mockCollection.Object,
-                QueryParserHelper.CreateQueryParser(mockCluster.Object), queryExecutor);
-        }
+        protected virtual IQueryable<T> CreateQueryable<T>(string bucketName) =>
+            QueryFactory.Queryable<T>(bucketName, N1QlHelpers.DefaultScopeName, N1QlHelpers.DefaultCollectionName, QueryExecutor);
 
         protected void SetContractResolver(IContractResolver contractResolver)
         {

--- a/Src/Couchbase.Linq.UnitTests/QueryFactory.cs
+++ b/Src/Couchbase.Linq.UnitTests/QueryFactory.cs
@@ -2,8 +2,13 @@
 using Couchbase.Core.IO.Serializers;
 using Couchbase.Core.Version;
 using Couchbase.KeyValue;
+using Couchbase.Linq.Execution;
+using Couchbase.Linq.Filters;
+using Couchbase.Linq.QueryGeneration;
 using Couchbase.Linq.Serialization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
 namespace Couchbase.Linq.UnitTests
@@ -11,22 +16,39 @@ namespace Couchbase.Linq.UnitTests
     internal class QueryFactory
     {
         public static IQueryable<T> Queryable<T>(IBucket bucket) =>
-            Queryable<T>(bucket.Name, "_default", "_default");
+            Queryable<T>(bucket.Name, N1QlHelpers.DefaultScopeName, N1QlHelpers.DefaultCollectionName);
 
         public static IQueryable<T> Queryable<T>(IBucket bucket, string scopeName, string collectionName) =>
             Queryable<T>(bucket.Name, scopeName, collectionName);
 
         public static IQueryable<T> Queryable<T>(string bucketName) =>
-            Queryable<T>(bucketName, "_default", "_default");
+            Queryable<T>(bucketName, N1QlHelpers.DefaultScopeName, N1QlHelpers.DefaultCollectionName);
 
-        public static IQueryable<T> Queryable<T>(string bucketName, string scopeName, string collectionName)
+        public static IQueryable<T> Queryable<T>(string bucketName, string scopeName, string collectionName) =>
+            Queryable<T>(bucketName, scopeName, collectionName, Mock.Of<IAsyncQueryExecutor>());
+
+        public static IQueryable<T> Queryable<T>(string bucketName, string scopeName, string collectionName, IAsyncQueryExecutor queryExecutor)
+        {
+            var mockCollection = CreateMockCollection(bucketName, scopeName, collectionName);
+
+            return new CollectionQueryable<T>(mockCollection,
+                new ClusterQueryProvider(
+                    QueryParserHelper.CreateQueryParser(mockCollection.Scope.Bucket.Cluster),
+                    queryExecutor));
+        }
+
+        public static ICouchbaseCollection CreateMockCollection(string bucketName, string scopeName, string collectionName) =>
+            CreateMockBucket(bucketName).Scope(scopeName).Collection(collectionName);
+
+        public static IBucket CreateMockBucket(string bucketName)
         {
             var serializer = new DefaultSerializer();
 
-            var services = new ServiceCollection();
+            IServiceCollection services = new ServiceCollection();
 
             services.AddSingleton<ITypeSerializer>(serializer);
-            services.AddLogging();
+            services.AddSingleton(new DocumentFilterManager());
+            services.Add(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(NullLogger<>)));
             services.AddSingleton(Mock.Of<IClusterVersionProvider>());
             services.AddSingleton<ISerializationConverterProvider>(
                 new DefaultSerializationConverterProvider(serializer,
@@ -38,21 +60,42 @@ namespace Couchbase.Linq.UnitTests
                 .Returns(services.BuildServiceProvider());
 
             var mockBucket = new Mock<IBucket>();
-            mockBucket.SetupGet(e => e.Name).Returns(bucketName);
-            mockBucket.SetupGet(e => e.Cluster).Returns(mockCluster.Object);
+            mockBucket
+                .SetupGet(e => e.Name)
+                .Returns(bucketName);
+            mockBucket
+                .SetupGet(e => e.Cluster)
+                .Returns(mockCluster.Object);
+            mockBucket
+                .Setup(e => e.Scope(It.IsAny<string>()))
+                .Returns((string scopeName) =>
+                {
+                    var mockScope = new Mock<IScope>();
+                    mockScope
+                        .SetupGet(p => p.Name)
+                        .Returns(scopeName);
+                    mockScope
+                        .SetupGet(p => p.Bucket)
+                        .Returns(mockBucket.Object);
+                    mockScope
+                        .Setup(e => e.Collection(It.IsAny<string>()))
+                        .Returns((string collectionName) =>
+                        {
+                            var mockCollection = new Mock<ICouchbaseCollection>();
+                            mockCollection
+                                .SetupGet(p => p.Name)
+                                .Returns(collectionName);
+                            mockCollection
+                                .SetupGet(p => p.Scope)
+                                .Returns(mockScope.Object);
 
-            var mockCollection = new Mock<ICouchbaseCollection>();
-            mockCollection
-                .SetupGet(p => p.Scope.Bucket)
-                .Returns(mockBucket.Object);
-            mockCollection
-                .SetupGet(p => p.Scope.Name)
-                .Returns(scopeName);
-            mockCollection
-                .SetupGet(p => p.Name)
-                .Returns(collectionName);
+                            return mockCollection.Object;
+                        });
 
-            return new CollectionQueryable<T>(mockCollection.Object, default);
+                    return mockScope.Object;
+                });
+
+            return mockBucket.Object;
         }
     }
 }

--- a/Src/Couchbase.Linq/CollectionQueryable.cs
+++ b/Src/Couchbase.Linq/CollectionQueryable.cs
@@ -1,75 +1,38 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using System.Threading;
-using Couchbase.KeyValue;
+﻿using Couchbase.KeyValue;
 using Couchbase.Linq.Execution;
-using Couchbase.Linq.QueryGeneration;
-using Remotion.Linq;
-using Remotion.Linq.Parsing.Structure;
+using Couchbase.Linq.Utils;
 
 namespace Couchbase.Linq
 {
     /// <summary>
     /// The main entry point and executor of the query.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    internal class CollectionQueryable<T> : QueryableBase<T>, ICollectionQueryable<T>
+    /// <typeparam name="T">Document type to query.</typeparam>
+    internal sealed class CollectionQueryable<T> : CouchbaseQueryable<T>, ICollectionQueryable<T>
     {
-        private readonly ICouchbaseCollection? _collection;
+        /// <inheritdoc />
+        public string CollectionName { get; }
 
         /// <inheritdoc />
-        public string CollectionName => _collection?.Name ?? N1QlHelpers.DefaultCollectionName;
-
-
-        /// <inheritdoc />
-        public string ScopeName => _collection?.Scope.Name ?? N1QlHelpers.DefaultScopeName;
-
+        public string ScopeName { get; }
 
         /// <inheritdoc />
-        public string BucketName => _collection?.Scope.Bucket.Name ?? "";
+        public string BucketName { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CollectionQueryable{T}"/> class.
         /// </summary>
         /// <param name="collection">The collection.</param>
-        /// <param name="queryParser">The query parser.</param>
-        /// <param name="executor">The executor.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="collection" /> is <see langword="null" />.</exception>
-        public CollectionQueryable(ICouchbaseCollection collection, IQueryParser queryParser, IAsyncQueryExecutor executor)
-            : base(new ClusterQueryProvider(queryParser, executor))
+        /// <param name="provider">The query provider to execute the query.</param>
+        public CollectionQueryable(ICouchbaseCollection collection, IAsyncQueryProvider provider) : base(provider)
         {
-            _collection = collection ?? throw new ArgumentNullException(nameof(collection));
-        }
+            ThrowHelpers.ThrowIfNull(collection);
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CollectionQueryable{T}"/> class.
-        /// </summary>
-        /// <remarks>Used to build new expressions as more methods are applied to the query.</remarks>
-        /// <param name="provider">The provider.</param>
-        /// <param name="expression">The expression.</param>
-        public CollectionQueryable(IAsyncQueryProvider provider, Expression expression)
-            : base(provider, expression)
-        {
-        }
+            CollectionName = collection.Name;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CollectionQueryable{T}"/> class.
-        /// </summary>
-        /// <param name="collection">The collection.</param>
-        /// <param name="queryTimeout">Query timeout, if null uses cluster default.</param>
-        public CollectionQueryable(ICouchbaseCollection collection, TimeSpan? queryTimeout)
-            : this(collection,
-                QueryParserHelper.CreateQueryParser(collection.Scope.Bucket.Cluster),
-                new ClusterQueryExecutor(collection.Scope.Bucket.Cluster)
-                {
-                    QueryTimeout = queryTimeout
-                })
-        {
+            var scope = collection.Scope;
+            ScopeName = scope.Name;
+            BucketName = scope.Bucket.Name;
         }
-
-        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) =>
-            ((IAsyncQueryProvider) Provider).ExecuteAsync<IAsyncEnumerable<T>>(Expression)
-                .GetAsyncEnumerator(cancellationToken);
     }
 }

--- a/Src/Couchbase.Linq/CouchbaseQueryable.cs
+++ b/Src/Couchbase.Linq/CouchbaseQueryable.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using Couchbase.Linq.Execution;
+using Remotion.Linq;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// The executor of the query.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal class CouchbaseQueryable<T> : QueryableBase<T>, IAsyncEnumerable<T>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CouchbaseQueryable{T}"/> class.
+        /// </summary>
+        /// <remarks>Used to build new expressions as more methods are applied to the query.</remarks>
+        /// <param name="provider">The provider.</param>
+        /// <param name="expression">The expression.</param>
+        public CouchbaseQueryable(IAsyncQueryProvider provider, Expression expression)
+            : base(provider, expression)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CouchbaseQueryable{T}"/> class.
+        /// </summary>
+        /// <remarks>Used by subclasses to create a root queryable.</remarks>
+        /// <param name="provider">The provider.</param>
+        protected CouchbaseQueryable(IAsyncQueryProvider provider)
+            : base(provider)
+        {
+        }
+
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) =>
+            ((IAsyncQueryProvider) Provider).ExecuteAsync<IAsyncEnumerable<T>>(Expression)
+                .GetAsyncEnumerator(cancellationToken);
+    }
+}

--- a/Src/Couchbase.Linq/Execution/ClusterQueryProvider.cs
+++ b/Src/Couchbase.Linq/Execution/ClusterQueryProvider.cs
@@ -22,12 +22,8 @@ namespace Couchbase.Linq.Execution
         {
         }
 
-        public override IQueryable<T> CreateQuery<T>(Expression expression)
-        {
-            return (IQueryable<T>) Activator.CreateInstance(
-                typeof(CollectionQueryable<>).MakeGenericType(typeof(T)),
-                this, expression);
-        }
+        public override IQueryable<T> CreateQuery<T>(Expression expression) =>
+            new CouchbaseQueryable<T>(this, expression);
 
         public T ExecuteAsync<T>(Expression expression, CancellationToken cancellationToken = default)
         {
@@ -39,7 +35,7 @@ namespace Couchbase.Linq.Execution
             {
                 var executeAsyncMethod = ExecuteAsyncMethod.MakeGenericMethod(sequence.ResultItemType);
 
-                return (T) executeAsyncMethod.Invoke(Executor, new object[] {queryModel, cancellationToken});
+                return (T) executeAsyncMethod.Invoke(Executor, new object[] {queryModel, cancellationToken})!;
             }
             else if (streamedDataInfo is AsyncStreamedValueInfo streamedValue)
             {

--- a/Src/Couchbase.Linq/Execution/DelayedFilterQueryProvider.cs
+++ b/Src/Couchbase.Linq/Execution/DelayedFilterQueryProvider.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using Couchbase.Linq.Filters;
+using Couchbase.Linq.Utils;
+using Remotion.Linq.Utilities;
+
+namespace Couchbase.Linq.Execution
+{
+    /// <summary>
+    /// Implementation of <see cref="IQueryProvider"/> which applies filters to <see cref="IDocumentSet"/> instances
+    /// as each query is executed. This allows a long-lived <see cref="IQueryProvider"/> which still functions correctly
+    /// if document filters are changed during its lifetime.
+    /// </summary>
+    internal sealed class DelayedFilterQueryProvider : IAsyncQueryProvider
+    {
+        private static readonly MethodInfo s_genericCreateQueryMethod =
+            ((Func<DelayedFilterQueryProvider, Expression, IQueryable<object>>)CreateQuery<object>).Method.GetGenericMethodDefinition();
+
+        private readonly IAsyncQueryProvider _innerQueryProvider;
+        private readonly ApplyFiltersExpressionVisitor _applyFiltersExpressionVisitor;
+
+        public DelayedFilterQueryProvider(IAsyncQueryProvider innerQueryProvider, DocumentFilterManager filterManager)
+        {
+            ThrowHelpers.ThrowIfNull(innerQueryProvider);
+            ThrowHelpers.ThrowIfNull(filterManager);
+
+            _innerQueryProvider = innerQueryProvider;
+            _applyFiltersExpressionVisitor = new ApplyFiltersExpressionVisitor(filterManager);
+        }
+
+        public IQueryable CreateQuery(Expression expression)
+        {
+            ThrowHelpers.ThrowIfNull(expression);
+
+            if (!ItemTypeReflectionUtility.TryGetItemTypeOfClosedGenericIEnumerable(expression.Type, out var itemType))
+            {
+                throw new ArgumentException($"Expected a closed generic type implementing IEnumerable<T>, but found '{expression.Type}'.", nameof(expression));
+            }
+
+            return (IQueryable)s_genericCreateQueryMethod.MakeGenericMethod(itemType).Invoke(null, new object[] { this, expression })!;
+        }
+
+        public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+        {
+            ThrowHelpers.ThrowIfNull(expression);
+            return CreateQuery<TElement>(this, expression);
+        }
+
+        private static IQueryable<TElement> CreateQuery<TElement>(DelayedFilterQueryProvider provider, Expression expression) =>
+            new CouchbaseQueryable<TElement>(provider, expression);
+
+        public object? Execute(Expression expression)
+        {
+            ThrowHelpers.ThrowIfNull(expression);
+
+            return _innerQueryProvider.Execute(ApplyFilters(expression));
+        }
+
+        public TResult Execute<TResult>(Expression expression)
+        {
+            ThrowHelpers.ThrowIfNull(expression);
+
+            return _innerQueryProvider.Execute<TResult>(ApplyFilters(expression));
+        }
+
+        public TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken = default)
+        {
+            ThrowHelpers.ThrowIfNull(expression);
+
+            return _innerQueryProvider.ExecuteAsync<TResult>(ApplyFilters(expression), cancellationToken);
+        }
+
+        // Apply filters to IDocumentSet constants on-demand for each query in case they are modified between queries
+        private Expression ApplyFilters(Expression expression) => _applyFiltersExpressionVisitor.Visit(expression);
+
+        /// <summary>
+        /// Visits the expression tree finding the innermost <see cref="IDocumentSet"/> constants
+        /// and replaces them with new Queryable instances that apply the filters. Because a query may
+        /// include multiple extents of multiple types, this visitor must be able to handle multiple different
+        /// types for T.
+        /// </summary>
+        private sealed class ApplyFiltersExpressionVisitor : ExpressionVisitor
+        {
+            private static readonly MethodInfo s_genericApplyFiltersMethod =
+                ((Func<DocumentFilterManager, IQueryable<object>, IQueryable<object>>)ApplyFilters).Method.GetGenericMethodDefinition();
+
+            private readonly DocumentFilterManager _filterManager;
+
+            public ApplyFiltersExpressionVisitor(DocumentFilterManager filterManager)
+            {
+                _filterManager = filterManager;
+            }
+
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                if (node.Value is IDocumentSet documentSet)
+                {
+                    var filterMethod = s_genericApplyFiltersMethod.MakeGenericMethod(documentSet.ElementType);
+                    var filteredQueryable = filterMethod.Invoke(null, new object[] { _filterManager, documentSet })!;
+
+                    if (!ReferenceEquals(documentSet, filteredQueryable))
+                    {
+                        // Replace the constant with a new queryable that applies the filters
+                        // if a different queryable is returned.
+
+                        return ((IQueryable) filteredQueryable).Expression;
+                    }
+                }
+
+                return node;
+            }
+
+            private static IQueryable<T> ApplyFilters<T>(DocumentFilterManager filterManager, IQueryable<T> source)
+            {
+                var filters = filterManager.GetFilterSet<T>();
+                if (filters is null)
+                {
+                    return source;
+                }
+
+                return filters.ApplyFilters(source);
+            }
+        }
+    }
+}

--- a/Src/Couchbase.Linq/IDocumentSet.cs
+++ b/Src/Couchbase.Linq/IDocumentSet.cs
@@ -1,0 +1,11 @@
+﻿using System.Linq;
+
+namespace Couchbase.Linq
+{
+    /// <summary>
+    /// A set of documents in a Couchbase collection.
+    /// </summary>
+    public interface IDocumentSet : IQueryable
+    {
+    }
+}

--- a/Src/Couchbase.Linq/IDocumentSet`1.cs
+++ b/Src/Couchbase.Linq/IDocumentSet`1.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Couchbase.KeyValue;
 
 namespace Couchbase.Linq
@@ -9,7 +8,7 @@ namespace Couchbase.Linq
     /// </summary>
     /// <typeparam name="T">Type of the document.</typeparam>
     // ReSharper disable once TypeParameterCanBeVariant
-    public interface IDocumentSet<T> : IQueryable<T>
+    public interface IDocumentSet<T> : IDocumentSet, IQueryable<T>
     {
         /// <summary>
         /// The couchbase collection for these documents.


### PR DESCRIPTION
Motivation
----------
Some forms of querying using `DocumentSet<T>` properties on an inherited `BucketContext` don't apply document filters such as the `DocumentType` attribute.

Modifications
-------------
- Split `CollectionQueryable<T>` into two types `CollectionQueryable<T>` and a base `CouchbaseQueryable<T>`. The former is used to represent the original extent of a query against a collection. The latter is used to construct new `IQueryable<T>` instances as the query is extended with predicates, etc. This removes unnecessary fields and logic from the simpler case that is repeated for every new LINQ method applied to the query.
- Add an additional non-generic `IDocumentSet` interface which is inherited by `IDocumentSet<T>`. This is a SemVer safe change because it only adds `IQueryable` which was already included on `IDocumentSet<T>` via `IQueryable<T>`.
- Create DelayedFilterQueryProvider as a wrapper for ClusterQueryProvider that applies filters to `IDocumentSet` at query execution time.
- Refactor query timeouts to always be based on a callback to the `BucketContext` rather than a property, which allows a singleton `ClusterQueryExecutor` per `BucketContext` rather than per query.
- Refactor `BucketContext` to build a singleton query provider, query parser, and query executor rather than recreating for every query.
- Refactor `DocumentSet<T>` to get the query provider from the `BucketContext`.
- Reduce interface invocations by caching the bucket, scope, and collection names once when constructing a `DocumentSet<T>` or `CollectionQueryable<T>` instead of for each property read.
- Minor perf and nullable ref type improvements to `DocumentFilterSet`.
- Fix some integration tests that were refering to data no longer found in the default `beer-sample` bucket.

Results
-------
Filters are applied consistently to `DocumentSet<T>` based on the filter configuration at the time the query is run. Queries in all cases will have fewer heap allocations and other CPU performance benefits.

Resolves #376