### PR TITLE
Target .NET 8

### DIFF
--- a/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
+++ b/Src/Couchbase.Linq.IntegrationTests/Couchbase.Linq.IntegrationTests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,15 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="3.4.8" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
+++ b/Src/Couchbase.Linq.UnitTests/Couchbase.Linq.UnitTests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,17 +10,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="3.4.8" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Couchbase.Linq/Clauses/ConsistentWithExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/ConsistentWithExpressionNode.cs
@@ -74,7 +74,7 @@ namespace Couchbase.Linq.Clauses
             ClauseGenerationContext clauseGenerationContext)
         {
             queryModel.BodyClauses.Add(new ConsistentWithClause(
-                (MutationState) MutationState.Value,
+                (MutationState) MutationState.Value!,
                 (TimeSpan?) ScanWait?.Value));
         }
     }

--- a/Src/Couchbase.Linq/Clauses/NestExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/NestExpressionNode.cs
@@ -11,8 +11,8 @@ namespace Couchbase.Linq.Clauses
     {
         public static readonly MethodInfo[] SupportedMethods =
         {
-            typeof(QueryExtensions).GetMethod("Nest"),
-            typeof(QueryExtensions).GetMethod("LeftOuterNest")
+            typeof(QueryExtensions).GetMethod("Nest")!,
+            typeof(QueryExtensions).GetMethod("LeftOuterNest")!
         };
 
         private readonly ResolvedExpressionCache<Expression> _cachedKeySelector;
@@ -92,7 +92,7 @@ namespace Couchbase.Linq.Clauses
             ClauseGenerationContext clauseGenerationContext)
         {
             var nestClause = new NestClause(
-                ResultSelector.Parameters[1].Name,
+                ResultSelector.Parameters[1].Name!,
                 ResultSelector.Parameters[1].Type,
                 InnerSequence,
                 GetResolvedKeySelector(clauseGenerationContext),

--- a/Src/Couchbase.Linq/Clauses/ScanConsistencyExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/ScanConsistencyExpressionNode.cs
@@ -69,7 +69,7 @@ namespace Couchbase.Linq.Clauses
             ClauseGenerationContext clauseGenerationContext)
         {
             queryModel.BodyClauses.Add(new ScanConsistencyClause(
-                (QueryScanConsistency) ScanConsistency.Value,
+                (QueryScanConsistency) ScanConsistency.Value!,
                 (TimeSpan?) ScanWait?.Value));
         }
     }

--- a/Src/Couchbase.Linq/Clauses/UseHashExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/UseHashExpressionNode.cs
@@ -37,7 +37,7 @@ namespace Couchbase.Linq.Clauses
         protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
             ClauseGenerationContext clauseGenerationContext)
         {
-            queryModel.BodyClauses.Add(new UseHashClause((HashHintType) HashHintType.Value));
+            queryModel.BodyClauses.Add(new UseHashClause((HashHintType) HashHintType.Value!));
         }
     }
 }

--- a/Src/Couchbase.Linq/Clauses/UseIndexExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/UseIndexExpressionNode.cs
@@ -48,7 +48,7 @@ namespace Couchbase.Linq.Clauses
         protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
             ClauseGenerationContext clauseGenerationContext)
         {
-            queryModel.BodyClauses.Add(new UseIndexClause((string) IndexName.Value, (N1QlIndexType) IndexType.Value));
+            queryModel.BodyClauses.Add(new UseIndexClause((string) IndexName.Value!, (N1QlIndexType) IndexType.Value!));
         }
     }
 }

--- a/Src/Couchbase.Linq/Clauses/UseKeysExpressionNode.cs
+++ b/Src/Couchbase.Linq/Clauses/UseKeysExpressionNode.cs
@@ -11,7 +11,7 @@ namespace Couchbase.Linq.Clauses
     {
         public static readonly MethodInfo[] SupportedMethods =
         {
-            typeof (QueryExtensions).GetMethod("UseKeys")
+            typeof (QueryExtensions).GetMethod("UseKeys")!
         };
 
         public UseKeysExpressionNode(MethodCallExpressionParseInfo parseInfo, Expression keys)

--- a/Src/Couchbase.Linq/Couchbase.Linq.csproj
+++ b/Src/Couchbase.Linq/Couchbase.Linq.csproj
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/couchbaselabs/Linq2Couchbase</PackageProjectUrl>
     <PackageIconUrl></PackageIconUrl>
 
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Couchbase.Linq</RootNamespace>
     <AssemblyName>Couchbase.Linq</AssemblyName>
 
@@ -22,7 +22,6 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
 
-    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>false</SignAssembly>
     <Version>2.0.1-beta.1</Version>
@@ -32,16 +31,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="3.4.8" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="CouchbaseNetClient" Version="3.5.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Remotion.Linq" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' ">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 

--- a/Src/Couchbase.Linq/Execution/ClusterQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/ClusterQueryExecutor.cs
@@ -159,15 +159,17 @@ namespace Couchbase.Linq.Execution
                 : ExecuteCollection<T>(queryModel).Single();
 
         public Task<T> ExecuteScalarAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default) =>
-            ExecuteSingleAsync<T>(queryModel, false, cancellationToken);
+            ExecuteSingleAsync<T>(queryModel, false, cancellationToken)!;
 
-        public Task<T> ExecuteSingleAsync<T>(QueryModel queryModel, bool returnDefaultWhenEmpty, CancellationToken cancellationToken = default)
+        public Task<T?> ExecuteSingleAsync<T>(QueryModel queryModel, bool returnDefaultWhenEmpty, CancellationToken cancellationToken = default)
         {
             // ReSharper disable MethodSupportsCancellation
-            var result = returnDefaultWhenEmpty
+#pragma warning disable CS8619 // Nullability of reference types in value doesn't match target type.
+            ValueTask<T?> result = returnDefaultWhenEmpty
                 ? ExecuteCollectionAsync<T>(queryModel).SingleOrDefaultAsync(cancellationToken)
                 : ExecuteCollectionAsync<T>(queryModel).SingleAsync(cancellationToken);
-            // ReSharper restore MethodSupportsCancellation
+#pragma warning restore CS8619 // Nullability of reference types in value doesn't match target type.
+                              // ReSharper restore MethodSupportsCancellation
 
             return result.AsTask();
         }

--- a/Src/Couchbase.Linq/Execution/IAsyncQueryExecutor.cs
+++ b/Src/Couchbase.Linq/Execution/IAsyncQueryExecutor.cs
@@ -12,7 +12,7 @@ namespace Couchbase.Linq.Execution
     {
         IAsyncEnumerable<T> ExecuteCollectionAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default);
 
-        Task<T> ExecuteSingleAsync<T>(QueryModel queryModel, bool returnDefaultWhenEmpty, CancellationToken cancellationToken = default);
+        Task<T?> ExecuteSingleAsync<T>(QueryModel queryModel, bool returnDefaultWhenEmpty, CancellationToken cancellationToken = default);
 
         Task<T> ExecuteScalarAsync<T>(QueryModel queryModel, CancellationToken cancellationToken = default);
     }

--- a/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedScalarValueInfo.cs
+++ b/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedScalarValueInfo.cs
@@ -27,8 +27,11 @@ namespace Couchbase.Linq.Execution.StreamedData
             new AsyncStreamedScalarValueInfo(dataType);
 
         /// <inheritdoc />
+#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member.
         public override Task<T> ExecuteQueryModelAsync<T>(QueryModel queryModel, IAsyncQueryExecutor executor,
+#pragma warning restore CS8609 // Nullability of reference types in return type doesn't match overridden member.
             CancellationToken cancellationToken = default)
+            where T : default
         {
             if (queryModel == null)
             {

--- a/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedSingleValueInfo.cs
+++ b/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedSingleValueInfo.cs
@@ -23,8 +23,9 @@ namespace Couchbase.Linq.Execution.StreamedData
         protected override AsyncStreamedValueInfo CloneWithNewDataType(Type dataType) =>
             new AsyncStreamedSingleValueInfo (dataType, ReturnDefaultWhenEmpty);
 
-        public override Task<T> ExecuteQueryModelAsync<T>(QueryModel queryModel, IAsyncQueryExecutor executor,
+        public override Task<T?> ExecuteQueryModelAsync<T>(QueryModel queryModel, IAsyncQueryExecutor executor,
             CancellationToken cancellationToken = default)
+            where T : default
         {
             if (queryModel == null)
             {

--- a/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedValueInfo.cs
+++ b/Src/Couchbase.Linq/Execution/StreamedData/AsyncStreamedValueInfo.cs
@@ -15,7 +15,7 @@ namespace Couchbase.Linq.Execution.StreamedData
     {
         private static readonly MethodInfo ExecuteMethod =
             typeof(AsyncStreamedValueInfo).GetMethod(nameof(ExecuteQueryModelAsync),
-                new[] {typeof(QueryModel), typeof(IAsyncQueryExecutor), typeof(CancellationToken)});
+                new[] {typeof(QueryModel), typeof(IAsyncQueryExecutor), typeof(CancellationToken)})!;
 
         /// <inheritdoc />
         /// <remarks>
@@ -70,7 +70,7 @@ namespace Couchbase.Linq.Execution.StreamedData
             return new AsyncStreamedValue(result, this);
         }
 
-        public abstract Task<T> ExecuteQueryModelAsync<T>(QueryModel queryModel, IAsyncQueryExecutor executor,
+        public abstract Task<T?> ExecuteQueryModelAsync<T>(QueryModel queryModel, IAsyncQueryExecutor executor,
             CancellationToken cancellationToken = default);
 
         protected abstract AsyncStreamedValueInfo CloneWithNewDataType (Type dataType);

--- a/Src/Couchbase.Linq/Operators/AsyncValueFromSequenceResultOperatorBase.cs
+++ b/Src/Couchbase.Linq/Operators/AsyncValueFromSequenceResultOperatorBase.cs
@@ -12,9 +12,9 @@ namespace Couchbase.Linq.Operators
     internal abstract class AsyncValueFromSequenceResultOperatorBase : ResultOperatorBase
     {
         private static readonly MethodInfo ExecuteMethod = typeof(AsyncValueFromSequenceResultOperatorBase)
-            .GetMethod(nameof(ExecuteInMemory), new[] {typeof(StreamedSequence)});
+            .GetMethod(nameof(ExecuteInMemory), new[] {typeof(StreamedSequence)})!;
 
-        public abstract AsyncStreamedValue ExecuteInMemory<T>(StreamedSequence sequence);
+        public abstract AsyncStreamedValue? ExecuteInMemory<T>(StreamedSequence sequence);
 
         /// <inheritdoc />
         public sealed override IStreamedData ExecuteInMemory(IStreamedData input)

--- a/Src/Couchbase.Linq/Operators/FirstAsyncResultOperator.cs
+++ b/Src/Couchbase.Linq/Operators/FirstAsyncResultOperator.cs
@@ -21,10 +21,10 @@ namespace Couchbase.Linq.Operators
         public override ResultOperatorBase Clone(CloneContext cloneContext) =>
             new FirstAsyncResultOperator(ReturnDefaultWhenEmpty);
 
-        public override AsyncStreamedValue ExecuteInMemory<T>(StreamedSequence input)
+        public override AsyncStreamedValue? ExecuteInMemory<T>(StreamedSequence input)
         {
             var sequence = input.GetTypedSequence<T>();
-            T result = ReturnDefaultWhenEmpty ? sequence.FirstOrDefault() : sequence.First();
+            T? result = ReturnDefaultWhenEmpty ? sequence.FirstOrDefault() : sequence.First();
             return new AsyncStreamedValue (Task.FromResult(result), GetOutputDataInfo (input.DataInfo));
         }
 

--- a/Src/Couchbase.Linq/Operators/SingleAsyncResultOperator.cs
+++ b/Src/Couchbase.Linq/Operators/SingleAsyncResultOperator.cs
@@ -23,10 +23,10 @@ namespace Couchbase.Linq.Operators
             new SingleAsyncResultOperator(ReturnDefaultWhenEmpty);
 
         /// <inheritdoc />
-        public override AsyncStreamedValue ExecuteInMemory<T>(StreamedSequence input)
+        public override AsyncStreamedValue? ExecuteInMemory<T>(StreamedSequence input)
         {
             var sequence = input.GetTypedSequence<T>();
-            T result = ReturnDefaultWhenEmpty ? sequence.SingleOrDefault() : sequence.Single();
+            T? result = ReturnDefaultWhenEmpty ? sequence.SingleOrDefault() : sequence.Single();
             return new AsyncStreamedValue (Task.FromResult(result), GetOutputDataInfo (input.DataInfo));
         }
 

--- a/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
@@ -31,7 +31,7 @@ namespace Couchbase.Linq.QueryGeneration
                         type.GetConstructor(Type.EmptyTypes) != null)
                 .SelectMany(type =>
                 {
-                    var instance = (IMethodCallTranslator) Activator.CreateInstance(type);
+                    var instance = (IMethodCallTranslator) Activator.CreateInstance(type)!;
 
                     return instance.SupportMethods
                         .Where(method => method != null)
@@ -232,7 +232,7 @@ namespace Couchbase.Linq.QueryGeneration
                 if (parameterType.IsGenericParameter)
                 {
                     // This parameter is a generic from the class (not a method generic), so convert before comparing
-                    var genericArgs = method.DeclaringType.GetGenericArguments();
+                    var genericArgs = method.DeclaringType!.GetGenericArguments();
 
                     for (var genericIndex = 0; genericIndex < genericArgs.Length; genericIndex++)
                     {

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
@@ -28,9 +28,9 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
         };
 
         private static readonly HashSet<MethodInfo> ConversionMethods = new HashSet<MethodInfo>(
-            Types.Select(type => typeof(ISerializationConverter<>).MakeGenericType(type).GetMethod("ConvertTo", new[] {type})));
+            Types.Select(type => typeof(ISerializationConverter<>).MakeGenericType(type).GetMethod("ConvertTo", new[] {type}))!);
         private static readonly HashSet<MethodInfo> InverseConversionMethods = new HashSet<MethodInfo>(
-            Types.Select(type => typeof(ISerializationConverter<>).MakeGenericType(type).GetMethod("ConvertFrom", new[] {type})));
+            Types.Select(type => typeof(ISerializationConverter<>).MakeGenericType(type).GetMethod("ConvertFrom", new[] {type}))!);
 
         private static readonly ExpressionType[] StaticSupportedExpressionTypes =
         {

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeSortExpressionTransformer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/DateTimeSortExpressionTransformer.cs
@@ -37,7 +37,7 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
 
         private static readonly HashSet<MethodInfo> InverseConversionMethods = new HashSet<MethodInfo>(
             Types.Select(type => typeof(ISerializationConverter<>).MakeGenericType(type)
-                .GetMethod(nameof(ISerializationConverter<DateTime>.ConvertFrom), new[] {type})));
+                .GetMethod(nameof(ISerializationConverter<DateTime>.ConvertFrom), new[] {type}))!);
 
         private static readonly ExpressionType[] StaticSupportedExpressionTypes =
         {

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/EnumComparisonExpressionTransformer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/EnumComparisonExpressionTransformer.cs
@@ -104,7 +104,7 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
 
             if (name != null)
             {
-                comparisonValue = Expression.Constant(enumType.GetField(name).GetValue(null));
+                comparisonValue = Expression.Constant(enumType.GetField(name)!.GetValue(null));
 
                 if (isNullable)
                 {

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/KeyExpressionTransfomer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/KeyExpressionTransfomer.cs
@@ -49,13 +49,13 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
             }
 
             _querySourceReference = querySourceReference;
-            _keyPropertyInfo = querySourceReference.ReferencedQuerySource.ItemType.GetProperty("Key");
+            _keyPropertyInfo = querySourceReference.ReferencedQuerySource.ItemType.GetProperty("Key")!;
             _replacementExpression = replacementExpression;
         }
 
         public Expression Transform(MemberExpression expression)
         {
-            if (expression.Expression.Equals(_querySourceReference) && (expression.Member == _keyPropertyInfo))
+            if (expression.Expression!.Equals(_querySourceReference) && (expression.Member == _keyPropertyInfo))
             {
                 return _replacementExpression;
             }

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/MultiKeyExpressionTransfomer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/MultiKeyExpressionTransfomer.cs
@@ -50,7 +50,7 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
             }
 
             _querySourceReference = querySourceReference;
-            _keyPropertyInfo = querySourceReference.ReferencedQuerySource.ItemType.GetProperty("Key");
+            _keyPropertyInfo = querySourceReference.ReferencedQuerySource.ItemType.GetProperty("Key")!;
             _newExpression = newExpression;
         }
 
@@ -58,10 +58,10 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
         {
             var keyExpression = expression.Expression as MemberExpression;
             
-            if ((keyExpression != null) && keyExpression.Expression.Equals(_querySourceReference)
+            if ((keyExpression != null) && keyExpression.Expression!.Equals(_querySourceReference)
                 && (keyExpression.Member == _keyPropertyInfo))
             {
-                for (var i = 0; i < _newExpression.Members.Count; i++)
+                for (var i = 0; i < _newExpression.Members!.Count; i++)
                 {
                     if (_newExpression.Members[i] == expression.Member)
                     {

--- a/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/StringComparisonExpressionTransformer.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/ExpressionTransformers/StringComparisonExpressionTransformer.cs
@@ -17,9 +17,9 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
     internal class StringComparisonExpressionTransformer : IExpressionTransformer<BinaryExpression>
     {
         private static readonly MethodInfo[] StringCompareMethods = {
-           typeof(string).GetMethod("Compare", new[] { typeof(string), typeof(string) }),
-           typeof (string).GetMethod("Compare", new[] { typeof (string), typeof(string), typeof(StringComparison) }),
-           typeof(string).GetMethod("CompareTo", new[] { typeof(string) })
+           typeof(string).GetMethod("Compare", new[] { typeof(string), typeof(string) })!,
+           typeof (string).GetMethod("Compare", new[] { typeof (string), typeof(string), typeof(StringComparison) })!,
+           typeof(string).GetMethod("CompareTo", new[] { typeof(string) })!
         };
 
         public ExpressionType[] SupportedExpressionTypes
@@ -74,7 +74,7 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
                 return expression;
             }
 
-            var number = (int)numericExpression.Value;
+            var number = (int)numericExpression.Value!;
 
             // Get the strings from the method call parameters
 
@@ -172,7 +172,7 @@ namespace Couchbase.Linq.QueryGeneration.ExpressionTransformers
             StringComparison? comparison = null;
             if (comparisonExpression != null)
             {
-                comparison = (StringComparison)comparisonExpression.Value;
+                comparison = (StringComparison)comparisonExpression.Value!;
                 if (comparison != StringComparison.Ordinal && comparison != StringComparison.OrdinalIgnoreCase)
                 {
                     var msg = $"String comparison option {comparison} is not supported";

--- a/Src/Couchbase.Linq/QueryGeneration/InnerNestDetectingExpressionVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/InnerNestDetectingExpressionVisitor.cs
@@ -29,7 +29,7 @@ namespace Couchbase.Linq.QueryGeneration
             _queryPartsAggregator = queyPartsAggregator ?? throw new ArgumentNullException(nameof(queyPartsAggregator));
         }
 
-        protected override Expression? VisitBinary(BinaryExpression node)
+        protected override Expression VisitBinary(BinaryExpression node)
         {
             if (node.NodeType == ExpressionType.AndAlso)
             {
@@ -58,7 +58,7 @@ namespace Couchbase.Linq.QueryGeneration
                 else
                 {
                     // Left side or both sides were dropped
-                    return right;
+                    return right!;
                 }
             }
             else

--- a/Src/Couchbase.Linq/QueryGeneration/MemberNameResolvers/JsonNetMemberNameResolver.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MemberNameResolvers/JsonNetMemberNameResolver.cs
@@ -30,13 +30,13 @@ namespace Couchbase.Linq.QueryGeneration.MemberNameResolvers
             if (member == null)
                 return false;
 
-            var contract = _contractResolver.ResolveContract(member.DeclaringType);
+            var contract = _contractResolver.ResolveContract(member.DeclaringType!);
 
             if (contract.GetType() == typeof (JsonObjectContract) &&
                 ((JsonObjectContract) contract).Properties.Any(p => p.UnderlyingName == member.Name && !p.Ignored))
             {
                 memberName =
-                    ((JsonObjectContract) contract).Properties.First(p => p.UnderlyingName == member.Name).PropertyName;
+                    ((JsonObjectContract) contract).Properties.First(p => p.UnderlyingName == member.Name).PropertyName!;
                 return true;
             }
 

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ConcatMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ConcatMethodCallTranslator.cs
@@ -12,15 +12,15 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class ConcatMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
-            typeof (string).GetMethod("Concat", new[] { typeof (object) }),
-            typeof (string).GetMethod("Concat", new[] { typeof (object), typeof (object) }),
-            typeof (string).GetMethod("Concat", new[] { typeof (object), typeof (object), typeof (object) }),
-            typeof (string).GetMethod("Concat", new[] { typeof (string), typeof (string) }),
-            typeof (string).GetMethod("Concat", new[] { typeof (string), typeof (string), typeof (string) }),
-            typeof (string).GetMethod("Concat", new[] { typeof (string), typeof (string), typeof (string), typeof (string) }),
-            typeof (string).GetMethod("Concat", new[] { typeof (object[]) }),
-            typeof (string).GetMethod("Concat", new[] { typeof (string[]) }),
-            typeof (string).GetMethod("Concat", new[] { typeof (IEnumerable<string>) }),
+            typeof (string).GetMethod("Concat", new[] { typeof (object) })!,
+            typeof (string).GetMethod("Concat", new[] { typeof (object), typeof (object) })!,
+            typeof (string).GetMethod("Concat", new[] { typeof (object), typeof (object), typeof (object) })!,
+            typeof (string).GetMethod("Concat", new[] { typeof (string), typeof (string) })!,
+            typeof (string).GetMethod("Concat", new[] { typeof (string), typeof (string), typeof (string) })!,
+            typeof (string).GetMethod("Concat", new[] { typeof (string), typeof (string), typeof (string), typeof (string) })!,
+            typeof (string).GetMethod("Concat", new[] { typeof (object[]) })!,
+            typeof (string).GetMethod("Concat", new[] { typeof (string[]) })!,
+            typeof (string).GetMethod("Concat", new[] { typeof (IEnumerable<string>) })!,
             typeof (string).GetMethods().Single (mi => mi.Name == "Concat" && mi.IsGenericMethod && mi.GetGenericArguments().Length == 1)
         };
 
@@ -75,7 +75,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                 }
                 else if (methodCallExpression.Arguments[0] is ConstantExpression argumentAsConstantExpression)
                 {
-                    return ((object[])argumentAsConstantExpression.Value).Select(element => (Expression)Expression.Constant(element));
+                    return ((object[])argumentAsConstantExpression.Value!).Select(element => (Expression)Expression.Constant(element));
                 }
                 else
                 {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ContainsMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ContainsMethodCallTranslator.cs
@@ -16,9 +16,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {
-            typeof(string).GetMethod(Contains, new[] {typeof(string)}),
-            typeof(string).GetMethod(StartsWith, new[] {typeof(string)}),
-            typeof(string).GetMethod(EndsWith, new[] {typeof(string)})
+            typeof(string).GetMethod(Contains, new[] {typeof(string)})!,
+            typeof(string).GetMethod(StartsWith, new[] {typeof(string)})!,
+            typeof(string).GetMethod(EndsWith, new[] {typeof(string)})!
         };
 
         public IEnumerable<MethodInfo> SupportMethods
@@ -43,7 +43,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("(");
-            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object!);
             expression.Append(" LIKE ");
 
             var constantExpression = methodCallExpression.Arguments[0] as ConstantExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DateMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DateMethodCallTranslator.cs
@@ -9,8 +9,8 @@ internal class DateMethodCallTranslator : IMethodCallTranslator
 {
     private static readonly MethodInfo[] SupportedMethodsStatic =
     {
-        typeof (DateTime).GetMethod("get_Date"),
-        typeof (DateTimeOffset).GetMethod("get_Date")
+        typeof (DateTime).GetMethod("get_Date")!,
+        typeof (DateTimeOffset).GetMethod("get_Date")!
     };
 
     public IEnumerable<MethodInfo> SupportMethods
@@ -31,7 +31,7 @@ internal class DateMethodCallTranslator : IMethodCallTranslator
         var expression = expressionTreeVisitor.Expression;
 
         expression.Append("DATE_TRUNC_STR(");
-        expressionTreeVisitor.Visit(methodCallExpression.Object);
+        expressionTreeVisitor.Visit(methodCallExpression.Object!);
         expression.Append(@",""day"")");
 
         return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryContainsKeyMethodCallTranslator .cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryContainsKeyMethodCallTranslator .cs
@@ -8,8 +8,8 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class DictionaryContainsKeyMethodCallTranslator  : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
-            typeof (IDictionary).GetMethod("Contains"),
-            typeof (IDictionary<,>).GetMethod("ContainsKey")
+            typeof (IDictionary).GetMethod("Contains")!,
+            typeof (IDictionary<,>).GetMethod("ContainsKey")!
         };
 
         public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
@@ -25,9 +25,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             {
                 var expression = expressionTreeVisitor.Expression;
 
-                expressionTreeVisitor.Visit(methodCallExpression.Object);
+                expressionTreeVisitor.Visit(methodCallExpression.Object!);
                 expression.Append('.');
-                expression.Append(N1QlHelpers.EscapeIdentifier(keyExpression.Value.ToString()));
+                expression.Append(N1QlHelpers.EscapeIdentifier(keyExpression.Value!.ToString()!));
                 expression.Append(" IS NOT MISSING");
             }
             else

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryItemMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryItemMethodCallTranslator.cs
@@ -8,8 +8,8 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class DictionaryItemMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
-            typeof (IDictionary).GetMethod("get_Item"),
-            typeof (IDictionary<,>).GetMethod("get_Item")
+            typeof (IDictionary).GetMethod("get_Item")!,
+            typeof (IDictionary<,>).GetMethod("get_Item")!
         };
 
         public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
@@ -25,9 +25,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             {
                 var expression = expressionTreeVisitor.Expression;
 
-                expressionTreeVisitor.Visit(methodCallExpression.Object);
+                expressionTreeVisitor.Visit(methodCallExpression.Object!);
                 expression.Append('.');
-                expression.Append(N1QlHelpers.EscapeIdentifier(keyExpression.Value.ToString()));
+                expression.Append(N1QlHelpers.EscapeIdentifier(keyExpression.Value!.ToString()!));
             }
             else
             {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryKeysMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryKeysMethodCallTranslator.cs
@@ -8,9 +8,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class DictionaryKeysMethodCallTranslator  : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
-            typeof (IDictionary).GetMethod("get_Keys"),
-            typeof (IDictionary<,>).GetMethod("get_Keys"),
-            typeof (Dictionary<,>).GetMethod("get_Keys")
+            typeof (IDictionary).GetMethod("get_Keys")!,
+            typeof (IDictionary<,>).GetMethod("get_Keys")!,
+            typeof (Dictionary<,>).GetMethod("get_Keys")!
         };
 
         public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
@@ -25,7 +25,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("OBJECT_NAMES(");
-            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object!);
             expression.Append(')');
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryValuesMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/DictionaryValuesMethodCallTranslator.cs
@@ -8,9 +8,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class DictionaryValuesMethodCallTranslator  : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
-            typeof (IDictionary).GetMethod("get_Values"),
-            typeof (IDictionary<,>).GetMethod("get_Values"),
-            typeof (Dictionary<,>).GetMethod("get_Values")
+            typeof (IDictionary).GetMethod("get_Values")!,
+            typeof (IDictionary<,>).GetMethod("get_Values")!,
+            typeof (Dictionary<,>).GetMethod("get_Values")!
         };
 
         public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
@@ -25,7 +25,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("OBJECT_VALUES(");
-            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object!);
             expression.Append(')');
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsMissingMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsMissingMethodCallTranslator.cs
@@ -41,7 +41,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                 }
 
                 expression.AppendFormat(".{0}",
-                    N1QlHelpers.EscapeIdentifier(constantExpression.Value.ToString()));
+                    N1QlHelpers.EscapeIdentifier(constantExpression.Value!.ToString()!));
             }
 
             expression.Append(methodCallExpression.Method.Name == "IsMissing" ? " IS MISSING" : " IS NOT MISSING");

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsValuedMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/IsValuedMethodCallTranslator.cs
@@ -41,7 +41,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
                 }
 
                 expression.AppendFormat(".{0}",
-                    N1QlHelpers.EscapeIdentifier(constantExpression.Value.ToString()));
+                    N1QlHelpers.EscapeIdentifier(constantExpression.Value!.ToString()!));
             }
 
             expression.Append(methodCallExpression.Method.Name == "IsValued" ? " IS VALUED" : " IS NOT VALUED");

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
@@ -11,7 +11,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class KeyMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
-            typeof (N1QlFunctions).GetMethod("Key")
+            typeof (N1QlFunctions).GetMethod("Key")!
         };
 
         public IEnumerable<MethodInfo> SupportMethods

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ListIndexMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ListIndexMethodCallTranslator.cs
@@ -12,8 +12,8 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class ListIndexMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
-            typeof (IList).GetMethod("get_Item"),
-            typeof (IList<>).GetMethod("get_Item")
+            typeof (IList).GetMethod("get_Item")!,
+            typeof (IList<>).GetMethod("get_Item")!
         };
 
         public IEnumerable<MethodInfo> SupportMethods
@@ -33,7 +33,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
             var expression = expressionTreeVisitor.Expression;
 
-            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object!);
             expression.Append('[');
             expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
             expression.Append(']');

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MathMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MathMethodCallTranslator.cs
@@ -74,7 +74,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             if ((t == typeof (decimal)) || (t == typeof (double)))
             {
                 // Also need to pickup Math.Round with a single integer second parameter
-                yield return typeof (Math).GetMethod("Round", new Type[] {t, typeof (int)});
+                yield return typeof (Math).GetMethod("Round", new Type[] {t, typeof (int)})!;
             }
         } 
 
@@ -98,7 +98,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
             var expression = expressionTreeVisitor.Expression;
 
-            string functionName;
+            string? functionName;
             if (!SupportedMethodNames.TryGetValue(methodCallExpression.Method.Name, out functionName))
             {
                 throw new NotSupportedException("Unsupported Math Method");

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MetaMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/MetaMethodCallTranslator.cs
@@ -11,7 +11,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     internal class MetaMethodCallTranslator : IMethodCallTranslator
     {
         private static readonly MethodInfo[] SupportedMethodsStatic = {
-            typeof (N1QlFunctions).GetMethod("Meta")
+            typeof (N1QlFunctions).GetMethod("Meta")!
         };
 
         public IEnumerable<MethodInfo> SupportMethods

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SerializationConverterMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SerializationConverterMethodCallTranslator.cs
@@ -10,8 +10,8 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {
-            typeof (ISerializationConverter<>).GetMethod("ConvertTo"),
-            typeof (ISerializationConverter<>).GetMethod("ConvertFrom")
+            typeof (ISerializationConverter<>).GetMethod("ConvertTo")!,
+            typeof (ISerializationConverter<>).GetMethod("ConvertFrom")!
         };
 
         public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringCapitalizationMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringCapitalizationMethodCallTranslator.cs
@@ -12,8 +12,8 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {
-            typeof (string).GetMethod("ToUpper", Type.EmptyTypes),
-            typeof (string).GetMethod("ToLower", Type.EmptyTypes)
+            typeof (string).GetMethod("ToUpper", Type.EmptyTypes)!,
+            typeof (string).GetMethod("ToLower", Type.EmptyTypes)!
         };
 
         public IEnumerable<MethodInfo> SupportMethods
@@ -34,7 +34,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append(methodCallExpression.Method.Name == "ToLower" ? "LOWER(" : "UPPER(");
-            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object!);
             expression.Append(")");
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringIndexOfMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringIndexOfMethodCallTranslator.cs
@@ -12,8 +12,8 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {
-            typeof (string).GetMethod("IndexOf", new[] { typeof (char) }),
-            typeof (string).GetMethod("IndexOf", new[] { typeof (string) })
+            typeof (string).GetMethod("IndexOf", new[] { typeof (char) })!,
+            typeof (string).GetMethod("IndexOf", new[] { typeof (string) })!
         };
 
         public IEnumerable<MethodInfo> SupportMethods
@@ -34,7 +34,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("POSITION(");
-            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object!);
             expression.Append(", ");
             expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
             expression.Append(")");

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringLengthMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringLengthMethodCallTranslator.cs
@@ -12,7 +12,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {
-            typeof (string).GetMethod("get_Length")
+            typeof (string).GetMethod("get_Length")!
         };
 
         public IEnumerable<MethodInfo> SupportMethods
@@ -33,7 +33,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("LENGTH(");
-            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object!);
             expression.Append(")");
 
             return methodCallExpression;

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringReplaceMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringReplaceMethodCallTranslator.cs
@@ -12,8 +12,8 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {
-            typeof (string).GetMethod("Replace", new[] { typeof (char), typeof(char) }),
-            typeof (string).GetMethod("Replace", new[] { typeof (string), typeof(string) })
+            typeof (string).GetMethod("Replace", new[] { typeof (char), typeof(char) })!,
+            typeof (string).GetMethod("Replace", new[] { typeof (string), typeof(string) })!
         };
 
         public IEnumerable<MethodInfo> SupportMethods
@@ -34,7 +34,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("REPLACE(");
-            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object!);
             expression.Append(", ");
             expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
             expression.Append(", ");

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
@@ -12,7 +12,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     {
         public static readonly MethodInfo[] SupportedMethodsStatic =
         {
-            typeof (string).GetMethod("Split", new[] { typeof (char[]) })
+            typeof (string).GetMethod("Split", new[] { typeof (char[]) })!
         };
 
         public IEnumerable<MethodInfo> SupportMethods
@@ -33,7 +33,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("SPLIT(");
-            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object!);
 
             if (methodCallExpression.Arguments[0].Type != typeof(char[]))
             {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
@@ -12,12 +12,12 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {
-            typeof (string).GetMethod("Trim", Type.EmptyTypes),
-            typeof (string).GetMethod("Trim", new[] { typeof (char[]) }),
-            typeof (string).GetMethod("TrimStart", Type.EmptyTypes),
-            typeof (string).GetMethod("TrimEnd", Type.EmptyTypes),
-            typeof (string).GetMethod("TrimStart", new [] { typeof(char[])}),
-            typeof (string).GetMethod("TrimEnd", new [] { typeof(char[])}),
+            typeof (string).GetMethod("Trim", Type.EmptyTypes)!,
+            typeof (string).GetMethod("Trim", new[] { typeof (char[]) })!,
+            typeof (string).GetMethod("TrimStart", Type.EmptyTypes)!,
+            typeof (string).GetMethod("TrimEnd", Type.EmptyTypes)!,
+            typeof (string).GetMethod("TrimStart", new [] { typeof(char[])})!,
+            typeof (string).GetMethod("TrimEnd", new [] { typeof(char[])})!,
         };
 
         public IEnumerable<MethodInfo> SupportMethods
@@ -39,7 +39,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
 
             expression.Append(methodCallExpression.Method.Name == "TrimStart" ? "LTRIM(" :
                 methodCallExpression.Method.Name == "TrimEnd" ? "RTRIM(" : "TRIM(");
-            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object!);
 
             if (methodCallExpression.Arguments.Count > 0)
             {

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubqueryMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubqueryMethodCallTranslator.cs
@@ -12,9 +12,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {
-            typeof (Enumerable).GetMethod("ToArray"),
-            typeof (Enumerable).GetMethod("ToList"),
-            typeof (Enumerable).GetMethod("AsEnumerable")
+            typeof (Enumerable).GetMethod("ToArray")!,
+            typeof (Enumerable).GetMethod("ToList")!,
+            typeof (Enumerable).GetMethod("AsEnumerable")!
         };
 
         public IEnumerable<MethodInfo> SupportMethods

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubstringMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/SubstringMethodCallTranslator.cs
@@ -12,9 +12,9 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {
-            typeof (string).GetMethod("Substring", new[] { typeof (int) }),
-            typeof (string).GetMethod("Substring", new[] { typeof (int), typeof(int) }),
-            typeof (string).GetMethod("get_Chars", new[] { typeof (int) })
+            typeof (string).GetMethod("Substring", new[] { typeof (int) })!,
+            typeof (string).GetMethod("Substring", new[] { typeof (int), typeof(int) })!,
+            typeof (string).GetMethod("get_Chars", new[] { typeof (int) })!
         };
 
         public IEnumerable<MethodInfo> SupportMethods
@@ -35,7 +35,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
             var expression = expressionTreeVisitor.Expression;
 
             expression.Append("SUBSTR(");
-            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expressionTreeVisitor.Visit(methodCallExpression.Object!);
             expression.Append(", ");
             expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
 

--- a/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ToStringMethodCallTranslator.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/MethodCallTranslators/ToStringMethodCallTranslator.cs
@@ -12,7 +12,7 @@ namespace Couchbase.Linq.QueryGeneration.MethodCallTranslators
     {
         private static readonly MethodInfo[] SupportedMethodsStatic =
         {
-            typeof (object).GetMethod("ToString")
+            typeof (object).GetMethod("ToString")!
         };
 
         public IEnumerable<MethodInfo> SupportMethods

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -103,7 +103,7 @@ namespace Couchbase.Linq.QueryGeneration
 
         protected override Expression VisitNew(NewExpression expression)
         {
-            VisitNewObject(expression.Members, expression.Arguments);
+            VisitNewObject(expression.Members!, expression.Arguments);
 
             return expression;
         }
@@ -197,7 +197,7 @@ namespace Couchbase.Linq.QueryGeneration
                 }
 
                 arguments = newExpression.Arguments;
-                members = newExpression.Members;
+                members = newExpression.Members!;
             }
 
             for (var i = 0; i < members.Count; i++)
@@ -483,7 +483,7 @@ namespace Couchbase.Linq.QueryGeneration
 
         protected override Expression VisitConstant(ConstantExpression expression)
         {
-            var namedParameter = QueryGenerationContext.ParameterAggregator.AddNamedParameter(expression.Value);
+            var namedParameter = QueryGenerationContext.ParameterAggregator.AddNamedParameter(expression.Value!);
 
             if (namedParameter.Value == null)
             {
@@ -580,7 +580,7 @@ namespace Couchbase.Linq.QueryGeneration
 
         protected override Expression VisitMember(MemberExpression expression)
         {
-            if (expression.Expression.Type.GetTypeInfo().Assembly.Equals(Mscorlib))
+            if (expression.Expression!.Type.GetTypeInfo().Assembly.Equals(Mscorlib))
             {
                 // For property getters on the core .Net classes, we don't want to just recurse through the .Net object model
                 // Instead, convert to a MethodCallExpression

--- a/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/Src/Couchbase.Linq/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -134,7 +134,7 @@ namespace Couchbase.Linq.QueryGeneration
 
                 _queryPartsAggregator.AddExtent(new FromPart(fromClause)
                 {
-                    Source = N1QlHelpers.GetCollectionExpression((ICollectionQueryable) bucketConstantExpression.Value),
+                    Source = N1QlHelpers.GetCollectionExpression((ICollectionQueryable) bucketConstantExpression.Value!),
                     ItemName = GetExtentName(fromClause)
                 });
             }

--- a/Src/Couchbase.Linq/Serialization/Converters/SerializationConverterBase.cs
+++ b/Src/Couchbase.Linq/Serialization/Converters/SerializationConverterBase.cs
@@ -208,8 +208,8 @@ namespace Couchbase.Linq.Serialization.Converters
                 .GetInterfaces()
                 .Where(p => p.GetTypeInfo().IsGenericType && p.GetGenericTypeDefinition() == typeof(ISerializationConverter<>))
                 .ToDictionary(
-                    p => p.GetGenericArguments()[0],
-                    p => p.GetMethod(methodName));
+                    p => p.GetGenericArguments()[0]!,
+                    p => p.GetMethod(methodName)!);
         }
     }
 }

--- a/Src/Couchbase.Linq/Serialization/Converters/StringEnumSerializationConverter.cs
+++ b/Src/Couchbase.Linq/Serialization/Converters/StringEnumSerializationConverter.cs
@@ -98,7 +98,7 @@ namespace Couchbase.Linq.Serialization.Converters
                     _jsonConverter.WriteJson(writer, constantExpression.Value,
                         JsonSerializer.CreateDefault());
 
-                    expressionTreeVisitor.Visit(Expression.Constant(writer.Token.ToString()));
+                    expressionTreeVisitor.Visit(Expression.Constant(writer.Token!.ToString()));
                 }
             }
         }

--- a/Src/Couchbase.Linq/Serialization/DefaultSerializationConverterProvider.cs
+++ b/Src/Couchbase.Linq/Serialization/DefaultSerializationConverterProvider.cs
@@ -52,7 +52,7 @@ namespace Couchbase.Linq.Serialization
 
             return _cache.GetOrAdd(member, p =>
             {
-                if (defaultSerializer.SerializerSettings.ContractResolver.ResolveContract(member.DeclaringType) is JsonObjectContract contract)
+                if (defaultSerializer.SerializerSettings.ContractResolver!.ResolveContract(member.DeclaringType!) is JsonObjectContract contract)
                 {
                     var property = contract.Properties.FirstOrDefault(
                         q => q.UnderlyingName == member.Name && !q.Ignored);
@@ -78,15 +78,15 @@ namespace Couchbase.Linq.Serialization
                 return property.Converter;
             }
 
-            var valueContract = defaultSerializer.SerializerSettings.ContractResolver
-                .ResolveContract(property.PropertyType);
+            var valueContract = defaultSerializer.SerializerSettings.ContractResolver!
+                .ResolveContract(property.PropertyType!);
             if (valueContract?.Converter != null)
             {
                 return valueContract.Converter;
             }
 
             var converters = defaultSerializer.SerializerSettings.Converters;
-            return converters?.FirstOrDefault(p => p.CanConvert(property.PropertyType));
+            return converters?.FirstOrDefault(p => p.CanConvert(property.PropertyType!));
         }
     }
 }

--- a/Src/Couchbase.Linq/Serialization/TypeBasedSerializationConverterRegistry.cs
+++ b/Src/Couchbase.Linq/Serialization/TypeBasedSerializationConverterRegistry.cs
@@ -103,7 +103,7 @@ namespace Couchbase.Linq.Serialization
                 return (ISerializationConverter) constructor.Invoke(new object[] {jsonConverter, member});
             }
 
-            return (ISerializationConverter) Activator.CreateInstance(converterType);
+            return (ISerializationConverter) Activator.CreateInstance(converterType)!;
         }
 
         /// <inheritdoc/>

--- a/Src/Couchbase.Linq/Utils/ServiceProviderExtensions.cs
+++ b/Src/Couchbase.Linq/Utils/ServiceProviderExtensions.cs
@@ -5,9 +5,8 @@ namespace Couchbase.Linq.Utils
 {
     internal static class ServiceProviderExtensions
     {
-        [return: MaybeNull]
-        public static T GetService<T>(this IServiceProvider serviceProvider) =>
-            (T) serviceProvider.GetService(typeof(T));
+        public static T? GetService<T>(this IServiceProvider serviceProvider) =>
+            (T?) serviceProvider.GetService(typeof(T));
 
         [return: NotNull]
         public static T GetRequiredService<T>(this IServiceProvider serviceProvider) =>

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <LangVersion>12</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/Src/couchbase-net-linq.sln
+++ b/Src/couchbase-net-linq.sln
@@ -1,15 +1,26 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31515.178
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35327.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{33CA2A25-DD9D-4E05-A786-6FF4DB1C5C3C}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		global.json = global.json
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Couchbase.Linq", "Couchbase.Linq\Couchbase.Linq.csproj", "{C0254649-0162-47A4-B3D3-354E0B3FF7D0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Couchbase.Linq.UnitTests", "Couchbase.Linq.UnitTests\Couchbase.Linq.UnitTests.csproj", "{8B5F339F-6E52-4E03-9FFA-12C1C025E591}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Couchbase.Linq.IntegrationTests", "Couchbase.Linq.IntegrationTests\Couchbase.Linq.IntegrationTests.csproj", "{AEA6FE33-62F1-4F1A-B955-6CD5AAF8AC7F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{CF57FE4D-9D61-4501-85EB-EB5DF7356D8A}"
 	ProjectSection(SolutionItems) = preProject
 		..\docs\any-all.md = ..\docs\any-all.md
 		..\docs\array-filtering-projections.md = ..\docs\array-filtering-projections.md
 		..\docs\async-queries.md = ..\docs\async-queries.md
 		..\docs\bucket-context.md = ..\docs\bucket-context.md
-		..\docs\change-tracking.md = ..\docs\change-tracking.md
 		..\docs\custom-serializers.md = ..\docs\custom-serializers.md
 		..\docs\date-handling.md = ..\docs\date-handling.md
 		..\docs\document-filters.md = ..\docs\document-filters.md
@@ -22,23 +33,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\docs\null-missing-valued.md = ..\docs\null-missing-valued.md
 		..\docs\poco-mapping.md = ..\docs\poco-mapping.md
 		..\docs\query-hints.md = ..\docs\query-hints.md
-		..\docs\result-streaming.md = ..\docs\result-streaming.md
 		..\docs\ryow.md = ..\docs\ryow.md
 		..\docs\serialization-converters.md = ..\docs\serialization-converters.md
 		..\docs\simple-select.md = ..\docs\simple-select.md
 		..\docs\sorting-take-limit.md = ..\docs\sorting-take-limit.md
 		..\docs\string-handling.md = ..\docs\string-handling.md
 		..\docs\unnest.md = ..\docs\unnest.md
-		..\docs\use-index.md = ..\docs\use-index.md
 		..\docs\use-keys.md = ..\docs\use-keys.md
 		..\docs\where-clause.md = ..\docs\where-clause.md
 	EndProjectSection
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Couchbase.Linq", "Couchbase.Linq\Couchbase.Linq.csproj", "{C0254649-0162-47A4-B3D3-354E0B3FF7D0}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Couchbase.Linq.UnitTests", "Couchbase.Linq.UnitTests\Couchbase.Linq.UnitTests.csproj", "{8B5F339F-6E52-4E03-9FFA-12C1C025E591}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Couchbase.Linq.IntegrationTests", "Couchbase.Linq.IntegrationTests\Couchbase.Linq.IntegrationTests.csproj", "{AEA6FE33-62F1-4F1A-B955-6CD5AAF8AC7F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -66,6 +69,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{CF57FE4D-9D61-4501-85EB-EB5DF7356D8A} = {33CA2A25-DD9D-4E05-A786-6FF4DB1C5C3C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {80B77510-6D97-4A9D-A10E-C3F3531A0052}

--- a/Src/global.json
+++ b/Src/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Motivation
----------
General modernization.

Modifications
-------------
- Add global.json to require the .NET 8 SDK
- Use LangVersion 12 in Directory.Build.props
- Drop the deprecated .NET Standard 2.1 build target and add .NET 8
- Update to Couchbase SDK 3.5.5
- Upgrade various NuGet dependencies, especially for unit tests, and drop some unnecessary dependencies
- Use the in-box SourceLink in .NET 8 SDK rather than the OOB package
- Target net8.0 for unit tests
- Fix a LOT of nullable reference type warnings due to improved annotations in .NET 8